### PR TITLE
workaround for regression in f14602cb34762f02ff483698b73ef963bdcb1da0

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -221,9 +221,13 @@ class Client(node.Node, pollmixin.PollMixin):
         self._node_key = sk
 
     def get_long_nodeid(self):
-        # this matches what IServer.get_longname() says about us elsewhere
-        vk_bytes = self._node_key.get_verifying_key_bytes()
-        return "v0-"+base32.b2a(vk_bytes)
+        try:
+            # this matches what IServer.get_longname() says about us elsewhere
+            vk_bytes = self._node_key.get_verifying_key_bytes()
+        except AttributeError:
+            return None
+        else:
+            return "v0-"+base32.b2a(vk_bytes)
 
     def get_long_tubid(self):
         return idlib.nodeid_b2a(self.nodeid)

--- a/src/allmydata/web/root.py
+++ b/src/allmydata/web/root.py
@@ -169,8 +169,13 @@ class Root(rend.Page):
     def data_import_path(self, ctx, data):
         return str(allmydata)
     def render_my_nodeid(self, ctx, data):
-        tubid_s = "TubID: "+self.client.get_long_tubid()
-        return T.td(title=tubid_s)[self.client.get_long_nodeid()]
+        long_nodeid = self.client.get_long_nodeid()
+        long_tubid = self.client.get_long_tubid()
+        if long_nodeid is not None:
+            tubid_s = "TubID: "+long_tubid
+            return T.td(title=tubid_s)[long_nodeid]
+        else:
+            return T.td()[long_tubid]
     def data_my_nickname(self, ctx, data):
         return self.client.nickname
 


### PR DESCRIPTION
caused the WUI's welcome page to not display on client-only nodes due to
_node_key not being present.
