### PR TITLE
test_web.py: fix test_GET_DIRECTORY_html_filenode_encoding for Twisted==12.3.0. fixes #1922

### DIFF
--- a/src/allmydata/test/test_web.py
+++ b/src/allmydata/test/test_web.py
@@ -1,4 +1,4 @@
-import os.path, re, urllib, time
+import os.path, re, urllib, time, cgi
 import simplejson
 from StringIO import StringIO
 
@@ -6,7 +6,7 @@ from twisted.application import service
 from twisted.trial import unittest
 from twisted.internet import defer, reactor
 from twisted.internet.task import Clock
-from twisted.web import client, error, http, html
+from twisted.web import client, error, http
 from twisted.python import failure, log
 
 from foolscap.api import fireEventually, flushEventualQueue
@@ -324,8 +324,8 @@ class WebMixin(object):
             self._htmlname_raw = self._htmlname_unicode.encode('utf-8')
             self._htmlname_urlencoded = urllib.quote(self._htmlname_raw, '')
             self._htmlname_escaped = escapeToXML(self._htmlname_raw)
-            self._htmlname_escaped_attr = html.escape(self._htmlname_raw)
-            self._htmlname_escaped_double = escapeToXML(html.escape(self._htmlname_raw))
+            self._htmlname_escaped_attr = cgi.escape(self._htmlname_raw, quote=True)
+            self._htmlname_escaped_double = escapeToXML(cgi.escape(self._htmlname_raw, quote=True))
             self.HTMLNAME_CONTENTS, n, self._htmlname_txt_uri = self.makefile(0)
             foo.set_uri(self._htmlname_unicode, self._htmlname_txt_uri, self._htmlname_txt_uri)
 


### PR DESCRIPTION
twisted.web.html.escape was used to produce html-encoded string (to then look it up in "value" attribute), but behavior of that function has changed between Twisted 12.2.0 (simple custom implementation) and 12.3.0 (imported from stdlib cgi module).
cgi.escape() requires quote=True parameter to escape double-quote characters.

Fixed by simply using reliable cgi.escape to produce html-escaped string for tests.

Pretty sure I used twisted.web.html.escape because Nevow also used it, but looks like currently it properly quotes attribute values, so guess different func is used for attributes there.
