### PR TITLE
2247 document pywin32 dependency 2

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,14 +9,13 @@ storage system.
 
 `about Tahoe-LAFS <about.rst>`__
 
-.. _the Tahoe-LAFS project: https://tahoe-lafs.org
+.. _the Tahoe-LAFS project: https://Tahoe-LAFS.org
 
 How To Get Tahoe-LAFS
 =====================
 
 This procedure has been verified to work on Windows, Mac, OpenSolaris, and
-too many flavors of Linux and of BSD to list. It's likely to work on other
-platforms.
+too many flavors of Linux and of BSD to list.
 
 In Case Of Trouble
 ------------------
@@ -26,7 +25,7 @@ be easy to set up on your platform. If the following instructions don't Just
 Work without any further effort on your part, then please write to `the
 tahoe-dev mailing list`_ where friendly hackers will help you out.
 
-.. _the tahoe-dev mailing list: https://tahoe-lafs.org/cgi-bin/mailman/listinfo/tahoe-dev
+.. _the tahoe-dev mailing list: https://Tahoe-LAFS.org/cgi-bin/mailman/listinfo/tahoe-dev
 
 Install Python
 --------------
@@ -35,25 +34,26 @@ Check if you already have an adequate version of Python installed by running
 ``python -V``. Python v2.6 (v2.6.6 or greater recommended) or Python v2.7
 will work. Python v3 does not work. On Windows, we recommend the use of
 native Python v2.7, not Cygwin Python. If you don't have one of these
-versions of Python installed, download and install `Python v2.7`_. Make sure
-that the path to the installation directory has no spaces in it (e.g. on
-Windows, do not install Python in the "Program Files" directory).
+versions of Python installed, `download`_ and install the latest version of
+Python v2.7. Make sure that the path to the installation directory has no
+spaces in it (e.g. on Windows, do not install Python in the “Program Files”
+directory).
 
-.. _Python v2.7: http://www.python.org/download/releases/2.7.4/
+.. _download: https://www.python.org/downloads/
 
 Get Tahoe-LAFS
 --------------
 
 Download the latest stable release, `Tahoe-LAFS v1.10.0`_.
 
-.. _Tahoe-LAFS v1.10.0: https://tahoe-lafs.org/source/tahoe-lafs/releases/allmydata-tahoe-1.10.0.zip
+.. _Tahoe-LAFS v1.10.0: https://Tahoe-LAFS.org/source/tahoe-lafs/releases/allmydata-tahoe-1.10.0.zip
 
 Set Up Tahoe-LAFS
 -----------------
 
 Unpack the zip file and cd into the top-level directory.
 
-Run "``python setup.py build``" to generate the ``tahoe`` executable in a
+Run “``python setup.py build``” to generate the ``tahoe`` executable in a
 subdirectory of the current directory named ``bin``. This will download and
 build anything you need from various websites.
 
@@ -61,11 +61,11 @@ On Windows, the ``build`` step might tell you to open a new Command Prompt
 (or, on XP and earlier, to log out and back in again). This is needed the
 first time you set up Tahoe-LAFS on a particular installation of Windows.
 
-Run "``bin/tahoe --version``" (on Windows, "``bin\tahoe --version``") to
+Run “``bin/tahoe --version``” (on Windows, “``bin\tahoe --version``”) to
 verify that the executable tool prints out the right version number after
-"``allmydata-tahoe:``".
+“``allmydata-tahoe:``”.
 
-Optionally run "``python setup.py trial``" to verify that it passes all of
+Optionally run “``python setup.py trial``” to verify that it passes all of
 its self-tests.
 
 Run Tahoe-LAFS


### PR DESCRIPTION
Please merge this, even though it does _not_ fix #2247, because it changes http://python.org to https://python.org and also improves the docs a little in other ways. We're currently not fixing #2247 because we can work-around it by instead avoiding the dependency on `pywin32`.
