### PR TITLE
Fixes the overlapping text in docs/lease-tradeoffs.svg

### DIFF
--- a/docs/lease-tradeoffs.svg
+++ b/docs/lease-tradeoffs.svg
@@ -119,11 +119,11 @@
          y="413.94577">lease</tspan><tspan
          sodipodi:role="line"
          x="411.13205"
-         y="413.94577"
+         y="435.94577"
          id="tspan4585">expiration</tspan><tspan
          sodipodi:role="line"
          x="411.13205"
-         y="435.94577"
+         y="457.94577"
          id="tspan2397">time</tspan></text>
     <text
        xml:space="preserve"


### PR DESCRIPTION
This fixes ticket #1842. Patch courtesy of PRabahy.

https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1842
