### PR TITLE
docs/quickstart.rst: python >=2.6.8 is required

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,12 +31,12 @@ Install Python
 --------------
 
 Check if you already have an adequate version of Python installed by running
-``python -V``. Python v2.4 (v2.4.4 or greater), Python v2.5, Python v2.6, or
-Python v2.7 will work. Python v3 does not work. On Windows, we recommend the
-use of native Python, not Cygwin. If you don't have one of these versions of
-Python installed, download and install `Python v2.7`_. Make sure that the
-path to the installation directory has no spaces in it (e.g. on Windows, do
-not install Python in the "Program Files" directory).
+``python -V``. Tahoe requires Python v2.6.8 or greater. Python v2.7 will work.
+Python v3 does not work. On Windows, we recommend the use of native Python, not
+Cygwin. If you don't have one of these versions of Python installed, download
+and install `Python v2.7`_. Make sure that the path to the installation
+directory has no spaces in it (e.g. on Windows, do not install Python in the
+"Program Files" directory).
 
 .. _Python v2.7: http://www.python.org/download/releases/2.7.2/
 


### PR DESCRIPTION
as per https://tahoe-lafs.org/trac/tahoe-lafs/wiki/CodingStandards?action=diff&version=21
