### PR TITLE
2340 version error reporting 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -366,7 +366,8 @@ Warning: no version information found. This may cause tests to fail.
 """)
 
     def try_from_git(self):
-        versions = versions_from_git("allmydata-tahoe-")
+        # If we change APPNAME, the release tag names should also change from then on.
+        versions = versions_from_git(APPNAME + '-')
         if versions:
             f = open(VERSION_PY_FILENAME, "wb")
             f.write(GIT_VERSION_BODY %


### PR DESCRIPTION
Improve error reporting when git commands fail to find the version. fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2340
