### PR TITLE
Added clarification on how interface= works

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,6 +45,8 @@ The item descriptions below use the following types:
     "``tcp:3456:interface=127.0.0.1``". For a full description of the format,
     see `the Twisted strports documentation
     <http://twistedmatrix.com/documents/current/api/twisted.application.strports.html>`_.
+    Please note, if interface= is not specified, Tahoe-LAFS will attempt to
+    bind the port specified on all interfaces.
 
 ``FURL string``
 


### PR DESCRIPTION
Updated docs/configuration.rst to notify people that if interface= is not specificed, Tahoe-LAFS attempts to bind to all interfaces.
