### PR TITLE
Fix ftp 'ls' to work with current Twisted-15.0.0

### DIFF
--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -110,10 +110,12 @@ if sys.platform == "win32":
         #   which includes the fix to <https://twistedmatrix.com/trac/ticket/411>.
         # * The SFTP frontend depends on Twisted 11.0.0 to fix the SSH server
         #   rekeying bug <https://twistedmatrix.com/trac/ticket/4395>
+        # * The FTP frontend depends on Twisted >=11.1.0 for
+        #   filepath.Permissions
         # * We don't want Twisted >= 12.2.0 to avoid a dependency of its endpoints
         #   code on pywin32. <https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2028>
         #
-        "Twisted >= 11.0.0, <= 12.1.0",
+        "Twisted >= 11.1.0, <= 12.1.0",
 
         # * We need Nevow >= 0.9.33 to avoid a bug in Nevow's setup.py
         #   which imported twisted at setup time.

--- a/src/allmydata/test/test_ftp.py
+++ b/src/allmydata/test/test_ftp.py
@@ -79,6 +79,11 @@ class Handler(GridTestMixin, ReallyEqualMixin, unittest.TestCase):
                                        actual_list, expected_list))
         for (a, b) in zip(actual_list, expected_list):
            (name, meta) = a
+           # convert meta.permissions to int for comparison. When we run
+           # against many (but not all) versions of Twisted, this is a
+           # filepath.Permissions object, not an int
+           meta = list(meta)
+           meta[2] = meta[2] & 0xffffffff
            (expected_name, expected_meta) = b
            self.failUnlessReallyEqual(name, expected_name)
            self.failUnlessReallyEqual(meta, expected_meta)

--- a/src/allmydata/test/test_ftp.py
+++ b/src/allmydata/test/test_ftp.py
@@ -79,11 +79,6 @@ class Handler(GridTestMixin, ReallyEqualMixin, unittest.TestCase):
                                        actual_list, expected_list))
         for (a, b) in zip(actual_list, expected_list):
            (name, meta) = a
-           # convert meta.permissions to int for comparison. When we run
-           # against many (but not all) versions of Twisted, this is a
-           # filepath.Permissions object, not an int
-           meta = list(meta)
-           meta[2] = meta[2] & 0xffffffff
            (expected_name, expected_meta) = b
            self.failUnlessReallyEqual(name, expected_name)
            self.failUnlessReallyEqual(meta, expected_meta)
@@ -98,12 +93,12 @@ class Handler(GridTestMixin, ReallyEqualMixin, unittest.TestCase):
 
         expected_root = [
             ('loop',
-             [0, True, 0600, 1, self.FALL_OF_BERLIN_WALL, 'alice', 'alice', '??']),
+             [0, True, ftpd.IntishPermissions(0600), 1, self.FALL_OF_BERLIN_WALL, 'alice', 'alice', '??']),
             ('immutable',
-             [23, False, 0600, 1, self.TURN_OF_MILLENIUM, 'alice', 'alice', '??']),
+             [23, False, ftpd.IntishPermissions(0600), 1, self.TURN_OF_MILLENIUM, 'alice', 'alice', '??']),
             ('mutable',
              # timestamp should be 0 if no timestamp metadata is present
-             [0, False, 0600, 1, 0, 'alice', 'alice', '??'])]
+             [0, False, ftpd.IntishPermissions(0600), 1, 0, 'alice', 'alice', '??'])]
 
         d.addCallback(lambda root: self._compareDirLists(root, expected_root))
 


### PR DESCRIPTION
refs ticket:2394

It's kind of a hack, but Twisted changed the API and I couldn't find a
cleaner way to detect which form of "permissions" value the Twisted FTP
server wants.

I've manually tested it against 14.0.2 and 15.0.0. I can't get a working Twisted-11.0.0 environment to test that corner case directly, but I force-enabled the workaround for it and that works too, so I'm pretty sure it'll work there.