### PR TITLE
Right aligning services div

### DIFF
--- a/src/allmydata/web/static/css/bootstrap.css
+++ b/src/allmydata/web/static/css/bootstrap.css
@@ -192,6 +192,8 @@ a:hover {
   width: 380px;
 }
 .span4 {
+  position: absolute;
+  right: 0px;
   width: 300px;
 }
 .span3 {


### PR DESCRIPTION
This fixes services overlapping the introducer and helper info on the welcome screen of the WUI.

Before:
![screenshot_lafs_without](https://f.cloud.github.com/assets/389800/1816835/887f6e2c-6f54-11e3-856e-1c25df2e6b73.png)

After:
![screenshot_lafs_with](https://f.cloud.github.com/assets/389800/1816836/88f4edfa-6f54-11e3-9413-3f373cff47f4.png)
