### PR TITLE
Remove 'needs-rebalancing' and add 'count-happiness' to checker reports

### DIFF
--- a/docs/frontends/webapi.rst
+++ b/docs/frontends/webapi.rst
@@ -1415,6 +1415,8 @@ mainly intended for developers.
            this dictionary has only the 'healthy' key, which will always be
            True. For distributed files, this dictionary has the following
            keys:
+    count-happiness: the servers-of-happiness level of the file, as
+                     defined in `docs/specifications/servers-of-happiness.rst`_.
     count-shares-good: the number of good shares that were found
     count-shares-needed: 'k', the number of shares required for recovery
     count-shares-expected: 'N', the number of total shares generated
@@ -1438,12 +1440,6 @@ mainly intended for developers.
     list-corrupt-shares: a list of "share locators", one for each share
                          that was found to be corrupt. Each share locator
                          is a list of (serverid, storage_index, sharenum).
-    needs-rebalancing: (bool) This field is intended to be True iff
-                       reliability could be improved for this file by
-                       rebalancing, i.e. by moving some shares to other
-                       servers. It may be incorrect in some cases for
-                       Tahoe-LAFS up to and including v1.10, and its
-                       precise definition is expected to change.
     servers-responding: list of base32-encoded storage server identifiers,
                         one for each server which responded to the share
                         query.
@@ -1465,6 +1461,12 @@ mainly intended for developers.
               immutable files, it is a string of the form
               'seq%d-%s-sh%d', containing the sequence number, the
               roothash, and the share number.
+
+Before Tahoe-LAFS v1.11, the `results` dictionary also had a `needs-rebalancing`
+field, but that has been removed since it was computed incorrectly.
+
+.. _`docs/specifications/servers-of-happiness.rst`: ../specifications/servers-of-happiness.rst
+
 
 ``POST $URL?t=start-deep-check``    (must add &ophandle=XYZ)
 

--- a/src/allmydata/check_results.py
+++ b/src/allmydata/check_results.py
@@ -8,7 +8,7 @@ class CheckResults:
     implements(ICheckResults)
 
     def __init__(self, uri, storage_index,
-                 healthy, recoverable, needs_rebalancing,
+                 healthy, recoverable, count_happiness,
                  count_shares_needed, count_shares_expected,
                  count_shares_good, count_good_share_hosts,
                  count_recoverable_versions, count_unrecoverable_versions,
@@ -31,8 +31,8 @@ class CheckResults:
         self._recoverable = recoverable
         if not self._recoverable:
             assert not self._healthy
-        self._needs_rebalancing_p = bool(needs_rebalancing)
 
+        self._count_happiness = count_happiness
         self._count_shares_needed = count_shares_needed
         self._count_shares_expected = count_shares_expected
         self._count_shares_good = count_shares_good
@@ -78,8 +78,8 @@ class CheckResults:
     def is_recoverable(self):
         return self._recoverable
 
-    def needs_rebalancing(self):
-        return self._needs_rebalancing_p
+    def get_happiness(self):
+        return self._count_happiness
 
     def get_encoding_needed(self):
         return self._count_shares_needed
@@ -120,7 +120,8 @@ class CheckResults:
                    for (s, SI, shnum) in self._list_corrupt_shares]
         incompatible = [(s.get_serverid(), SI, shnum)
                         for (s, SI, shnum) in self._list_incompatible_shares]
-        d = {"count-shares-needed": self._count_shares_needed,
+        d = {"count-happiness": self._count_happiness,
+             "count-shares-needed": self._count_shares_needed,
              "count-shares-expected": self._count_shares_expected,
              "count-shares-good": self._count_shares_good,
              "count-good-share-hosts": self._count_good_share_hosts,

--- a/src/allmydata/immutable/checker.py
+++ b/src/allmydata/immutable/checker.py
@@ -12,6 +12,7 @@ from allmydata.util.hashutil import file_renewal_secret_hash, \
      file_cancel_secret_hash, bucket_renewal_secret_hash, \
      bucket_cancel_secret_hash, uri_extension_hash, CRYPTO_VAL_SIZE, \
      block_hash
+from allmydata.util.happinessutil import servers_of_happiness
 
 from allmydata.immutable import layout
 
@@ -775,15 +776,11 @@ class Checker(log.PrefixingLogMixin):
             recoverable = 0
             unrecoverable = 1
 
-        # The file needs rebalancing if the set of servers that have at least
-        # one share is less than the number of uniquely-numbered shares
-        # available.
-        # TODO: this may be wrong, see ticket #1115 comment:27 and ticket #1784.
-        needs_rebalancing = bool(good_share_hosts < len(verifiedshares))
+        count_happiness = servers_of_happiness(verifiedshares)
 
         cr = CheckResults(self._verifycap, SI,
                           healthy=healthy, recoverable=bool(recoverable),
-                          needs_rebalancing=needs_rebalancing,
+                          count_happiness=count_happiness,
                           count_shares_needed=self._verifycap.needed_shares,
                           count_shares_expected=self._verifycap.total_shares,
                           count_shares_good=len(verifiedshares),

--- a/src/allmydata/immutable/filenode.py
+++ b/src/allmydata/immutable/filenode.py
@@ -11,6 +11,7 @@ from allmydata.interfaces import IImmutableFileNode, IUploadResults
 from allmydata.util import consumer
 from allmydata.check_results import CheckResults, CheckAndRepairResults
 from allmydata.util.dictutil import DictOfSets
+from allmydata.util.happinessutil import servers_of_happiness
 from pycryptopp.cipher.aes import AES
 
 # local imports
@@ -144,12 +145,11 @@ class CiphertextFileNode:
         is_healthy = bool(len(sm) >= verifycap.total_shares)
         is_recoverable = bool(len(sm) >= verifycap.needed_shares)
 
-        # TODO: this may be wrong, see ticket #1115 comment:27 and ticket #1784.
-        needs_rebalancing = bool(len(sm) >= verifycap.total_shares)
+        count_happiness = servers_of_happiness(sm)
 
         prr = CheckResults(cr.get_uri(), cr.get_storage_index(),
                            healthy=is_healthy, recoverable=is_recoverable,
-                           needs_rebalancing=needs_rebalancing,
+                           count_happiness=count_happiness,
                            count_shares_needed=verifycap.needed_shares,
                            count_shares_expected=verifycap.total_shares,
                            count_shares_good=len(sm),

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -2156,18 +2156,16 @@ class ICheckResults(Interface):
         not. Unrecoverable files are obviously unhealthy. Non-distributed LIT
         files always return True."""
 
-    def needs_rebalancing():
-        """Return a boolean, True if the file/dir's reliability could be
-        improved by moving shares to new servers. Non-distributed LIT files
-        always return False."""
-
     # the following methods all return None for non-distributed LIT files
 
+    def get_happiness():
+        """Return the happiness count of the file."""
+
     def get_encoding_needed():
-        """Return 'k', the number of shares required for recovery"""
+        """Return 'k', the number of shares required for recovery."""
 
     def get_encoding_expected():
-        """Return 'N', the number of total shares generated"""
+        """Return 'N', the number of total shares generated."""
 
     def get_share_counter_good():
         """Return the number of distinct good shares that were found. For

--- a/src/allmydata/test/common.py
+++ b/src/allmydata/test/common.py
@@ -70,7 +70,7 @@ class FakeCHKFileNode:
         s = StubServer("\x00"*20)
         r = CheckResults(self.my_uri, self.storage_index,
                          healthy=True, recoverable=True,
-                         needs_rebalancing=False,
+                         count_happiness=10,
                          count_shares_needed=3,
                          count_shares_expected=10,
                          count_shares_good=10,
@@ -282,7 +282,7 @@ class FakeMutableFileNode:
         s = StubServer("\x00"*20)
         r = CheckResults(self.my_uri, self.storage_index,
                          healthy=True, recoverable=True,
-                         needs_rebalancing=False,
+                         count_happiness=10,
                          count_shares_needed=3,
                          count_shares_expected=10,
                          count_shares_good=10,

--- a/src/allmydata/test/test_checker.py
+++ b/src/allmydata/test/test_checker.py
@@ -84,7 +84,8 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
         server_1 = sb.get_stub_server(serverid_1)
         server_f = sb.get_stub_server(serverid_f)
         u = uri.CHKFileURI("\x00"*16, "\x00"*32, 3, 10, 1234)
-        data = { "count_shares_needed": 3,
+        data = { "count_happiness": 8,
+                 "count_shares_needed": 3,
                  "count_shares_expected": 9,
                  "count_shares_good": 10,
                  "count_good_share_hosts": 11,
@@ -101,7 +102,6 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
                  }
         cr = check_results.CheckResults(u, u.get_storage_index(),
                                         healthy=True, recoverable=True,
-                                        needs_rebalancing=False,
                                         summary="groovy",
                                         **data)
         w = web_check_results.CheckResultsRenderer(c, cr)
@@ -110,6 +110,7 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
         self.failUnlessIn("File Check Results for SI=2k6avp", s) # abbreviated
         self.failUnlessIn("Healthy : groovy", s)
         self.failUnlessIn("Share Counts: need 3-of-9, have 10", s)
+        self.failUnlessIn("Happiness Count: 8", s)
         self.failUnlessIn("Hosts with good shares: 11", s)
         self.failUnlessIn("Corrupt shares: none", s)
         self.failUnlessIn("Wrong Shares: 0", s)
@@ -119,7 +120,6 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
 
         cr = check_results.CheckResults(u, u.get_storage_index(),
                                         healthy=False, recoverable=True,
-                                        needs_rebalancing=False,
                                         summary="ungroovy",
                                         **data)
         w = web_check_results.CheckResultsRenderer(c, cr)
@@ -132,7 +132,6 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
         data["list_corrupt_shares"] = [(server_1, u.get_storage_index(), 2)]
         cr = check_results.CheckResults(u, u.get_storage_index(),
                                         healthy=False, recoverable=False,
-                                        needs_rebalancing=False,
                                         summary="rather dead",
                                         **data)
         w = web_check_results.CheckResultsRenderer(c, cr)
@@ -157,7 +156,7 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
             self.failUnlessEqual(j["summary"], "rather dead")
             self.failUnlessEqual(j["storage-index"],
                                  "2k6avpjga3dho3zsjo6nnkt7n4")
-            expected = {'needs-rebalancing': False,
+            expected = {'count-happiness': 8,
                         'count-shares-expected': 9,
                         'healthy': False,
                         'count-unrecoverable-versions': 0,
@@ -192,7 +191,8 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
         serverid_f = "\xff"*20
         u = uri.CHKFileURI("\x00"*16, "\x00"*32, 3, 10, 1234)
 
-        data = { "count_shares_needed": 3,
+        data = { "count_happiness": 5,
+                 "count_shares_needed": 3,
                  "count_shares_expected": 10,
                  "count_shares_good": 6,
                  "count_good_share_hosts": 7,
@@ -210,11 +210,11 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
                  }
         pre_cr = check_results.CheckResults(u, u.get_storage_index(),
                                             healthy=False, recoverable=True,
-                                            needs_rebalancing=False,
                                             summary="illing",
                                             **data)
 
-        data = { "count_shares_needed": 3,
+        data = { "count_happiness": 9,
+                 "count_shares_needed": 3,
                  "count_shares_expected": 10,
                  "count_shares_good": 10,
                  "count_good_share_hosts": 11,
@@ -232,7 +232,6 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
                  }
         post_cr = check_results.CheckResults(u, u.get_storage_index(),
                                              healthy=True, recoverable=True,
-                                             needs_rebalancing=False,
                                              summary="groovy",
                                              **data)
 
@@ -265,7 +264,6 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
         crr.repair_successful = False
         post_cr = check_results.CheckResults(u, u.get_storage_index(),
                                              healthy=False, recoverable=True,
-                                             needs_rebalancing=False,
                                              summary="better",
                                              **data)
         crr.post_repair_results = post_cr
@@ -281,7 +279,6 @@ class WebResultsRendering(unittest.TestCase, WebRenderingMixin):
         crr.repair_successful = False
         post_cr = check_results.CheckResults(u, u.get_storage_index(),
                                              healthy=False, recoverable=False,
-                                             needs_rebalancing=False,
                                              summary="worse",
                                              **data)
         crr.post_repair_results = post_cr

--- a/src/allmydata/test/test_deepcheck.py
+++ b/src/allmydata/test/test_deepcheck.py
@@ -277,13 +277,12 @@ class DeepCheckWebGood(DeepCheckBase, unittest.TestCase):
         self.failUnlessEqual(cr.get_storage_index_string(),
                              base32.b2a(n.get_storage_index()), where)
         num_servers = len(self.g.all_servers)
-        needs_rebalancing = bool( num_servers < 10 )
-        if not incomplete:
-            self.failUnlessEqual(cr.needs_rebalancing(), needs_rebalancing,
-                                 str((where, cr, cr.as_dict())))
-        self.failUnlessEqual(cr.get_share_counter_good(), 10, where)
+        self.failUnlessEqual(num_servers, 10, where)
+
+        self.failUnlessEqual(cr.get_happiness(), num_servers, where)
+        self.failUnlessEqual(cr.get_share_counter_good(), num_servers, where)
         self.failUnlessEqual(cr.get_encoding_needed(), 3, where)
-        self.failUnlessEqual(cr.get_encoding_expected(), 10, where)
+        self.failUnlessEqual(cr.get_encoding_expected(), num_servers, where)
         if not incomplete:
             self.failUnlessEqual(cr.get_host_counter_good_shares(),
                                  num_servers, where)
@@ -533,13 +532,13 @@ class DeepCheckWebGood(DeepCheckBase, unittest.TestCase):
         r = data["results"]
         self.failUnlessEqual(r["healthy"], True, where)
         num_servers = len(self.g.all_servers)
-        needs_rebalancing = bool( num_servers < 10 )
-        if not incomplete:
-            self.failUnlessEqual(r["needs-rebalancing"], needs_rebalancing,
-                                 where)
-        self.failUnlessEqual(r["count-shares-good"], 10, where)
+        self.failUnlessEqual(num_servers, 10)
+
+        self.failIfIn("needs-rebalancing", r)
+        self.failUnlessEqual(r["count-happiness"], num_servers, where)
+        self.failUnlessEqual(r["count-shares-good"], num_servers, where)
         self.failUnlessEqual(r["count-shares-needed"], 3, where)
-        self.failUnlessEqual(r["count-shares-expected"], 10, where)
+        self.failUnlessEqual(r["count-shares-expected"], num_servers, where)
         if not incomplete:
             self.failUnlessEqual(r["count-good-share-hosts"], num_servers,
                                  where)

--- a/src/allmydata/web/check_results.py
+++ b/src/allmydata/web/check_results.py
@@ -8,8 +8,10 @@ from allmydata.web.operations import ReloadMixin
 from allmydata.interfaces import ICheckAndRepairResults, ICheckResults
 from allmydata.util import base32, dictutil
 
+
 def json_check_counts(r):
-    d = {"count-shares-good": r.get_share_counter_good(),
+    d = {"count-happiness": r.get_happiness(),
+         "count-shares-good": r.get_share_counter_good(),
          "count-shares-needed": r.get_encoding_needed(),
          "count-shares-expected": r.get_encoding_expected(),
          "count-good-share-hosts": r.get_host_counter_good_shares(),
@@ -40,7 +42,6 @@ def json_check_results(r):
     data["storage-index"] = r.get_storage_index_string()
     data["summary"] = r.get_summary()
     data["results"] = json_check_counts(r)
-    data["results"]["needs-rebalancing"] = r.needs_rebalancing()
     data["results"]["healthy"] = r.is_healthy()
     data["results"]["recoverable"] = r.is_recoverable()
     return data
@@ -86,6 +87,7 @@ class ResultsBase:
             "need %d-of-%d, have %d" % (cr.get_encoding_needed(),
                                         cr.get_encoding_expected(),
                                         cr.get_share_counter_good()))
+        add("Happiness Count", cr.get_happiness())
         add("Hosts with good shares", cr.get_host_counter_good_shares())
 
         if cr.get_corrupt_shares():


### PR DESCRIPTION
Remove 'needs-rebalancing' and add 'count-happiness' to checker reports; repair tests.
fixes #1784, #2105

Signed-off-by: Daira Hopwood daira@jacaranda.org
