### PR TITLE
Ticket #573: A server selection framework.

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -344,7 +344,8 @@ class Client(node.Node, pollmixin.PollMixin):
     def init_client_storage_broker(self):
         # create a StorageFarmBroker object, for use by Uploader/Downloader
         # (and everybody else who wants to use storage servers)
-        sb = storage_client.StorageFarmBroker(self.tub, permute_peers=True)
+        server_selection_hook = self.get_config("client", "server_selection_hook", "allmydata.storage_client.sort_servers")
+        sb = storage_client.StorageFarmBroker(self.tub, permute_peers=True, server_selection_hook=server_selection_hook)
         self.storage_broker = sb
 
         # load static server specifications from tahoe.cfg, if any.


### PR DESCRIPTION
The 3rd party server selection function can be passed in as
[client][server_selection_hook] in the tahoe.cfg file.
The format is python module syntax, like "module_a.submodule_b.function_c".
A default hook function "sort_servers" is implemented in allmydata.storage_client
to catch no 3rd party hook functoin configured case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/140)
<!-- Reviewable:end -->
