### PR TITLE
pkg_resources: better error message on bad spec

### DIFF
--- a/setuptools-0.6c16dev3.egg/pkg_resources.py
+++ b/setuptools-0.6c16dev3.egg/pkg_resources.py
@@ -528,11 +528,14 @@ class WorkingSet(object):
         # dist is unsatisfactory, in which case we won't add it.
         if __requires__ is not None:
             for thisreqstr in __requires__:
-                for thisreq in parse_requirements(thisreqstr):
-                    if thisreq.key == dist.key:
-                        if dist not in thisreq:
-                            return
-
+                try:
+                    for thisreq in parse_requirements(thisreqstr):
+                        if thisreq.key == dist.key:
+                            if dist not in thisreq:
+                                return
+                except ValueError, e:
+                    e.args = tuple(e.args + ({'thisreqstr': thisreqstr},))
+                    raise
 
         self.by_key[dist.key] = dist
         if dist.key not in keys:


### PR DESCRIPTION
Include the text of the offending distribution spec when it is ill-formed.

I got an error message from pkg_resources.py saying that a distribution spec
was ill-formed, because it ended with an '=' and nothing came after the '='.
However, the error message and stack trace didn't tell which distribution spec
it was.

With this patch, it includes the distribution spec itself in the error message.

There is no unit test of this patch, but I did test it manually by inserting a
"raise ValueError('WHATEVER')" into the code and re-running it and observing
that the new output correctly included the distribution
