### PR TITLE
isolate test_keygen data

### DIFF
--- a/src/allmydata/key_generator.py
+++ b/src/allmydata/key_generator.py
@@ -6,7 +6,7 @@ from foolscap.api import Referenceable, Tub
 from zope.interface import implements
 from twisted.internet import reactor
 from twisted.application import service
-from allmydata.util import log
+from allmydata.util import log, fileutil
 
 from pycryptopp.publickey import rsa
 from allmydata.interfaces import RIKeyGenerator
@@ -79,6 +79,7 @@ class KeyGeneratorService(service.MultiService):
     def __init__(self, basedir='.', display_furl=True, default_key_size=2048):
         service.MultiService.__init__(self)
         self.basedir = basedir
+        fileutil.make_dirs(self.basedir)
         self.tub = Tub(certFile=os.path.join(self.basedir, 'key_generator.pem'))
         self.tub.setOption("expose-remote-exception-types", False)
         self.tub.setServiceParent(self)

--- a/src/allmydata/test/test_keygen.py
+++ b/src/allmydata/test/test_keygen.py
@@ -43,7 +43,7 @@ class KeyGenService(unittest.TestCase, pollmixin.PollMixin):
 
         #print 'starting key generator service'
         keysize = TEST_RSA_KEY_SIZE
-        kgs = key_generator.KeyGeneratorService(display_furl=False, default_key_size=keysize)
+        kgs = key_generator.KeyGeneratorService(display_furl=False, default_key_size=keysize, basedir="key_generator_service")
         kgs.key_generator.verbose = True
         kgs.setServiceParent(self.parent)
         kgs.key_generator.pool_size = 8


### PR DESCRIPTION
This makes test_keygen use its own basedir, to avoid polluting the _trial_temp
directory for later tests.
