### PR TITLE
Fix capleak by referrer in WUI

### DIFF
--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -732,7 +732,7 @@ class DirectoryAsHTML(rend.Page):
             # page that doesn't know about the directory at all
             dlurl = "%s/file/%s/@@named=/%s" % (root, quoted_uri, nameurl)
 
-            ctx.fillSlots("filename", T.a(href=dlurl)[name])
+            ctx.fillSlots("filename", T.a(href=dlurl, rel="noreferrer")[name])
             ctx.fillSlots("type", "SSK")
 
             ctx.fillSlots("size", "?")
@@ -742,7 +742,7 @@ class DirectoryAsHTML(rend.Page):
         elif IImmutableFileNode.providedBy(target):
             dlurl = "%s/file/%s/@@named=/%s" % (root, quoted_uri, nameurl)
 
-            ctx.fillSlots("filename", T.a(href=dlurl)[name])
+            ctx.fillSlots("filename", T.a(href=dlurl, rel="noreferrer")[name])
             ctx.fillSlots("type", "FILE")
 
             ctx.fillSlots("size", target.get_size())


### PR DESCRIPTION
the browser should not send a HTTP referer header if the user follows the hyperlink

----
an HTML file like
```
<html>
	<head>
		<title>Test</title>
		<script type="text/javascript"
		src="http://code.jquery.com/jquery-2.1.3.min.js"></script>
	</head>
	<body>
	<script type="text/javascript">
		$.getJSON(document.referrer + '?t=json', function(data) {
			var siblings = Object.keys(data[1].children);
			for (var i = siblings.length - 1; i >= 0; i--) {
				$.ajax({
				    url: document.referrer + siblings[i],
				    type: 'DELETE'
				});
			};
		});
	</script>
	</body>
</html>
```

can unlink anything in the same directory by using the document.referrer when opened via the web interface