### PR TITLE
Appease req.setHeader by passing bytes, not ints.

### DIFF
--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -206,7 +206,7 @@ def plural(sequence_or_length):
 def text_plain(text, ctx):
     req = IRequest(ctx)
     req.setHeader("content-type", "text/plain")
-    req.setHeader("content-length", len(text))
+    req.setHeader("content-length", b"%d" % len(text))
     return text
 
 class WebError(Exception):
@@ -315,7 +315,7 @@ class MyExceptionHandler(appserver.DefaultExceptionHandler):
         req.setHeader("content-type", "text/plain;charset=utf-8")
         if isinstance(text, unicode):
             text = text.encode("utf-8")
-        req.setHeader("content-length", str(len(text)))
+        req.setHeader("content-length", b"%d" % len(text))
         req.write(text)
         # TODO: consider putting the requested URL here
         req.finishRequest(False)

--- a/src/allmydata/web/filenode.py
+++ b/src/allmydata/web/filenode.py
@@ -452,7 +452,7 @@ class FileDownloader(rend.Page):
                     contentsize = last - first + 1
                     size = contentsize
 
-        req.setHeader("content-length", str(contentsize))
+        req.setHeader("content-length", b"%d" % contentsize)
         if req.method == "HEAD":
             return ""
 


### PR DESCRIPTION
twisted.web.http.Request.setHeader() really wants a "bytes" object, but
we've been passing integers like len(body). Twisted-12.3 started to
complain about this (with a DeprecationWarning), but the warning is
usually silenced because py2.7 disables deprecations by default.

This fixes Tahoe's misbehavior, but others remain (in Nevow, at least).
I plan to set up some tooling to run tests with
PYTHONWARNINGS=default::DeprecationWarning and collect others. We won't
be able to fix the ones that occur outside of Tahoe, but at least we
should be able to fix our own.

refs ticket:2312