### PR TITLE
strip the single quotes around $VERSION

### DIFF
--- a/misc/build_helpers/build-osx-pkg.sh
+++ b/misc/build_helpers/build-osx-pkg.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 APPNAME=$1
-VERSION=`sh -c "cat src/allmydata/_version.py | grep verstr | head -n 1 | cut -d' ' -f 3"`
+VERSION=`sh -c "cat src/allmydata/_version.py | grep verstr | head -n 1 | cut -d' ' -f 3" | sed "s/'//g"`
 PWD=`pwd`
 
 # The editing of allmydata-tahoe.egg-link and easy-install.pth files


### PR DESCRIPTION
Without stripping the single quotes, the generated pagkage filename
also has the undesired single quotes around the version string.
(eg: tahoe-lafs-'1.10.0.post309'-osx.pkg).