### PR TITLE
Add SSH key authentication to the SFTP server

### DIFF
--- a/src/allmydata/frontends/auth.py
+++ b/src/allmydata/frontends/auth.py
@@ -43,9 +43,12 @@ class AccountFileChecker:
                 rootcap = rest
             self.rootcaps[name] = rootcap
 
+    def _avatarId(self, username):
+        return FTPAvatarID(username, self.rootcaps[username])
+
     def _cbPasswordMatch(self, matched, username):
         if matched:
-            return FTPAvatarID(username, self.rootcaps[username])
+            return self._avatarId(username)
         raise error.UnauthorizedLogin
 
     def requestAvatarId(self, creds):
@@ -110,7 +113,7 @@ class AccountFileChecker:
             if creds.signature is None:
                 return defer.fail(conch_error.ValidPublicKey())
             if self._correctSignature(creds):
-                return defer.succeed(creds.username)
+                return defer.succeed(self._avatarId(creds.username))
         return defer.fail(error.UnauthorizedLogin())
 
 class AccountURLChecker:

--- a/src/allmydata/test/test_auth.py
+++ b/src/allmydata/test/test_auth.py
@@ -1,0 +1,50 @@
+from twisted.trial import unittest
+from twisted.python import filepath
+from twisted.cred import error, credentials
+from twisted.conch.ssh import keys
+
+from allmydata.frontends import auth
+
+DUMMY_KEY = keys.Key.fromString("""\
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQDEP3DYiukOu+NrUlBZeLL9JoHkK5nSvINYfeOQWYVW9J5NG485
+pZFVUQKzvvht34Ihj4ucrrvj7vOp+FFvzxI+zHKBpDxyJwV96dvWDAZMjxTxL7iV
+8HcO7hqgtQ/Xk1Kjde5lH3EOEDs3IhFHA+sox9y6i4A5NUr2AJZSHiOEVwIDAQAB
+AoGASrrNwefDr7SkeS2zIx7vKa8ML1LbFIBsk7n8ee9c8yvbTAl+lLkTiqV6ne/O
+sig2aYk75MI1Eirf5o2ElUsI6u36i6AeKL2u/W7tLBVijmBB8dTiWZ5gMOARWt8w
+daF2An2826YdcU+iNZ7Yi0q4xtlxHQn3JcNNWxicphLvt0ECQQDtajJ/bK+Nqd9j
+/WGvqYcMzkkorQq/0+MQYhcIwDlpf2Xoi45tP4HeoBubeJmU5+jXpXmdP5epWpBv
+k3ZCwV7pAkEA05xBP2HTdwRFTJov5I/w7uKOrn7mj7DCvSjQFCufyPOoCJJMeBSq
+tfCQlHFtwlkyNfiSbhtgZ0Pp6ovL+1RBPwJBAOlFRBKxrpgpxcXQK5BWqMwrT/S4
+eWxb+6mYR3ugq4h91Zq0rJ+pG6irdhS/XV/SsZRZEXIxDoom4u3OXQ9gQikCQErM
+ywuaiuNhMRXY0uEaOHJYx1LLLLjSJKQ0zwiyOvMPnfAZtsojlAxoEtNGHSQ731HQ
+ogIlzzfxe7ga3mni6IUCQQCwNK9zwARovcQ8nByqotGQzohpl+1b568+iw8GXP2u
+dBSD8940XU3YW+oeq8e+p3yQ2GinHfeJ3BYQyNQLuMAJ
+-----END RSA PRIVATE KEY-----
+""")
+
+DUMMY_ACCOUNTS = u"""\
+alice password URI:DIR2:aaaaaaaaaaaaaaaaaaaaaaaaaa:1111111111111111111111111111111111111111111111111111
+bob sekrit URI:DIR2:bbbbbbbbbbbbbbbbbbbbbbbbbb:2222222222222222222222222222222222222222222222222222
+carol %(key)s URI:DIR2:cccccccccccccccccccccccccc:3333333333333333333333333333333333333333333333333333
+""".format(DUMMY_KEY.public().toString("openssh")).encode("ascii")
+
+class AccountFileCheckerKeyTests(unittest.TestCase):
+    """
+    Tests for key handling done by allmydata.frontends.auth.AccountFileChecker.
+    """
+    def setUp(self):
+        self.account_file = filepath.FilePath(self.mktemp())
+        self.account_file.setContent(DUMMY_ACCOUNTS)
+        self.checker = auth.AccountFileChecker(None, self.account_file.path)
+
+    def test_unknown_user(self):
+        """
+        AccountFileChecker.requestAvatarId returns a Deferred that fires with
+        UnauthorizedLogin if called with an SSHPrivateKey object with a
+        username not present in the account file.
+        """
+        key_credentials = credentials.SSHPrivateKey(
+            b"dennis", b"md5", None, None, None)
+        avatarId = self.checker.requestAvatarId(key_credentials)
+        return self.assertFailure(avatarId, error.UnauthorizedLogin)

--- a/src/allmydata/test/test_auth.py
+++ b/src/allmydata/test/test_auth.py
@@ -48,3 +48,18 @@ class AccountFileCheckerKeyTests(unittest.TestCase):
             b"dennis", b"md5", None, None, None)
         avatarId = self.checker.requestAvatarId(key_credentials)
         return self.assertFailure(avatarId, error.UnauthorizedLogin)
+
+    def test_unrecognized_key(self):
+        """
+        AccountFileChecker.requestAvatarId returns a Deferred that fires with
+        UnauthorizedLogin if called with an SSHPrivateKey object with a public
+        key other than the one indicated in the account file for the indicated
+        user.
+        """
+        wrong_key_blob = b"""\
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQDJGMWlPXh2M3pYzTiamjcBIMqctt4VvLVW2QZgEFc86XhGjPXq5QAiRTKv9yVZJR9HW70CfBI7GHun8+v4Wb6aicWBoxgI3OB5NN+OUywdme2HSaif5yenFdQr0ME71Xs=
+"""
+        key_credentials = credentials.SSHPrivateKey(
+            b"carol", b"md5", wrong_key_blob, None, None)
+        avatarId = self.checker.requestAvatarId(key_credentials)
+        return self.assertFailure(avatarId, error.UnauthorizedLogin)


### PR DESCRIPTION
Fixed https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1411

I used the patch attached to that ticket for inspiration but re-implemented the functionality test-driven.  The PR comes with nearly full unit test coverage but:

  * I didn't see an easy, useful way to unit test the addition of `ISSHPrivateKey` to `credentialInterfaces`
  * These unit tests don't prove the new functionality actually integrates properly with the rest of the system.  I didn't see any existing convention for integration or functional testing to cover this sort of thing.
