### PR TITLE
Switch to 'subprocess32' to avoid iputil.py crashes

### DIFF
--- a/src/allmydata/__init__.py
+++ b/src/allmydata/__init__.py
@@ -42,7 +42,7 @@ except ImportError:
 # https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Versioning
 __full_version__ = __appname__ + '/' + str(__version__)
 
-import os, platform, re, subprocess, sys, traceback
+import os, platform, re, subprocess32 as subprocess, sys, traceback
 _distributor_id_cmdline_re = re.compile("(?:Distributor ID:)\s*(.*)", re.I)
 _release_cmdline_re = re.compile("(?:Release:)\s*(.*)", re.I)
 

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -9,6 +9,9 @@ install_requires = [
     # zetuptoolz) to build, but can handle older versions to run
     "setuptools >= 0.6c6",
 
+    # python-2.7.[4567] stdlib/subprocess has bugs. #2023, python#18851
+    "subprocess32 >= 3.2.6",
+
     "zfec >= 1.1.0",
 
     # Feisty has simplejson 1.4

--- a/src/allmydata/util/iputil.py
+++ b/src/allmydata/util/iputil.py
@@ -1,5 +1,5 @@
 # from the Python Standard Library
-import os, re, socket, subprocess, errno
+import os, re, socket, subprocess32 as subprocess, errno
 
 from sys import platform
 


### PR DESCRIPTION
The stdlib 'subprocess' module in python-2.7.4 through 2.7.7 suffers
from http://bugs.python.org/issue18851 which causes most/all file
descriptors to be closed when `subprocess.call()` fails the `exec()`,
such as when the executable being invoked does not actually exist. There
appears to be some randomness involved. This was fixed in python-2.7.8.

Tahoe's iputil.py uses subprocess.call on many different "ifconfig"-type
executables, most of which don't exist on any given platform (git commit
8e31d66). This results in a lot of file-descriptor closing, which (at
least during unit tests) tends to clobber important things like Tub TCP
sockets. This seems to be the root cause behind ticket:2121, in which
normal code tries to close already-closed sockets. Since different
platforms have different ifconfigs, some platforms will experience more
failed execs than others, so this bug could easily behave differently on
linux vs freebsd, as well as working normally on python-2.7.8 or 2.7.4.

PyPI hosts the 'subprocess32' module, which is a backport of the newer
'subprocess' from python3's stdlib. In python issue 18851, Gregory P.
Smith recommends subprocess32 for all python2 users who would normally
use the stdlib version. 'subprocess32' does not suffer from the bug.

To fix 2121, I think we must either switch to subprocess32, or require
python >= 2.7.8 (which would rule out development/deployment on the
current OS-X release, which ships with 2.7.5, as well as other
distributions). Using subprocess32 seems like the easiest fix.

I believe this closes ticket:2121, and given the apparent relationship
between 2121 and 2023, I think it also closes ticket:2023 (although
since 2023 doesn't have copies of the failing log files, it's hard to
tell).
