### PR TITLE
fix a couple more "file:" links

### DIFF
--- a/docs/cautions.rst
+++ b/docs/cautions.rst
@@ -5,7 +5,7 @@
 
 See also known_issues.rst_.
 
-.. _known_issues.rst: file:known_issues.rst
+.. _known_issues.rst: known_issues.rst
 
 Timing Attacks
 ==============

--- a/docs/helper.rst
+++ b/docs/helper.rst
@@ -17,7 +17,7 @@ them during download. With the default 3-of-10 encoding parameters, this
 means that an upload will require about 3.3x the traffic as a download of the
 same file.
 
-.. _architecture.rst: file:architecture.rst
+.. _architecture.rst: architecture.rst
 
 Unfortunately, this "expansion penalty" occurs in the same upstream direction
 that most consumer DSL lines are slow anyways. Typical ADSL lines get 8 times
@@ -132,7 +132,7 @@ give you, and edit your tahoe.cfg file. Enter the helper's furl into the
 value of the key "helper.furl" in the "[client]" section of tahoe.cfg, as
 described in the "Client Configuration" section of configuration.rst_.
 
-.. _configuration.rst: file:configuration.rst
+.. _configuration.rst: configuration.rst
 
 Then restart the node. This will signal the client to try and connect to the
 helper. Subsequent uploads will use the helper rather than using direct


### PR DESCRIPTION
Making them be just links to "$FILENAME" instead of to "file:$FILENAME" causes
them to be working links on trac and on github. Yay!
