### PR TITLE
1901 - Fix Welcome Page

### DIFF
--- a/src/allmydata/web/welcome.xhtml
+++ b/src/allmydata/web/welcome.xhtml
@@ -59,6 +59,7 @@
                   Filename
                   <input type="text" name="filename" />
                 </label>
+                <input type="hidden" name="save" value="true"/>
                 <p><input type="submit" class="btn" value="Download File &#187;" /></p>
               </form>
             </div>


### PR DESCRIPTION
Solution was very simple to implement, no content disposition header was
necessary.  Tested with both Firefox and Chrome, using a binary image file stored in
directory, as well as with text data using LIT cap.  Depending on your browser settings, the file may present a download dialog, or it may just download directly, using the filename entered in the download form.

we want to force all files to download. -- complete 
the filename field for the download form is ignored.  -- no longer ignored
