### PR TITLE
Adding aliases to the WUI

### DIFF
--- a/src/allmydata/web/root.py
+++ b/src/allmydata/web/root.py
@@ -15,7 +15,7 @@ from allmydata.web import filenode, directory, unlinked, status, operations
 from allmydata.web import storage
 from allmydata.web.common import abbreviate_size, getxmlfile, WebError, \
      get_arg, RenderMixin, get_format, get_mutable_type, TIME_FORMAT
-
+from allmydata.scripts.common import get_aliases, get_default_nodedir
 
 class URIHandler(RenderMixin, rend.Page):
     # I live at /uri . There are several operations defined on /uri itself,
@@ -263,6 +263,16 @@ class Root(rend.Page):
     def data_services(self, ctx, data):
         sb = self.client.get_storage_broker()
         return sorted(sb.get_known_servers(), key=lambda s: s.get_serverid())
+
+    def data_list_aliases(self, ctx, data):
+        aliases = get_aliases(get_default_nodedir())
+        return sorted(aliases.items())
+
+    def render_list_aliases_row(self, ctx, alias):
+        ctx.fillSlots("alias_name", alias[0])
+        ctx.fillSlots("alias_uri", "uri/" + alias[1])
+        ctx.fillSlots("alias_short_uri", alias[1].split("DIR2:")[1][:15])
+        return ctx.tag
 
     def render_service_row(self, ctx, server):
         nodeid = server.get_serverid()

--- a/src/allmydata/web/welcome.xhtml
+++ b/src/allmydata/web/welcome.xhtml
@@ -46,6 +46,22 @@
                  <p><input type="submit" class="btn" value="View File or Directory &#187;" /></p>
                </form>
             </div>
+            <div class="nav-header">Aliases</div>
+            <div class="aliases"/>
+            <table n:render="sequence" n:data="list_aliases">
+              <thead n:pattern="header">
+                <tr>
+                  <td><h5>Alias</h5></td>
+                  <td><h5>URI</h5></td>
+                </tr>
+              </thead>
+              <tr n:pattern="item" n:render="list_aliases_row">
+                <td>
+                  <a><n:attr name="href"><n:slot name="alias_uri" /></n:attr><n:slot name="alias_name" /></a>
+                </td>
+                <td><n:slot name="alias_short_uri" /></td>
+              </tr>
+            </table>
             <hr/>
 
             <div class="nav-header">Download Tahoe-URI:</div>


### PR DESCRIPTION
The aliases will be listed just under "View File or Directory" on the welcome screen.
At this point it lists clickable links to the aliases (which opens them in the wui) and their shortened node ids.

Later it would be nice to be able to add and remove aliases too.
