### PR TITLE
Preferred peers (rebased)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -388,13 +388,20 @@ Client Configuration
 
 ``peers.preferred = (string, optional)``
 
-    This is an optional comma-separated list of storage server node IDs that
-    will be tried first when selecting storage servers for reading or writing.
+    This is an optional comma-separated list of Node IDs of servers that will
+    be tried first when selecting storage servers for reading or writing.
 
-    Every selected node, preferred or not, will still receive the same number
-    of shares (one, if there are ``N`` or more servers accepting uploads).
-    Preferred nodes are simply moved to the front of the server selection lists
-    computed for each file.
+    Servers should be identified here by their Node ID as it appears in the web
+    ui, underneath the server's nickname. For storage servers running tahoe
+    versions >=1.10 (if the introducer is also running tahoe >=1.10) this will
+    be a "Node Key" (which is prefixed with 'v0-'). For older nodes, it will be
+    a TubID instead. When a preferred server (and/or the introducer) is
+    upgraded to 1.10 or later, clients must adjust their configs accordingly.
+
+    Every node selected for upload, whether preferred or not, will still
+    receive the same number of shares (one, if there are ``N`` or more servers
+    accepting uploads). Preferred nodes are simply moved to the front of the
+    server selection lists computed for each file.
 
     This is useful if a subset of your nodes have different availability or
     connectivity characteristics than the rest of the grid. For instance, if

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -386,6 +386,24 @@ Client Configuration
 .. _performance.rst: performance.rst
 .. _mutable.rst: specifications/mutable.rst
 
+``peers.preferred = (string, optional)``
+
+    This is an optional comma-separated list of storage server node IDs that
+    will be tried first when selecting storage servers for reading or writing.
+
+    Every selected node, preferred or not, will still receive the same number
+    of shares (one, if there are ``N`` or more servers accepting uploads).
+    Preferred nodes are simply moved to the front of the server selection lists
+    computed for each file.
+
+    This is useful if a subset of your nodes have different availability or
+    connectivity characteristics than the rest of the grid. For instance, if
+    there are more than ``N`` servers on the grid, and ``K`` or more of them
+    are at a single physical location, it would make sense for clients at that
+    location to prefer their local servers so that they can maintain access to
+    all of their uploads without using the internet.
+
+
 Frontend Configuration
 ======================
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -342,7 +342,8 @@ class Client(node.Node, pollmixin.PollMixin):
     def init_client_storage_broker(self):
         # create a StorageFarmBroker object, for use by Uploader/Downloader
         # (and everybody else who wants to use storage servers)
-        sb = storage_client.StorageFarmBroker(self.tub, permute_peers=True)
+        preferred_peers = [p.strip() for p in self.get_config("client", "peers.preferred", "").split(",") if p != ""]
+        sb = storage_client.StorageFarmBroker(self.tub, permute_peers=True, preferred_peers=preferred_peers)
         self.storage_broker = sb
 
         # load static server specifications from tahoe.cfg, if any.

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -62,7 +62,7 @@ class StorageFarmBroker:
     I'm also responsible for subscribing to the IntroducerClient to find out
     about new servers as they are announced by the Introducer.
     """
-    def __init__(self, tub, permute_peers, preferred_peers):
+    def __init__(self, tub, permute_peers, preferred_peers=()):
         self.tub = tub
         assert permute_peers # False not implemented yet
         self.permute_peers = permute_peers

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -62,10 +62,11 @@ class StorageFarmBroker:
     I'm also responsible for subscribing to the IntroducerClient to find out
     about new servers as they are announced by the Introducer.
     """
-    def __init__(self, tub, permute_peers):
+    def __init__(self, tub, permute_peers, preferred_peers):
         self.tub = tub
         assert permute_peers # False not implemented yet
         self.permute_peers = permute_peers
+        self.preferred_peers = preferred_peers
         # self.servers maps serverid -> IServer, and keeps track of all the
         # storage servers that we've heard about. Each descriptor manages its
         # own Reconnector, and will give us a RemoteReference when we ask
@@ -124,7 +125,10 @@ class StorageFarmBroker:
         def _permuted(server):
             seed = server.get_permutation_seed()
             return sha1(peer_selection_index + seed).digest()
-        return sorted(self.get_connected_servers(), key=_permuted)
+        connected_servers = self.get_connected_servers()
+        preferred_servers = frozenset([s for s in connected_servers if s.get_longname() in self.preferred_peers])
+        unpreferred_servers = connected_servers - preferred_servers
+        return sorted(preferred_servers, key=_permuted) + sorted(unpreferred_servers, key=_permuted)
 
     def get_all_serverids(self):
         return frozenset(self.servers.keys())

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -6,7 +6,7 @@ import allmydata
 from allmydata.node import Node, OldConfigError, OldConfigOptionError, MissingConfigEntry, UnescapedHashError
 from allmydata import client
 from allmydata.storage_client import StorageFarmBroker
-from allmydata.util import base32, fileutil
+from allmydata.util import base32, fileutil, idlib
 from allmydata.interfaces import IFilesystemNode, IFileNode, \
      IImmutableFileNode, IMutableFileNode, IDirectoryNode
 from foolscap.api import flushEventualQueue
@@ -177,7 +177,7 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         return [ s.get_longname() for s in sb.get_servers_for_psi(key) ]
 
     def test_permute(self):
-        sb = StorageFarmBroker(None, True)
+        sb = StorageFarmBroker(None, True, [])
         for k in ["%d" % i for i in range(5)]:
             ann = {"anonymous-storage-FURL": "pb://abcde@nowhere/fake",
                    "permutation-seed-base32": base32.b2a(k) }
@@ -185,6 +185,16 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
 
         self.failUnlessReallyEqual(self._permute(sb, "one"), ['3','1','0','4','2'])
         self.failUnlessReallyEqual(self._permute(sb, "two"), ['0','4','2','1','3'])
+        sb.servers.clear()
+        self.failUnlessReallyEqual(self._permute(sb, "one"), [])
+
+    def test_permute_with_preferred(self):
+        sb = StorageFarmBroker(None, True, map(idlib.nodeid_b2a, ['1','4']))
+        for k in ["%d" % i for i in range(5)]:
+            sb.test_add_rref(k, "rref")
+
+        self.failUnlessReallyEqual(self._permute(sb, "one"), ['1','4','3','0','2'])
+        self.failUnlessReallyEqual(self._permute(sb, "two"), ['4','1','0','2','3'])
         sb.servers.clear()
         self.failUnlessReallyEqual(self._permute(sb, "one"), [])
 

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -6,7 +6,7 @@ import allmydata
 from allmydata.node import Node, OldConfigError, OldConfigOptionError, MissingConfigEntry, UnescapedHashError
 from allmydata import client
 from allmydata.storage_client import StorageFarmBroker
-from allmydata.util import base32, fileutil, idlib
+from allmydata.util import base32, fileutil
 from allmydata.interfaces import IFilesystemNode, IFileNode, \
      IImmutableFileNode, IMutableFileNode, IDirectoryNode
 from foolscap.api import flushEventualQueue
@@ -177,7 +177,7 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         return [ s.get_longname() for s in sb.get_servers_for_psi(key) ]
 
     def test_permute(self):
-        sb = StorageFarmBroker(None, True, [])
+        sb = StorageFarmBroker(None, True)
         for k in ["%d" % i for i in range(5)]:
             ann = {"anonymous-storage-FURL": "pb://abcde@nowhere/fake",
                    "permutation-seed-base32": base32.b2a(k) }
@@ -189,9 +189,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         self.failUnlessReallyEqual(self._permute(sb, "one"), [])
 
     def test_permute_with_preferred(self):
-        sb = StorageFarmBroker(None, True, map(idlib.nodeid_b2a, ['1','4']))
+        sb = StorageFarmBroker(None, True, ['1','4'])
         for k in ["%d" % i for i in range(5)]:
-            sb.test_add_rref(k, "rref")
+            ann = {"anonymous-storage-FURL": "pb://abcde@nowhere/fake",
+                   "permutation-seed-base32": base32.b2a(k) }
+            sb.test_add_rref(k, "rref", ann)
 
         self.failUnlessReallyEqual(self._permute(sb, "one"), ['1','4','3','0','2'])
         self.failUnlessReallyEqual(self._permute(sb, "two"), ['4','1','0','2','3'])


### PR DESCRIPTION
See changes to ```doc/configuration.rst``` for the description of what this does.

This is one of the features discussed at https://tahoe-lafs.org/trac/tahoe-lafs/ticket/467

It was previously submitted as pull request #39; this is rebased to the latest master.