### PR TITLE
add comments which set emacs variables to all source files

### DIFF
--- a/COPYING.TGPPL.rst
+++ b/COPYING.TGPPL.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 This work also comes with the added permission that you may combine it with a
 work licensed under the OpenSSL license (any version) and distribute the

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================================
 User-Visible Changes in Tahoe-LAFS

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 Welcome to Tahoe-LAFS!
 ======================

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 Tahoe-LAFS Architecture

--- a/docs/backdoors.rst
+++ b/docs/backdoors.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 Statement on Backdoors
 ======================

--- a/docs/backupdb.rst
+++ b/docs/backupdb.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================
 The Tahoe BackupDB

--- a/docs/cautions.rst
+++ b/docs/cautions.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================================================
  Things To Be Careful About As We Venture Boldly Forth

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============================
 Configuring a Tahoe-LAFS node

--- a/docs/convergence-secret.rst
+++ b/docs/convergence-secret.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 What Is It?
 -----------

--- a/docs/debian.rst
+++ b/docs/debian.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =========================
 Debian and Ubuntu Support

--- a/docs/filesystem-notes.rst
+++ b/docs/filesystem-notes.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =========================
 Filesystem-specific notes

--- a/docs/frontends/CLI.rst
+++ b/docs/frontends/CLI.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===========================
 The Tahoe-LAFS CLI commands

--- a/docs/frontends/FTP-and-SFTP.rst
+++ b/docs/frontends/FTP-and-SFTP.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =================================
 Tahoe-LAFS SFTP and FTP Frontends

--- a/docs/frontends/download-status.rst
+++ b/docs/frontends/download-status.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===============
 Download status

--- a/docs/frontends/drop-upload.rst
+++ b/docs/frontends/drop-upload.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===============================
 Tahoe-LAFS Drop-Upload Frontend

--- a/docs/frontends/webapi.rst
+++ b/docs/frontends/webapi.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==========================
 The Tahoe REST-ful Web API

--- a/docs/garbage-collection.rst
+++ b/docs/garbage-collection.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===========================
 Garbage Collection in Tahoe

--- a/docs/helper.rst
+++ b/docs/helper.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 The Tahoe Upload Helper

--- a/docs/historical/configuration.rst
+++ b/docs/historical/configuration.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 Old Configuration Files

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 See also `cautions.rst`_.
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============
 Tahoe Logging

--- a/docs/nodekeys.rst
+++ b/docs/nodekeys.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =======================
 Node Keys in Tahoe-LAFS

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ============================================
 Performance costs for some common operations

--- a/docs/proposed/leasedb.rst
+++ b/docs/proposed/leasedb.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =====================
 Lease database design

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================
 Getting Tahoe-LAFS

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =====================
 How To Run Tahoe-LAFS

--- a/docs/specifications/URI-extension.rst
+++ b/docs/specifications/URI-extension.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ===================
 URI Extension Block

--- a/docs/specifications/backends/raic.rst
+++ b/docs/specifications/backends/raic.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============================================================
 Redundant Array of Independent Clouds: Share To Cloud Mapping

--- a/docs/specifications/dirnodes.rst
+++ b/docs/specifications/dirnodes.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==========================
 Tahoe-LAFS Directory Nodes

--- a/docs/specifications/file-encoding.rst
+++ b/docs/specifications/file-encoding.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============
 File Encoding

--- a/docs/specifications/mutable.rst
+++ b/docs/specifications/mutable.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 =============
 Mutable Files

--- a/docs/specifications/outline.rst
+++ b/docs/specifications/outline.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==============================
 Specification Document Outline

--- a/docs/specifications/servers-of-happiness.rst
+++ b/docs/specifications/servers-of-happiness.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ====================
 Servers of Happiness

--- a/docs/specifications/uri.rst
+++ b/docs/specifications/uri.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==========
 Tahoe URIs

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ================
 Tahoe Statistics

--- a/docs/write_coordination.rst
+++ b/docs/write_coordination.rst
@@ -1,4 +1,4 @@
-﻿.. -*- coding: utf-8-with-signature -*-
+﻿.. -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
 
 ==================================
 Avoiding Write Collisions in Tahoe

--- a/misc/build_helpers/build-deb.py
+++ b/misc/build_helpers/build-deb.py
@@ -1,4 +1,6 @@
-#!/bin/false # invoke this with a specific python
+﻿#!/bin/false # invoke this with a specific python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import sys, shutil, os.path
 from subprocess import Popen, PIPE

--- a/misc/build_helpers/check-build.py
+++ b/misc/build_helpers/check-build.py
@@ -1,4 +1,6 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # This helper script is used with the 'test-desert-island' Makefile target.
 

--- a/misc/build_helpers/clean-up-after-fake-dists.py
+++ b/misc/build_helpers/clean-up-after-fake-dists.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import glob, os, shutil
 
 if os.path.exists('support'):

--- a/misc/build_helpers/gen-package-table.py
+++ b/misc/build_helpers/gen-package-table.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # This script generates a table of dependencies in HTML format on stdout.
 # It expects to be run in the tahoe-lafs-dep-eggs directory.
 

--- a/misc/build_helpers/get-version.py
+++ b/misc/build_helpers/get-version.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 """Determine the version number of the current tree.
 

--- a/misc/build_helpers/pyver.py
+++ b/misc/build_helpers/pyver.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import sys
 print "python%d.%d" % (sys.version_info[:2])

--- a/misc/build_helpers/run-with-pythonpath.py
+++ b/misc/build_helpers/run-with-pythonpath.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # -*- python -*-
 # you must invoke this with an explicit python, from the tree root
 

--- a/misc/build_helpers/run_trial.py
+++ b/misc/build_helpers/run_trial.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys, re, glob
 

--- a/misc/build_helpers/show-tool-versions.py
+++ b/misc/build_helpers/show-tool-versions.py
@@ -1,4 +1,6 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import locale, os, platform, subprocess, sys, traceback
 

--- a/misc/build_helpers/sub-ver.py
+++ b/misc/build_helpers/sub-ver.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from allmydata import __version__ as v
 

--- a/misc/build_helpers/test-darcs-boringfile.py
+++ b/misc/build_helpers/test-darcs-boringfile.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import sys
 from subprocess import Popen, PIPE

--- a/misc/build_helpers/test-dont-install-newer-dep-when-you-already-have-sufficiently-new-one.py
+++ b/misc/build_helpers/test-dont-install-newer-dep-when-you-already-have-sufficiently-new-one.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import StringIO, os, platform, shutil, subprocess, sys, tarfile, zipfile
 import pkg_resources

--- a/misc/build_helpers/test-dont-use-too-old-dep.py
+++ b/misc/build_helpers/test-dont-use-too-old-dep.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import StringIO, os, platform, shutil, subprocess, sys, tarfile, zipfile, time
 import pkg_resources

--- a/misc/build_helpers/test-git-ignore.py
+++ b/misc/build_helpers/test-git-ignore.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import sys
 from subprocess import Popen, PIPE

--- a/misc/build_helpers/test_mac_diskimage.py
+++ b/misc/build_helpers/test_mac_diskimage.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # This script uses hdiutil to attach a dmg (whose name is derived from the
 # appname and the version number passed in), asserts that it attached as
 # expected, cd's into the mounted filesystem, executes "$appname

--- a/misc/coding_tools/check-interfaces.py
+++ b/misc/coding_tools/check-interfaces.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # To check a particular Tahoe source distribution, this should be invoked from
 # the root directory of that distribution as

--- a/misc/coding_tools/check-miscaptures.py
+++ b/misc/coding_tools/check-miscaptures.py
@@ -1,4 +1,6 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys, compiler
 from compiler.ast import Node, For, While, ListComp, AssName, Name, Lambda, Function

--- a/misc/coding_tools/check-umids.py
+++ b/misc/coding_tools/check-umids.py
@@ -1,4 +1,6 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # ./rumid.py foo.py
 

--- a/misc/coding_tools/coverage2el.py
+++ b/misc/coding_tools/coverage2el.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path
 from coverage import coverage, summary, misc

--- a/misc/coding_tools/find-trailing-spaces.py
+++ b/misc/coding_tools/find-trailing-spaces.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys
 

--- a/misc/coding_tools/fixshebangs.py
+++ b/misc/coding_tools/fixshebangs.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from allmydata.util import fileutil
 

--- a/misc/coding_tools/make-canary-files.py
+++ b/misc/coding_tools/make-canary-files.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 """
 Given a list of nodeids and a 'convergence' file, create a bunch of files

--- a/misc/incident-gatherer/classify_tahoe.py
+++ b/misc/incident-gatherer/classify_tahoe.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re
 

--- a/misc/operations_helpers/cpu-watcher-poll.py
+++ b/misc/operations_helpers/cpu-watcher-poll.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from foolscap import Tub, eventual
 from twisted.internet import reactor

--- a/misc/operations_helpers/cpu-watcher-subscribe.py
+++ b/misc/operations_helpers/cpu-watcher-subscribe.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # -*- python -*-
 
 from twisted.internet import reactor

--- a/misc/operations_helpers/find-share-anomalies.py
+++ b/misc/operations_helpers/find-share-anomalies.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # feed this the results of 'tahoe catalog-shares' for all servers
 

--- a/misc/operations_helpers/getmem.py
+++ b/misc/operations_helpers/getmem.py
@@ -1,4 +1,6 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from foolscap import Tub
 from foolscap.eventual import eventually

--- a/misc/operations_helpers/provisioning/provisioning.py
+++ b/misc/operations_helpers/provisioning/provisioning.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from nevow import inevow, rend, loaders, tags as T
 import math

--- a/misc/operations_helpers/provisioning/reliability.py
+++ b/misc/operations_helpers/provisioning/reliability.py
@@ -1,4 +1,6 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import math
 from allmydata.util import statistics

--- a/misc/operations_helpers/provisioning/run.py
+++ b/misc/operations_helpers/provisioning/run.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # this depends upon Twisted and Nevow, but not upon Tahoe itself
 

--- a/misc/operations_helpers/provisioning/test_provisioning.py
+++ b/misc/operations_helpers/provisioning/test_provisioning.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import unittest
 from allmydata import provisioning

--- a/misc/operations_helpers/provisioning/util.py
+++ b/misc/operations_helpers/provisioning/util.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path
 

--- a/misc/operations_helpers/provisioning/web_reliability.py
+++ b/misc/operations_helpers/provisioning/web_reliability.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from nevow import rend, loaders, tags as T
 from nevow.inevow import IRequest

--- a/misc/operations_helpers/spacetime/diskwatcher.py
+++ b/misc/operations_helpers/spacetime/diskwatcher.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from axiom.item import Item
 from axiom.attributes import text, integer, timestamp

--- a/misc/simulators/bench_spans.py
+++ b/misc/simulators/bench_spans.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 To use this, get a trace file such as this one:
 

--- a/misc/simulators/count_dirs.py
+++ b/misc/simulators/count_dirs.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 """
 This tool estimates how much space would be consumed by a filetree into which

--- a/misc/simulators/hashbasedsig.py
+++ b/misc/simulators/hashbasedsig.py
@@ -1,4 +1,6 @@
-#!python
+﻿#!python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # range of hash output lengths
 range_L_hash = [128]

--- a/misc/simulators/ringsim.py
+++ b/misc/simulators/ringsim.py
@@ -1,4 +1,6 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # used to discuss ticket #302: "stop permuting peerlist?"
 

--- a/misc/simulators/simulate_load.py
+++ b/misc/simulators/simulate_load.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # WARNING. There is a bug in this script so that it does not simulate the actual Tahoe Two server selection algorithm that it was intended to simulate. See http://allmydata.org/trac/tahoe-lafs/ticket/302 (stop permuting peerlist, use SI as offset into ring instead?)
 

--- a/misc/simulators/simulator.py
+++ b/misc/simulators/simulator.py
@@ -1,4 +1,6 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import sha as shamodule
 import os, random

--- a/misc/simulators/sizes.py
+++ b/misc/simulators/sizes.py
@@ -1,4 +1,6 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import random, math, re
 from twisted.python import usage

--- a/misc/simulators/storage-overhead.py
+++ b/misc/simulators/storage-overhead.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import sys, math
 from allmydata import uri, storage

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-#! /usr/bin/env python
-# -*- coding: utf-8 -*-
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import sys; assert sys.version_info < (3,), ur"Tahoe-LAFS does not run under Python 3. Please use a version of Python between 2.6 and 2.7.x inclusive."
 
 # Tahoe-LAFS -- secure, distributed storage grid

--- a/src/allmydata/__init__.py
+++ b/src/allmydata/__init__.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 Decentralized storage grid.
 

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # Note: please minimize imports in this file. In particular, do not import
 # any module from Tahoe-LAFS or its dependencies, and do not import any
 # modules at all at global level. That includes setuptools and pkg_resources.

--- a/src/allmydata/blacklist.py
+++ b/src/allmydata/blacklist.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 

--- a/src/allmydata/check_results.py
+++ b/src/allmydata/check_results.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import implements
 from allmydata.interfaces import ICheckResults, ICheckAndRepairResults, \

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, stat, time, weakref
 from allmydata import node
 

--- a/src/allmydata/codec.py
+++ b/src/allmydata/codec.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # -*- test-case-name: allmydata.test.test_encode_share -*-
 
 from zope.interface import implements

--- a/src/allmydata/control.py
+++ b/src/allmydata/control.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, time
 from zope.interface import implements

--- a/src/allmydata/debugshell.py
+++ b/src/allmydata/debugshell.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # 'app' is overwritten by manhole when the connection is established. We set
 # it to None now to keep pyflakes from complaining.

--- a/src/allmydata/dirnode.py
+++ b/src/allmydata/dirnode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time, math, unicodedata
 

--- a/src/allmydata/frontends/auth.py
+++ b/src/allmydata/frontends/auth.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os
 from zope.interface import implements
 from twisted.web.client import getPage

--- a/src/allmydata/frontends/drop_upload.py
+++ b/src/allmydata/frontends/drop_upload.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys
 

--- a/src/allmydata/frontends/ftpd.py
+++ b/src/allmydata/frontends/ftpd.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import implements
 from twisted.application import service, strports

--- a/src/allmydata/frontends/sftpd.py
+++ b/src/allmydata/frontends/sftpd.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import heapq, traceback, array, stat, struct
 from types import NoneType

--- a/src/allmydata/hashtree.py
+++ b/src/allmydata/hashtree.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # -*- test-case-name: allmydata.test.test_hashtree -*-
 
 from allmydata.util import mathutil # from the pyutil library

--- a/src/allmydata/history.py
+++ b/src/allmydata/history.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import weakref
 

--- a/src/allmydata/immutable/checker.py
+++ b/src/allmydata/immutable/checker.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from zope.interface import implements
 from twisted.internet import defer
 from foolscap.api import DeadReferenceError, RemoteException

--- a/src/allmydata/immutable/downloader/common.py
+++ b/src/allmydata/immutable/downloader/common.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 (AVAILABLE, PENDING, OVERDUE, COMPLETE, CORRUPT, DEAD, BADSEGNUM) = \
  ("AVAILABLE", "PENDING", "OVERDUE", "COMPLETE", "CORRUPT", "DEAD", "BADSEGNUM")

--- a/src/allmydata/immutable/downloader/fetcher.py
+++ b/src/allmydata/immutable/downloader/fetcher.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.python.failure import Failure
 from foolscap.api import eventually

--- a/src/allmydata/immutable/downloader/finder.py
+++ b/src/allmydata/immutable/downloader/finder.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 now = time.time

--- a/src/allmydata/immutable/downloader/node.py
+++ b/src/allmydata/immutable/downloader/node.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 now = time.time

--- a/src/allmydata/immutable/downloader/segmentation.py
+++ b/src/allmydata/immutable/downloader/segmentation.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 now = time.time

--- a/src/allmydata/immutable/downloader/share.py
+++ b/src/allmydata/immutable/downloader/share.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import struct
 import time

--- a/src/allmydata/immutable/downloader/status.py
+++ b/src/allmydata/immutable/downloader/status.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import itertools
 from zope.interface import implements

--- a/src/allmydata/immutable/encode.py
+++ b/src/allmydata/immutable/encode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # -*- test-case-name: allmydata.test.test_encode -*-
 
 import time

--- a/src/allmydata/immutable/filenode.py
+++ b/src/allmydata/immutable/filenode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import binascii
 import time

--- a/src/allmydata/immutable/layout.py
+++ b/src/allmydata/immutable/layout.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import struct
 from zope.interface import implements
 from twisted.internet import defer

--- a/src/allmydata/immutable/literal.py
+++ b/src/allmydata/immutable/literal.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from cStringIO import StringIO
 from zope.interface import implements
 from twisted.internet import defer

--- a/src/allmydata/immutable/offloaded.py
+++ b/src/allmydata/immutable/offloaded.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, stat, time, weakref
 from zope.interface import implements

--- a/src/allmydata/immutable/repairer.py
+++ b/src/allmydata/immutable/repairer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from zope.interface import implements
 from twisted.internet import defer
 from allmydata.storage.server import si_b2a

--- a/src/allmydata/immutable/upload.py
+++ b/src/allmydata/immutable/upload.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, time, weakref, itertools
 from zope.interface import implements
 from twisted.python import failure

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import Interface
 from foolscap.api import StringConstraint, ListOf, TupleOf, SetOf, DictOf, \

--- a/src/allmydata/introducer/__init__.py
+++ b/src/allmydata/introducer/__init__.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # This is for compatibilty with old .tac files, which reference
 # allmydata.introducer.IntroducerNode

--- a/src/allmydata/introducer/client.py
+++ b/src/allmydata/introducer/client.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 from zope.interface import implements

--- a/src/allmydata/introducer/common.py
+++ b/src/allmydata/introducer/common.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re, simplejson
 from allmydata.util import keyutil, base32, rrefutil

--- a/src/allmydata/introducer/interfaces.py
+++ b/src/allmydata/introducer/interfaces.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import Interface
 from foolscap.api import StringConstraint, TupleOf, SetOf, DictOf, Any, \

--- a/src/allmydata/introducer/old.py
+++ b/src/allmydata/introducer/old.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 from base64 import b32decode

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time, os.path, textwrap
 from zope.interface import implements

--- a/src/allmydata/key_generator.py
+++ b/src/allmydata/key_generator.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 import time

--- a/src/allmydata/manhole.py
+++ b/src/allmydata/manhole.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # this is adapted from my code in Buildbot  -warner
 

--- a/src/allmydata/monitor.py
+++ b/src/allmydata/monitor.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import Interface, implements
 from allmydata.util import observer

--- a/src/allmydata/mutable/checker.py
+++ b/src/allmydata/mutable/checker.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from allmydata.uri import from_string
 from allmydata.util import base32, log, dictutil

--- a/src/allmydata/mutable/common.py
+++ b/src/allmydata/mutable/common.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 MODE_CHECK = "MODE_CHECK" # query all peers
 MODE_ANYTHING = "MODE_ANYTHING" # one recoverable version

--- a/src/allmydata/mutable/filenode.py
+++ b/src/allmydata/mutable/filenode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import random
 

--- a/src/allmydata/mutable/layout.py
+++ b/src/allmydata/mutable/layout.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import struct
 from allmydata.mutable.common import NeedMoreDataError, UnknownVersionError, \

--- a/src/allmydata/mutable/publish.py
+++ b/src/allmydata/mutable/publish.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 
 import os, time

--- a/src/allmydata/mutable/repairer.py
+++ b/src/allmydata/mutable/repairer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import implements
 from twisted.internet import defer

--- a/src/allmydata/mutable/retrieve.py
+++ b/src/allmydata/mutable/retrieve.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 from itertools import count

--- a/src/allmydata/mutable/servermap.py
+++ b/src/allmydata/mutable/servermap.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import sys, time, copy
 from zope.interface import implements

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import datetime, os.path, re, types, ConfigParser, tempfile
 from base64 import b32decode, b32encode
 

--- a/src/allmydata/nodemaker.py
+++ b/src/allmydata/nodemaker.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import weakref
 from zope.interface import implements
 from allmydata.util.assertutil import precondition

--- a/src/allmydata/scripts/admin.py
+++ b/src/allmydata/scripts/admin.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.python import usage
 from allmydata.scripts.common import BaseOptions

--- a/src/allmydata/scripts/backupdb.py
+++ b/src/allmydata/scripts/backupdb.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path, sys, time, random, stat
 

--- a/src/allmydata/scripts/cli.py
+++ b/src/allmydata/scripts/cli.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os.path, re, fnmatch
 from twisted.python import usage
 from allmydata.scripts.common import get_aliases, get_default_nodedir, \

--- a/src/allmydata/scripts/common.py
+++ b/src/allmydata/scripts/common.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys, urllib
 import codecs

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 from cStringIO import StringIO

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys
 from allmydata.scripts.common import BasedirOptions

--- a/src/allmydata/scripts/debug.py
+++ b/src/allmydata/scripts/debug.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # do not import any allmydata modules at this level. Do that from inside
 # individual functions instead.

--- a/src/allmydata/scripts/keygen.py
+++ b/src/allmydata/scripts/keygen.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys
 from allmydata.scripts.common import BasedirOptions

--- a/src/allmydata/scripts/runner.py
+++ b/src/allmydata/scripts/runner.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys
 from cStringIO import StringIO

--- a/src/allmydata/scripts/slow_operation.py
+++ b/src/allmydata/scripts/slow_operation.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, time
 from allmydata.scripts.common import get_alias, DEFAULT_ALIAS, escape_path, \

--- a/src/allmydata/scripts/startstop_node.py
+++ b/src/allmydata/scripts/startstop_node.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys, signal, time
 from allmydata.scripts.common import BasedirOptions

--- a/src/allmydata/scripts/stats_gatherer.py
+++ b/src/allmydata/scripts/stats_gatherer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys
 from allmydata.scripts.common import BasedirOptions

--- a/src/allmydata/scripts/tahoe_add_alias.py
+++ b/src/allmydata/scripts/tahoe_add_alias.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path
 import codecs

--- a/src/allmydata/scripts/tahoe_backup.py
+++ b/src/allmydata/scripts/tahoe_backup.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path
 import time

--- a/src/allmydata/scripts/tahoe_check.py
+++ b/src/allmydata/scripts/tahoe_check.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import urllib
 import simplejson

--- a/src/allmydata/scripts/tahoe_cp.py
+++ b/src/allmydata/scripts/tahoe_cp.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path
 import urllib

--- a/src/allmydata/scripts/tahoe_get.py
+++ b/src/allmydata/scripts/tahoe_get.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, urllib
 from allmydata.scripts.common import get_alias, DEFAULT_ALIAS, escape_path, \

--- a/src/allmydata/scripts/tahoe_ls.py
+++ b/src/allmydata/scripts/tahoe_ls.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import urllib, time
 import simplejson

--- a/src/allmydata/scripts/tahoe_manifest.py
+++ b/src/allmydata/scripts/tahoe_manifest.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import urllib, simplejson
 from twisted.protocols.basic import LineOnlyReceiver

--- a/src/allmydata/scripts/tahoe_mkdir.py
+++ b/src/allmydata/scripts/tahoe_mkdir.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import urllib
 from allmydata.scripts.common_http import do_http, check_http_error

--- a/src/allmydata/scripts/tahoe_mv.py
+++ b/src/allmydata/scripts/tahoe_mv.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re
 import urllib

--- a/src/allmydata/scripts/tahoe_put.py
+++ b/src/allmydata/scripts/tahoe_put.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 from cStringIO import StringIO

--- a/src/allmydata/scripts/tahoe_unlink.py
+++ b/src/allmydata/scripts/tahoe_unlink.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import urllib
 from allmydata.scripts.common_http import do_http, format_http_success, format_http_error

--- a/src/allmydata/scripts/tahoe_webopen.py
+++ b/src/allmydata/scripts/tahoe_webopen.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from allmydata.scripts.common import get_alias, DEFAULT_ALIAS, escape_path, \
                                      UnknownAliasError

--- a/src/allmydata/stats.py
+++ b/src/allmydata/stats.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 import pickle

--- a/src/allmydata/storage/common.py
+++ b/src/allmydata/storage/common.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path
 from allmydata.util import base32

--- a/src/allmydata/storage/crawler.py
+++ b/src/allmydata/storage/crawler.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, time, struct
 import cPickle as pickle

--- a/src/allmydata/storage/expirer.py
+++ b/src/allmydata/storage/expirer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import time, os, pickle, struct
 from allmydata.storage.crawler import ShareCrawler
 from allmydata.storage.shares import get_share_file

--- a/src/allmydata/storage/immutable.py
+++ b/src/allmydata/storage/immutable.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, stat, struct, time
 
 from foolscap.api import Referenceable

--- a/src/allmydata/storage/lease.py
+++ b/src/allmydata/storage/lease.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import struct, time
 
 class LeaseInfo:

--- a/src/allmydata/storage/mutable.py
+++ b/src/allmydata/storage/mutable.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, stat, struct
 
 from allmydata.interfaces import BadWriteEnablerError

--- a/src/allmydata/storage/server.py
+++ b/src/allmydata/storage/server.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, re, weakref, struct, time
 
 from foolscap.api import Referenceable

--- a/src/allmydata/storage/shares.py
+++ b/src/allmydata/storage/shares.py
@@ -1,4 +1,6 @@
-#! /usr/bin/python
+﻿#! /usr/bin/python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from allmydata.storage.mutable import MutableShareFile
 from allmydata.storage.immutable import ShareFile

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 """
 I contain the client-side code which speaks to storage servers, in particular

--- a/src/allmydata/test/__init__.py
+++ b/src/allmydata/test/__init__.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from foolscap.logging.incident import IncidentQualifier
 class NonQualifier(IncidentQualifier):

--- a/src/allmydata/test/bench_dirnode.py
+++ b/src/allmydata/test/bench_dirnode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import hotshot.stats, os, random, sys
 
 from pyutil import benchutil, randutil # http://tahoe-lafs.org/trac/pyutil

--- a/src/allmydata/test/check_grid.py
+++ b/src/allmydata/test/check_grid.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 Test an existing Tahoe grid, both to see if the grid is still running and to
 see if the client is still compatible with it. This script is suitable for

--- a/src/allmydata/test/check_load.py
+++ b/src/allmydata/test/check_load.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 this is a load-generating client program. It does all of its work through a
 given tahoe node (specified by URL), and performs random reads and writes

--- a/src/allmydata/test/check_memory.py
+++ b/src/allmydata/test/check_memory.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, shutil, sys, urllib, time, stat
 from cStringIO import StringIO
 from twisted.internet import defer, reactor, protocol, error

--- a/src/allmydata/test/check_speed.py
+++ b/src/allmydata/test/check_speed.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, sys
 from twisted.internet import reactor, defer
 from twisted.python import log

--- a/src/allmydata/test/common.py
+++ b/src/allmydata/test/common.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, random, struct
 from zope.interface import implements
 from twisted.internet import defer

--- a/src/allmydata/test/common_util.py
+++ b/src/allmydata/test/common_util.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, signal, sys, time
 from random import randrange
 

--- a/src/allmydata/test/common_web.py
+++ b/src/allmydata/test/common_web.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re
 from twisted.internet import defer

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # This contains a test harness that creates a full Tahoe grid in a single
 # process (actually in a single MultiService) which does not use the network.

--- a/src/allmydata/test/test_backupdb.py
+++ b/src/allmydata/test/test_backupdb.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path, time
 from StringIO import StringIO

--- a/src/allmydata/test/test_base62.py
+++ b/src/allmydata/test/test_base62.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import random, unittest
 
 from allmydata.util import base62, mathutil

--- a/src/allmydata/test/test_checker.py
+++ b/src/allmydata/test/test_checker.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import simplejson
 import os.path, shutil

--- a/src/allmydata/test/test_cli.py
+++ b/src/allmydata/test/test_cli.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path
 from twisted.trial import unittest

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os
 from twisted.trial import unittest
 from twisted.application import service

--- a/src/allmydata/test/test_codec.py
+++ b/src/allmydata/test/test_codec.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 from twisted.trial import unittest

--- a/src/allmydata/test/test_crawler.py
+++ b/src/allmydata/test/test_crawler.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 import os.path

--- a/src/allmydata/test/test_deepcheck.py
+++ b/src/allmydata/test/test_deepcheck.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, simplejson, urllib
 from cStringIO import StringIO

--- a/src/allmydata/test/test_dirnode.py
+++ b/src/allmydata/test/test_dirnode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import time
 import unicodedata
 from zope.interface import implements

--- a/src/allmydata/test/test_download.py
+++ b/src/allmydata/test/test_download.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # system-level upload+download roundtrip test, but using shares created from
 # a previous run. This asserts that the current code is capable of decoding

--- a/src/allmydata/test/test_drop_upload.py
+++ b/src/allmydata/test/test_drop_upload.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, sys
 

--- a/src/allmydata/test/test_encode.py
+++ b/src/allmydata/test/test_encode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from zope.interface import implements
 from twisted.trial import unittest
 from twisted.internet import defer

--- a/src/allmydata/test/test_encodingutil.py
+++ b/src/allmydata/test/test_encodingutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 lumiere_nfc = u"lumi\u00E8re"
 Artonwall_nfc = u"\u00C4rtonwall.mp3"

--- a/src/allmydata/test/test_filenode.py
+++ b/src/allmydata/test/test_filenode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 from allmydata import uri, client

--- a/src/allmydata/test/test_ftp.py
+++ b/src/allmydata/test/test_ftp.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 

--- a/src/allmydata/test/test_hashtree.py
+++ b/src/allmydata/test/test_hashtree.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # -*- test-case-name: allmydata.test.test_hashtree -*-
 
 from twisted.trial import unittest

--- a/src/allmydata/test/test_helper.py
+++ b/src/allmydata/test/test_helper.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os
 from twisted.internet import defer
 from twisted.trial import unittest

--- a/src/allmydata/test/test_hung_server.py
+++ b/src/allmydata/test/test_hung_server.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, shutil
 from twisted.trial import unittest

--- a/src/allmydata/test/test_immutable.py
+++ b/src/allmydata/test/test_immutable.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import random
 
 from twisted.trial import unittest

--- a/src/allmydata/test/test_import.py
+++ b/src/allmydata/test/test_import.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, re, itertools
 from base64 import b32decode

--- a/src/allmydata/test/test_iputil.py
+++ b/src/allmydata/test/test_iputil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re, errno, subprocess, os
 

--- a/src/allmydata/test/test_keygen.py
+++ b/src/allmydata/test/test_keygen.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 from twisted.trial import unittest

--- a/src/allmydata/test/test_mutable.py
+++ b/src/allmydata/test/test_mutable.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os, re, base64
 from cStringIO import StringIO
 from twisted.trial import unittest

--- a/src/allmydata/test/test_netstring.py
+++ b/src/allmydata/test/test_netstring.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 from allmydata.util.netstring import netstring, split_netstring

--- a/src/allmydata/test/test_no_network.py
+++ b/src/allmydata/test/test_no_network.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # Test the NoNetworkGrid test harness
 

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, stat, sys, time
 from twisted.trial import unittest

--- a/src/allmydata/test/test_observer.py
+++ b/src/allmydata/test/test_observer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 from twisted.internet import defer, reactor

--- a/src/allmydata/test/test_repairer.py
+++ b/src/allmydata/test/test_repairer.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from allmydata.test import common
 from allmydata.monitor import Monitor
 from allmydata import check_results

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from twisted.trial import unittest
 
 from twisted.python import usage, runtime

--- a/src/allmydata/test/test_sftp.py
+++ b/src/allmydata/test/test_sftp.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re, struct, traceback, time, calendar
 from stat import S_IFREG, S_IFDIR

--- a/src/allmydata/test/test_stats.py
+++ b/src/allmydata/test/test_stats.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 from twisted.application import service

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import time, os.path, platform, stat, re, simplejson, struct, shutil
 
 import mock

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, re, sys, time, simplejson
 from cStringIO import StringIO

--- a/src/allmydata/test/test_upload.py
+++ b/src/allmydata/test/test_upload.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, shutil
 from cStringIO import StringIO

--- a/src/allmydata/test/test_uri.py
+++ b/src/allmydata/test/test_uri.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os
 from twisted.trial import unittest

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 def foo(): pass # keep the line number constant
 
@@ -45,7 +47,7 @@ class NoArgumentException(Exception):
 class HumanReadable(unittest.TestCase):
     def test_repr(self):
         hr = humanreadable.hr
-        self.failUnlessEqual(hr(foo), "<foo() at test_util.py:2>")
+        self.failUnlessEqual(hr(foo), "<foo() at test_util.py:4>")
         self.failUnlessEqual(hr(self.test_repr),
                              "<bound method HumanReadable.test_repr of <allmydata.test.test_util.HumanReadable testMethod=test_repr>>")
         self.failUnlessEqual(hr(1L), "1")

--- a/src/allmydata/test/test_version.py
+++ b/src/allmydata/test/test_version.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 

--- a/src/allmydata/test/test_web.py
+++ b/src/allmydata/test/test_web.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os.path, re, urllib, time, cgi
 import simplejson
 from StringIO import StringIO

--- a/src/allmydata/test/trial_coverage.py
+++ b/src/allmydata/test/trial_coverage.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 """A Trial IReporter plugin that gathers coverage.py code-coverage information.
 

--- a/src/allmydata/test/trialtest.py
+++ b/src/allmydata/test/trialtest.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # This is a dummy test suite that we can use to check that 'tahoe debug trial'
 # is working properly. Since the module name does not start with 'test_', it

--- a/src/allmydata/unknown.py
+++ b/src/allmydata/unknown.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import implements
 from twisted.internet import defer

--- a/src/allmydata/uri.py
+++ b/src/allmydata/uri.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re
 

--- a/src/allmydata/util/abbreviate.py
+++ b/src/allmydata/util/abbreviate.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import re
 

--- a/src/allmydata/util/assertutil.py
+++ b/src/allmydata/util/assertutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 Tests useful in assertion checking, prints out nicely formated messages too.
 """

--- a/src/allmydata/util/base32.py
+++ b/src/allmydata/util/base32.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # from the Python Standard Library
 import string
 

--- a/src/allmydata/util/base62.py
+++ b/src/allmydata/util/base62.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # from the Python Standard Library
 import string
 

--- a/src/allmydata/util/cachedir.py
+++ b/src/allmydata/util/cachedir.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os.path, stat, weakref, time
 from twisted.application import service, internet

--- a/src/allmydata/util/consumer.py
+++ b/src/allmydata/util/consumer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 """This file defines a basic download-to-memory consumer, suitable for use in
 a filenode's read() method. See download_to_data() for an example of its use.

--- a/src/allmydata/util/deferredutil.py
+++ b/src/allmydata/util/deferredutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from twisted.internet import defer
 
 # utility wrapper for DeferredList

--- a/src/allmydata/util/dictutil.py
+++ b/src/allmydata/util/dictutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 Tools to mess with dicts.
 """

--- a/src/allmydata/util/encodingutil.py
+++ b/src/allmydata/util/encodingutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 Functions used to convert inputs from whatever encoding used in the system to
 unicode and back.

--- a/src/allmydata/util/fake_inotify.py
+++ b/src/allmydata/util/fake_inotify.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # Most of this is copied from Twisted 11.0. The reason for this hack is that
 # twisted.internet.inotify can't be imported when the platform does not support inotify.

--- a/src/allmydata/util/fileutil.py
+++ b/src/allmydata/util/fileutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 Futz with files like a pro.
 """

--- a/src/allmydata/util/happinessutil.py
+++ b/src/allmydata/util/happinessutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 I contain utilities useful for calculating servers_of_happiness, and for
 reporting it in messages

--- a/src/allmydata/util/hashutil.py
+++ b/src/allmydata/util/hashutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from pycryptopp.hash.sha256 import SHA256
 import os
 from allmydata.util.netstring import netstring

--- a/src/allmydata/util/humanreadable.py
+++ b/src/allmydata/util/humanreadable.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import exceptions, os
 from repr import Repr
 

--- a/src/allmydata/util/idlib.py
+++ b/src/allmydata/util/idlib.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 
 from foolscap import base32

--- a/src/allmydata/util/iputil.py
+++ b/src/allmydata/util/iputil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # from the Python Standard Library
 import os, re, socket, subprocess, errno
 

--- a/src/allmydata/util/keyutil.py
+++ b/src/allmydata/util/keyutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os
 from pycryptopp.publickey import ed25519
 from allmydata.util.base32 import a2b, b2a

--- a/src/allmydata/util/limiter.py
+++ b/src/allmydata/util/limiter.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.internet import defer
 from foolscap.api import eventually

--- a/src/allmydata/util/log.py
+++ b/src/allmydata/util/log.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from allmydata.util import nummedobj
 
 from foolscap.logging import log

--- a/src/allmydata/util/mathutil.py
+++ b/src/allmydata/util/mathutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 A few commonly needed functions.
 """

--- a/src/allmydata/util/netstring.py
+++ b/src/allmydata/util/netstring.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 
 def netstring(s):

--- a/src/allmydata/util/nummedobj.py
+++ b/src/allmydata/util/nummedobj.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 from allmydata.util import dictutil
 
 class NummedObj(object):

--- a/src/allmydata/util/observer.py
+++ b/src/allmydata/util/observer.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # -*- test-case-name: allmydata.test.test_observer -*-
 
 import weakref

--- a/src/allmydata/util/pipeline.py
+++ b/src/allmydata/util/pipeline.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.internet import defer
 from twisted.python.failure import Failure

--- a/src/allmydata/util/pkgresutil.py
+++ b/src/allmydata/util/pkgresutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 def install():
     """

--- a/src/allmydata/util/pollmixin.py
+++ b/src/allmydata/util/pollmixin.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 from twisted.internet import task

--- a/src/allmydata/util/repeatable_random.py
+++ b/src/allmydata/util/repeatable_random.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 If you execute force_repeatability() then the following things are changed in the runtime:
 

--- a/src/allmydata/util/rrefutil.py
+++ b/src/allmydata/util/rrefutil.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.internet import address
 from foolscap.api import Violation, RemoteException, DeadReferenceError, \

--- a/src/allmydata/util/sibpath.py
+++ b/src/allmydata/util/sibpath.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import os
 import sys
 from twisted.python.util import sibpath as tsibpath

--- a/src/allmydata/util/spans.py
+++ b/src/allmydata/util/spans.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 class Spans:
     """I represent a compressed list of booleans, one per index (an integer).

--- a/src/allmydata/util/statistics.py
+++ b/src/allmydata/util/statistics.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # Copyright (c) 2009 Shawn Willden
 # mailto:shawn@willden.org
 # I hereby license all patches I have contributed or will contribute to the

--- a/src/allmydata/util/time_format.py
+++ b/src/allmydata/util/time_format.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 # ISO-8601:
 # http://www.cl.cam.ac.uk/~mgk25/iso-time.html
 

--- a/src/allmydata/util/verlib.py
+++ b/src/allmydata/util/verlib.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 """
 "Rational" version definition and parsing for DistutilsVersionFight
 discussion at PyCon 2009.

--- a/src/allmydata/web/check_results.py
+++ b/src/allmydata/web/check_results.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 import simplejson

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import simplejson
 from twisted.web import http, server

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import simplejson
 import urllib

--- a/src/allmydata/web/filenode.py
+++ b/src/allmydata/web/filenode.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import simplejson
 

--- a/src/allmydata/web/info.py
+++ b/src/allmydata/web/info.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import os, urllib
 

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time, os
 from nevow import rend, inevow

--- a/src/allmydata/web/operations.py
+++ b/src/allmydata/web/operations.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time
 from zope.interface import implements

--- a/src/allmydata/web/root.py
+++ b/src/allmydata/web/root.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import time, os
 
 from twisted.internet import address

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time, pprint, itertools
 import simplejson

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import time, simplejson
 from nevow import rend, tags as T, inevow

--- a/src/allmydata/web/unlinked.py
+++ b/src/allmydata/web/unlinked.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 import urllib
 from twisted.web import http

--- a/src/allmydata/webish.py
+++ b/src/allmydata/webish.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import re, time
 from twisted.application import service, strports, internet
 from twisted.web import http

--- a/src/allmydata/windows/fixups.py
+++ b/src/allmydata/windows/fixups.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 done = False
 

--- a/src/allmydata/windows/registry.py
+++ b/src/allmydata/windows/registry.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import sys
 import _winreg
 

--- a/src/allmydata/windows/tahoesvc.py
+++ b/src/allmydata/windows/tahoesvc.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 import sys
 reload(sys)
 sys.setdefaultencoding("utf-8")

--- a/src/buildtest/test_build_with_fake_dist.py
+++ b/src/buildtest/test_build_with_fake_dist.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from twisted.trial import unittest
 

--- a/static/tahoe.py
+++ b/static/tahoe.py
@@ -1,3 +1,5 @@
+﻿# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 # This checks that we can import the right versions of all dependencies.
 # Import this first to suppress deprecation warnings.

--- a/twisted/plugins/allmydata_trial.py
+++ b/twisted/plugins/allmydata_trial.py
@@ -1,4 +1,6 @@
-#! /usr/bin/env python
+﻿#! /usr/bin/env python
+# -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-
+# -*- indent-tabs-mode: nil -*-
 
 from zope.interface import implements
 from twisted.trial.itrial import IReporter


### PR DESCRIPTION
This makes it so that emacs knows the intended character encoding, BOM,
end-of-line markers, standard line-width, and tabs-vs-spaces policy for these
files.

This is also a form of documentation. It means that you should put only
utf-8-encoded things into text files, only utf-8-encoded things into source
code files (and actually you should write only put ASCII-encoded things except
possibly in comments or docstrings!), and that you should line-wrap everything
at 77 columns wide.

It also specifies that text files should start with a "utf-8 BOM". (Brian
questions the point of this, and my answer is that it adds information and
doesn't hurt. Whether that information will ever be useful is an open
question.)

It also specifies that text files should have unix-style end-of-line markers
(i.e. '\n'), not windows-style or old-macos-style.

For Python source code files, it also specifies that you should not insert tab
characters (so you should use spaces for Python block structure).

I generated this patch by writing and running the following script, and then
reading the resulting diff to make sure it was correct. I then undid the
changes that the script had done to the files inside the
"setuptools-0.6c16dev4.egg" directory before committing the patch.

------- begin appended script::
    
    #!/usr/bin/env python
    # -*- coding: utf-8-with-signature-unix; fill-column: 77 -*-

    import os

    magic_header_line_comment_prefix = {
        '.py': u"# ",
        '.rst': u".. ",
        }

    def format():
        for dirpath, dirnames, filenames in os.walk('.'):
            for filename in filenames:
                ext = os.path.splitext(filename)[-1]
                if ext in ('.py', '.rst'):
                    fname = os.path.join(dirpath, filename)
                    info = open(fname, 'rU')
                    formattedlines = [ line.decode('utf-8') for line in info ]
                    info.close()

                    if len(formattedlines) == 0:
                        continue

                    outfo = open(fname, 'w')
                    outfo.write(u"\ufeff".encode('utf-8'))

                    commentsign = magic_header_line_comment_prefix[ext]

                    firstline = formattedlines.pop(0)
                    while firstline.startswith(u"\ufeff"):
                        firstline = firstline[len(u"\ufeff"):]
                    if firstline.startswith(u"#!"):
                        outfo.write(firstline.encode('utf-8'))
                        outfo.write(commentsign+"-*- coding: utf-8-with-signature-unix; fill-column: 77 -*-\n".encode('utf-8'))
                        if ext == '.py':
                            outfo.write(commentsign+"-*- indent-tabs-mode: nil -*-\n".encode('utf-8'))
                    else:
                        outfo.write(commentsign+"-*- coding: utf-8-with-signature-unix; fill-column: 77 -*-\n".encode('utf-8'))
                        if ext == '.py':
                            outfo.write(commentsign+"-*- indent-tabs-mode: nil -*-\n".encode('utf-8'))
                        if (firstline.strip().startswith(commentsign)) and ("-*-" in firstline) and ("coding:" in firstline):
                            print "warning there was already a coding line %r in %r"  % (firstline, fname)
                        else:
                            outfo.write(firstline.encode('utf-8'))

                    for l in formattedlines:
                        if (l.strip().startswith(commentsign)) and ("-*-" in l) and ("coding:" in l):
                            print "warning there was already a coding line %r in %r"  % (l, fname)
                        else:
                            outfo.write(l.encode('utf-8'))
                    outfo.close()

    if __name__ == '__main__':
        format()