### PR TITLE
comments which set emacs variables

### DIFF
--- a/COPYING.TGPPL.rst
+++ b/COPYING.TGPPL.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 This work also comes with the added permission that you may combine it with a
 work licensed under the OpenSSL license (any version) and distribute the

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================================
 User-Visible Changes in Tahoe-LAFS

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 Welcome to Tahoe-LAFS!
 ======================

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 Tahoe-LAFS Architecture

--- a/docs/backdoors.rst
+++ b/docs/backdoors.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 Statement on Backdoors
 ======================

--- a/docs/backupdb.rst
+++ b/docs/backupdb.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================
 The Tahoe BackupDB

--- a/docs/cautions.rst
+++ b/docs/cautions.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================================================
  Things To Be Careful About As We Venture Boldly Forth

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============================
 Configuring a Tahoe-LAFS node

--- a/docs/convergence-secret.rst
+++ b/docs/convergence-secret.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 What Is It?
 -----------

--- a/docs/debian.rst
+++ b/docs/debian.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =========================
 Debian and Ubuntu Support

--- a/docs/filesystem-notes.rst
+++ b/docs/filesystem-notes.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =========================
 Filesystem-specific notes

--- a/docs/frontends/CLI.rst
+++ b/docs/frontends/CLI.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===========================
 The Tahoe-LAFS CLI commands

--- a/docs/frontends/FTP-and-SFTP.rst
+++ b/docs/frontends/FTP-and-SFTP.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =================================
 Tahoe-LAFS SFTP and FTP Frontends

--- a/docs/frontends/download-status.rst
+++ b/docs/frontends/download-status.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===============
 Download status

--- a/docs/frontends/drop-upload.rst
+++ b/docs/frontends/drop-upload.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===============================
 Tahoe-LAFS Drop-Upload Frontend

--- a/docs/frontends/webapi.rst
+++ b/docs/frontends/webapi.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==========================
 The Tahoe REST-ful Web API

--- a/docs/garbage-collection.rst
+++ b/docs/garbage-collection.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===========================
 Garbage Collection in Tahoe

--- a/docs/helper.rst
+++ b/docs/helper.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 The Tahoe Upload Helper

--- a/docs/historical/configuration.rst
+++ b/docs/historical/configuration.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 Old Configuration Files

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 See also `cautions.rst`_.
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============
 Tahoe Logging

--- a/docs/nodekeys.rst
+++ b/docs/nodekeys.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 Node Keys in Tahoe-LAFS

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ============================================
 Performance costs for some common operations

--- a/docs/proposed/leasedb.rst
+++ b/docs/proposed/leasedb.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =====================
 Lease database design

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================
 Getting Tahoe-LAFS

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =====================
 How To Run Tahoe-LAFS

--- a/docs/specifications/URI-extension.rst
+++ b/docs/specifications/URI-extension.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===================
 URI Extension Block

--- a/docs/specifications/backends/raic.rst
+++ b/docs/specifications/backends/raic.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============================================================
 Redundant Array of Independent Clouds: Share To Cloud Mapping

--- a/docs/specifications/dirnodes.rst
+++ b/docs/specifications/dirnodes.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==========================
 Tahoe-LAFS Directory Nodes

--- a/docs/specifications/file-encoding.rst
+++ b/docs/specifications/file-encoding.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============
 File Encoding

--- a/docs/specifications/mutable.rst
+++ b/docs/specifications/mutable.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============
 Mutable Files

--- a/docs/specifications/outline.rst
+++ b/docs/specifications/outline.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==============================
 Specification Document Outline

--- a/docs/specifications/servers-of-happiness.rst
+++ b/docs/specifications/servers-of-happiness.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ====================
 Servers of Happiness

--- a/docs/specifications/uri.rst
+++ b/docs/specifications/uri.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==========
 Tahoe URIs

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ================
 Tahoe Statistics

--- a/docs/write_coordination.rst
+++ b/docs/write_coordination.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================================
 Avoiding Write Collisions in Tahoe

--- a/misc/build_helpers/build-deb.py
+++ b/misc/build_helpers/build-deb.py
@@ -1,4 +1,5 @@
-#!/bin/false # invoke this with a specific python
+﻿#!/bin/false # invoke this with a specific python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import sys, shutil, os.path
 from subprocess import Popen, PIPE

--- a/misc/build_helpers/check-build.py
+++ b/misc/build_helpers/check-build.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # This helper script is used with the 'test-desert-island' Makefile target.
 

--- a/misc/build_helpers/clean-up-after-fake-dists.py
+++ b/misc/build_helpers/clean-up-after-fake-dists.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 import glob, os, shutil
 
 if os.path.exists('support'):

--- a/misc/build_helpers/gen-package-table.py
+++ b/misc/build_helpers/gen-package-table.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 # This script generates a table of dependencies in HTML format on stdout.
 # It expects to be run in the tahoe-lafs-dep-eggs directory.
 

--- a/misc/build_helpers/get-version.py
+++ b/misc/build_helpers/get-version.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 """Determine the version number of the current tree.
 

--- a/misc/build_helpers/pyver.py
+++ b/misc/build_helpers/pyver.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import sys
 print "python%d.%d" % (sys.version_info[:2])

--- a/misc/build_helpers/run-with-pythonpath.py
+++ b/misc/build_helpers/run-with-pythonpath.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 # -*- python -*-
 # you must invoke this with an explicit python, from the tree root
 

--- a/misc/build_helpers/run_trial.py
+++ b/misc/build_helpers/run_trial.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os, sys, re, glob
 

--- a/misc/build_helpers/show-tool-versions.py
+++ b/misc/build_helpers/show-tool-versions.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import locale, os, platform, subprocess, sys, traceback
 

--- a/misc/build_helpers/sub-ver.py
+++ b/misc/build_helpers/sub-ver.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from allmydata import __version__ as v
 

--- a/misc/build_helpers/test-darcs-boringfile.py
+++ b/misc/build_helpers/test-darcs-boringfile.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import sys
 from subprocess import Popen, PIPE

--- a/misc/build_helpers/test-dont-install-newer-dep-when-you-already-have-sufficiently-new-one.py
+++ b/misc/build_helpers/test-dont-install-newer-dep-when-you-already-have-sufficiently-new-one.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import StringIO, os, platform, shutil, subprocess, sys, tarfile, zipfile
 import pkg_resources

--- a/misc/build_helpers/test-dont-use-too-old-dep.py
+++ b/misc/build_helpers/test-dont-use-too-old-dep.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import StringIO, os, platform, shutil, subprocess, sys, tarfile, zipfile, time
 import pkg_resources

--- a/misc/build_helpers/test-git-ignore.py
+++ b/misc/build_helpers/test-git-ignore.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import sys
 from subprocess import Popen, PIPE

--- a/misc/build_helpers/test_mac_diskimage.py
+++ b/misc/build_helpers/test_mac_diskimage.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 # This script uses hdiutil to attach a dmg (whose name is derived from the
 # appname and the version number passed in), asserts that it attached as
 # expected, cd's into the mounted filesystem, executes "$appname

--- a/misc/coding_tools/check-interfaces.py
+++ b/misc/coding_tools/check-interfaces.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # To check a particular Tahoe source distribution, this should be invoked from
 # the root directory of that distribution as

--- a/misc/coding_tools/check-miscaptures.py
+++ b/misc/coding_tools/check-miscaptures.py
@@ -1,4 +1,5 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os, sys, compiler
 from compiler.ast import Node, For, While, ListComp, AssName, Name, Lambda, Function

--- a/misc/coding_tools/check-umids.py
+++ b/misc/coding_tools/check-umids.py
@@ -1,4 +1,5 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # ./rumid.py foo.py
 

--- a/misc/coding_tools/coverage2el.py
+++ b/misc/coding_tools/coverage2el.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os.path
 from coverage import coverage, summary, misc

--- a/misc/coding_tools/find-trailing-spaces.py
+++ b/misc/coding_tools/find-trailing-spaces.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os, sys
 

--- a/misc/coding_tools/fixshebangs.py
+++ b/misc/coding_tools/fixshebangs.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from allmydata.util import fileutil
 

--- a/misc/coding_tools/make-canary-files.py
+++ b/misc/coding_tools/make-canary-files.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 """
 Given a list of nodeids and a 'convergence' file, create a bunch of files

--- a/misc/incident-gatherer/classify_tahoe.py
+++ b/misc/incident-gatherer/classify_tahoe.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import re
 

--- a/misc/operations_helpers/cpu-watcher-poll.py
+++ b/misc/operations_helpers/cpu-watcher-poll.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from foolscap import Tub, eventual
 from twisted.internet import reactor

--- a/misc/operations_helpers/cpu-watcher-subscribe.py
+++ b/misc/operations_helpers/cpu-watcher-subscribe.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 # -*- python -*-
 
 from twisted.internet import reactor

--- a/misc/operations_helpers/find-share-anomalies.py
+++ b/misc/operations_helpers/find-share-anomalies.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # feed this the results of 'tahoe catalog-shares' for all servers
 

--- a/misc/operations_helpers/getmem.py
+++ b/misc/operations_helpers/getmem.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from foolscap import Tub
 from foolscap.eventual import eventually

--- a/misc/operations_helpers/provisioning/provisioning.py
+++ b/misc/operations_helpers/provisioning/provisioning.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from nevow import inevow, rend, loaders, tags as T
 import math

--- a/misc/operations_helpers/provisioning/reliability.py
+++ b/misc/operations_helpers/provisioning/reliability.py
@@ -1,4 +1,5 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import math
 from allmydata.util import statistics

--- a/misc/operations_helpers/provisioning/run.py
+++ b/misc/operations_helpers/provisioning/run.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # this depends upon Twisted and Nevow, but not upon Tahoe itself
 

--- a/misc/operations_helpers/provisioning/test_provisioning.py
+++ b/misc/operations_helpers/provisioning/test_provisioning.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import unittest
 from allmydata import provisioning

--- a/misc/operations_helpers/provisioning/util.py
+++ b/misc/operations_helpers/provisioning/util.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os.path
 

--- a/misc/operations_helpers/provisioning/web_reliability.py
+++ b/misc/operations_helpers/provisioning/web_reliability.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from nevow import rend, loaders, tags as T
 from nevow.inevow import IRequest

--- a/misc/operations_helpers/spacetime/diskwatcher.py
+++ b/misc/operations_helpers/spacetime/diskwatcher.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from axiom.item import Item
 from axiom.attributes import text, integer, timestamp

--- a/misc/simulators/bench_spans.py
+++ b/misc/simulators/bench_spans.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 """
 To use this, get a trace file such as this one:
 

--- a/misc/simulators/count_dirs.py
+++ b/misc/simulators/count_dirs.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 """
 This tool estimates how much space would be consumed by a filetree into which

--- a/misc/simulators/hashbasedsig.py
+++ b/misc/simulators/hashbasedsig.py
@@ -1,4 +1,5 @@
-#!python
+﻿#!python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # range of hash output lengths
 range_L_hash = [128]

--- a/misc/simulators/ringsim.py
+++ b/misc/simulators/ringsim.py
@@ -1,4 +1,5 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # used to discuss ticket #302: "stop permuting peerlist?"
 

--- a/misc/simulators/simulate_load.py
+++ b/misc/simulators/simulate_load.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # WARNING. There is a bug in this script so that it does not simulate the actual Tahoe Two server selection algorithm that it was intended to simulate. See http://allmydata.org/trac/tahoe-lafs/ticket/302 (stop permuting peerlist, use SI as offset into ring instead?)
 

--- a/misc/simulators/simulator.py
+++ b/misc/simulators/simulator.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import sha as shamodule
 import os, random

--- a/misc/simulators/sizes.py
+++ b/misc/simulators/sizes.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import random, math, re
 from twisted.python import usage

--- a/misc/simulators/storage-overhead.py
+++ b/misc/simulators/storage-overhead.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import sys, math
 from allmydata import uri, storage

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-#! /usr/bin/env python
-# -*- coding: utf-8 -*-
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 import sys; assert sys.version_info < (3,), ur"Tahoe-LAFS does not run under Python 3. Please use a version of Python between 2.6 and 2.7.x inclusive."
 
 # Tahoe-LAFS -- secure, distributed storage grid

--- a/src/allmydata/__init__.py
+++ b/src/allmydata/__init__.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 """
 Decentralized storage grid.
 

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 # Note: please minimize imports in this file. In particular, do not import
 # any module from Tahoe-LAFS or its dependencies, and do not import any
 # modules at all at global level. That includes setuptools and pkg_resources.

--- a/src/allmydata/blacklist.py
+++ b/src/allmydata/blacklist.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os
 

--- a/src/allmydata/check_results.py
+++ b/src/allmydata/check_results.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from zope.interface import implements
 from allmydata.interfaces import ICheckResults, ICheckAndRepairResults, \

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 import os, stat, time, weakref
 from allmydata import node
 

--- a/src/allmydata/codec.py
+++ b/src/allmydata/codec.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 # -*- test-case-name: allmydata.test.test_encode_share -*-
 
 from zope.interface import implements

--- a/src/allmydata/control.py
+++ b/src/allmydata/control.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os, time
 from zope.interface import implements

--- a/src/allmydata/debugshell.py
+++ b/src/allmydata/debugshell.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # 'app' is overwritten by manhole when the connection is established. We set
 # it to None now to keep pyflakes from complaining.

--- a/src/allmydata/dirnode.py
+++ b/src/allmydata/dirnode.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import time, math, unicodedata
 

--- a/src/allmydata/hashtree.py
+++ b/src/allmydata/hashtree.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 # -*- test-case-name: allmydata.test.test_hashtree -*-
 
 from allmydata.util import mathutil # from the pyutil library

--- a/src/allmydata/history.py
+++ b/src/allmydata/history.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import weakref
 

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from zope.interface import Interface
 from foolscap.api import StringConstraint, ListOf, TupleOf, SetOf, DictOf, \

--- a/src/allmydata/key_generator.py
+++ b/src/allmydata/key_generator.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os
 import time

--- a/src/allmydata/manhole.py
+++ b/src/allmydata/manhole.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 # this is adapted from my code in Buildbot  -warner
 

--- a/src/allmydata/monitor.py
+++ b/src/allmydata/monitor.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from zope.interface import Interface, implements
 from allmydata.util import observer

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 import datetime, os.path, re, types, ConfigParser, tempfile
 from base64 import b32decode, b32encode
 

--- a/src/allmydata/nodemaker.py
+++ b/src/allmydata/nodemaker.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 import weakref
 from zope.interface import implements
 from allmydata.util.assertutil import precondition

--- a/src/allmydata/stats.py
+++ b/src/allmydata/stats.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import os
 import pickle

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 """
 I contain the client-side code which speaks to storage servers, in particular

--- a/src/allmydata/unknown.py
+++ b/src/allmydata/unknown.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 from zope.interface import implements
 from twisted.internet import defer

--- a/src/allmydata/uri.py
+++ b/src/allmydata/uri.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 import re
 

--- a/src/allmydata/webish.py
+++ b/src/allmydata/webish.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 import re, time
 from twisted.application import service, strports, internet
 from twisted.web import http


### PR DESCRIPTION
This makes it so that emacs knows the intended character encoding, BOM,
end-of-line markers, and standard line-width of these files.

Also this is a form of documentation. It means that you should put only
utf-8-encoded things into text files, only utf-8-encoded things into source
code files (and actually you should write only put ASCII-encoded things except
possibly in comments or docstrings!), and that you should line-wrap everything
at 77 columns wide.

It also specifies that text files should start with a "utf-8 BOM". (Brian
questions the point of this, and my answer is that it adds information and
doesn't hurt. Whether that information will ever be useful is an open
question.)

It also specifies that text files should have unix-style ('\n') end-of-line
markers, not windows-style or old-macos-style.

I generated this patch by writing and running the following script, and then
reading the resulting diff to make sure it was correct. I then undid the
changes that the script had done to the files inside the
"setuptools-0.6c16dev4.egg" directory before committing the patch.

------- begin appended script::

```
import os

magic_header_line_comment_prefix = {
    '.py': u"# ",
    '.rst': u".. ",
    }

def format():
    for dirpath, dirnames, filenames in os.walk('.'):
        for filename in filenames:
            ext = os.path.splitext(filename)[-1]
            if ext in ('.py', '.rst'):
                fname = os.path.join(dirpath, filename)
                info = open(fname, 'rU')
                formattedlines = [ line.decode('utf-8') for line in info ]
                info.close()

                if len(formattedlines) == 0:
                    return

                outfo = open(fname, 'w')
                outfo.write(u"\ufeff".encode('utf-8'))

                commentsign = magic_header_line_comment_prefix[ext]

                firstline = formattedlines.pop(0)
                while firstline.startswith(u"\ufeff"):
                    firstline = firstline[len(u"\ufeff"):]
                if firstline.startswith(u"#!"):
                    outfo.write(firstline.encode('utf-8'))
                    outfo.write(commentsign.encode('utf-8'))
                    outfo.write("-*- coding: utf-8-with-signature-unix; fill-column: 77 -*-\n".encode('utf-8'))
                else:
                    outfo.write(commentsign.encode('utf-8'))
                    outfo.write("-*- coding: utf-8-with-signature-unix; fill-column: 77 -*-\n".encode('utf-8'))
                    if (commentsign in firstline) and ("-*-" in firstline) and ("coding:" in firstline):
                        print "warning there was already a coding line %r in %r"  % (firstline, fname)
                    else:
                        outfo.write(firstline.encode('utf-8'))

                for l in formattedlines:
                    if (commentsign in l) and ("-*-" in l) and ("coding:" in l):
                        print "warning there was already a coding line %r in %r"  % (l, fname)
                    else:
                        outfo.write(l.encode('utf-8'))
                outfo.close()

if __name__ == '__main__':
    format()
```
