### PR TITLE
docs/frontends/webapi.rst: remove (ignored) "size" keyword from mkdir POST example

### DIFF
--- a/docs/frontends/webapi.rst
+++ b/docs/frontends/webapi.rst
@@ -459,7 +459,6 @@ Creating A New Directory
   {
     "Fran\u00e7ais": [ "filenode", {
         "ro_uri": "URI:CHK:...",
-        "size": bytes,
         "metadata": {
           "ctime": 1202777696.7564139,
           "mtime": 1202777696.7564139,


### PR DESCRIPTION
Unless I've fatally missed something, that key is completely ignored, and probably shouldn't be in the directory objects anyway.
Tried looking for code relying on it in "src/allmydata/web" (turned up nothing) as well as passing arbitrary numbers there (to no effect).

Looks like a simple mistake in b30041c5 (summary: "webapi: t=mkdir now accepts initial children, using the same JSON that t=json emits."), in which apparently GET data was reused and that key not stripped.
