### PR TITLE
client.py: rename instance attribute DEFAULT_ENCODING_PARAMETERS...

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -130,7 +130,7 @@ class Client(node.Node, pollmixin.PollMixin):
         node.Node.__init__(self, basedir)
         self.started_timestamp = time.time()
         self.logSource="Client"
-        self.DEFAULT_ENCODING_PARAMETERS = self.DEFAULT_ENCODING_PARAMETERS.copy()
+        self._encoding_parameters = self.DEFAULT_ENCODING_PARAMETERS.copy()
         self.init_introducer_client()
         self.init_stats_provider()
         self.init_secrets()
@@ -306,10 +306,10 @@ class Client(node.Node, pollmixin.PollMixin):
 
     def init_client(self):
         helper_furl = self.get_config("client", "helper.furl", None)
-        DEP = self.DEFAULT_ENCODING_PARAMETERS
-        DEP["k"] = int(self.get_config("client", "shares.needed", DEP["k"]))
-        DEP["n"] = int(self.get_config("client", "shares.total", DEP["n"]))
-        DEP["happy"] = int(self.get_config("client", "shares.happy", DEP["happy"]))
+        params = self._encoding_parameters
+        params["k"] = int(self.get_config("client", "shares.needed", params["k"]))
+        params["n"] = int(self.get_config("client", "shares.total", params["n"]))
+        params["happy"] = int(self.get_config("client", "shares.happy", params["happy"]))
 
         self.init_client_storage_broker()
         self.history = History(self.stats_provider)
@@ -488,7 +488,7 @@ class Client(node.Node, pollmixin.PollMixin):
         reactor.stop()
 
     def get_encoding_parameters(self):
-        return self.DEFAULT_ENCODING_PARAMETERS
+        return self._encoding_parameters
 
     def connected_to_introducer(self):
         if self.introducer_client:

--- a/src/allmydata/test/test_checker.py
+++ b/src/allmydata/test/test_checker.py
@@ -367,9 +367,9 @@ class BalancingAct(GridTestMixin, unittest.TestCase):
         self.basedir = "checker/BalancingAct/1115"
         self.set_up_grid(num_servers=1)
         c0 = self.g.clients[0]
-        c0.DEFAULT_ENCODING_PARAMETERS['happy'] = 1
-        c0.DEFAULT_ENCODING_PARAMETERS['n'] = 4
-        c0.DEFAULT_ENCODING_PARAMETERS['k'] = 3
+        c0._encoding_parameters['happy'] = 1
+        c0._encoding_parameters['n'] = 4
+        c0._encoding_parameters['k'] = 3
 
         DATA = "data" * 100
         d = c0.upload(Data(DATA, convergence=""))
@@ -426,7 +426,7 @@ class AddLease(GridTestMixin, unittest.TestCase):
         self.basedir = "checker/AddLease/875"
         self.set_up_grid(num_servers=1)
         c0 = self.g.clients[0]
-        c0.DEFAULT_ENCODING_PARAMETERS['happy'] = 1
+        c0._encoding_parameters['happy'] = 1
         self.uris = {}
         DATA = "data" * 100
         d = c0.upload(Data(DATA, convergence=""))
@@ -514,11 +514,11 @@ class TooParallel(GridTestMixin, unittest.TestCase):
         def _start(ign):
             self.set_up_grid(num_servers=4)
             self.c0 = self.g.clients[0]
-            self.c0.DEFAULT_ENCODING_PARAMETERS = { "k": 1,
-                                               "happy": 4,
-                                               "n": 4,
-                                               "max_segment_size": 5,
-                                               }
+            self.c0._encoding_parameters = { "k": 1,
+                                             "happy": 4,
+                                             "n": 4,
+                                             "max_segment_size": 5,
+                                             }
             self.uris = {}
             DATA = "data" * 100 # 400/5 = 80 blocks
             return self.c0.upload(Data(DATA, convergence=""))

--- a/src/allmydata/test/test_helper.py
+++ b/src/allmydata/test/test_helper.py
@@ -86,9 +86,10 @@ class FakeClient(service.MultiService):
                                    "n": 100,
                                    "max_segment_size": 1*MiB,
                                    }
-
+    def __init__(self):
+        self._encoding_parameters = self.DEFAULT_ENCODING_PARAMETERS.copy()
     def get_encoding_parameters(self):
-        return self.DEFAULT_ENCODING_PARAMETERS
+        return self._encoding_parameters
     def get_storage_broker(self):
         return self.storage_broker
 

--- a/src/allmydata/test/test_immutable.py
+++ b/src/allmydata/test/test_immutable.py
@@ -140,10 +140,10 @@ class Test(GridTestMixin, unittest.TestCase, common.ShouldFailMixin):
         c1 = self.g.clients[1]
         # We need multiple segments to test crypttext hash trees that are
         # non-trivial (i.e. they have more than just one hash in them).
-        c1.DEFAULT_ENCODING_PARAMETERS['max_segment_size'] = 12
+        c1._encoding_parameters['max_segment_size'] = 12
         # Tests that need to test servers of happiness using this should
         # set their own value for happy -- the default (7) breaks stuff.
-        c1.DEFAULT_ENCODING_PARAMETERS['happy'] = 1
+        c1._encoding_parameters['happy'] = 1
         d = c1.upload(Data(TEST_DATA, convergence=""))
         def _after_upload(ur):
             self.uri = ur.get_uri()

--- a/src/allmydata/test/test_repairer.py
+++ b/src/allmydata/test/test_repairer.py
@@ -59,7 +59,7 @@ class RepairTestMixin:
     def upload_and_stash(self):
         c0 = self.g.clients[0]
         c1 = self.g.clients[1]
-        c0.DEFAULT_ENCODING_PARAMETERS['max_segment_size'] = 12
+        c0._encoding_parameters['max_segment_size'] = 12
         d = c0.upload(upload.Data(common.TEST_DATA, convergence=""))
         def _stash_uri(ur):
             self.uri = ur.get_uri()
@@ -678,8 +678,8 @@ class Repairer(GridTestMixin, unittest.TestCase, RepairTestMixin,
         self.set_up_grid()
         c0 = self.g.clients[0]
         DATA = "a"*135
-        c0.DEFAULT_ENCODING_PARAMETERS['k'] = 22
-        c0.DEFAULT_ENCODING_PARAMETERS['n'] = 66
+        c0._encoding_parameters['k'] = 22
+        c0._encoding_parameters['n'] = 66
         d = c0.upload(upload.Data(DATA, convergence=""))
         def _then(ur):
             self.uri = ur.get_uri()

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -101,7 +101,7 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
         d = self.set_up_nodes()
         def _check_connections(res):
             for c in self.clients:
-                c.DEFAULT_ENCODING_PARAMETERS['happy'] = 5
+                c._encoding_parameters['happy'] = 5
                 all_peerids = c.get_storage_broker().get_all_serverids()
                 self.failUnlessEqual(len(all_peerids), self.numclients)
                 sb = c.storage_broker
@@ -213,7 +213,7 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
                                                       add_to_sparent=True))
         def _added(extra_node):
             self.extra_node = extra_node
-            self.extra_node.DEFAULT_ENCODING_PARAMETERS['happy'] = 5
+            self.extra_node._encoding_parameters['happy'] = 5
         d.addCallback(_added)
 
         def _has_helper():
@@ -723,7 +723,7 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
         d = self.set_up_nodes(use_stats_gatherer=True)
         def _new_happy_semantics(ign):
             for c in self.clients:
-                c.DEFAULT_ENCODING_PARAMETERS['happy'] = 1
+                c._encoding_parameters['happy'] = 1
         d.addCallback(_new_happy_semantics)
         d.addCallback(self._test_introweb)
         d.addCallback(self.log, "starting publish")
@@ -1171,7 +1171,7 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
         def _new_happy_semantics(ign):
             for c in self.clients:
                 # these get reset somewhere? Whatever.
-                c.DEFAULT_ENCODING_PARAMETERS['happy'] = 1
+                c._encoding_parameters['happy'] = 1
         d.addCallback(_new_happy_semantics)
         d.addCallback(lambda res: self.PUT(public + "/subdir3/big.txt",
                                            "big" * 500000)) # 1.5MB
@@ -1764,7 +1764,7 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
         d = self.set_up_nodes()
         def _new_happy_semantics(ign):
             for c in self.clients:
-                c.DEFAULT_ENCODING_PARAMETERS['happy'] = 1
+                c._encoding_parameters['happy'] = 1
         d.addCallback(_new_happy_semantics)
 
         def _run_in_subprocess(ignored, verb, *args, **kwargs):

--- a/src/allmydata/test/test_web.py
+++ b/src/allmydata/test/test_web.py
@@ -5205,7 +5205,7 @@ class Grid(GridTestMixin, WebErrorMixin, ShouldFailMixin, testutil.ReallyEqualMi
         self.basedir = "web/Grid/exceptions"
         self.set_up_grid(num_clients=1, num_servers=2)
         c0 = self.g.clients[0]
-        c0.DEFAULT_ENCODING_PARAMETERS['happy'] = 2
+        c0._encoding_parameters['happy'] = 2
         self.fileurls = {}
         DATA = "data" * 100
         d = c0.create_dirnode()


### PR DESCRIPTION
... to _encoding_parameters. fixes #1847

Signed-off-by: David-Sarah Hopwood david-sarah@jacaranda.org
