### PR TITLE
tahoe cp: deal with trailing slash on source arguments

### DIFF
--- a/src/allmydata/scripts/tahoe_cp.py
+++ b/src/allmydata/scripts/tahoe_cp.py
@@ -151,6 +151,7 @@ class LocalDirectoryTarget:
 
     def get_child_target(self, name):
         precondition(isinstance(name, unicode), name)
+        precondition(len(name), name) # don't want ""
         if self.children is None:
             self.populate(recurse=False)
         if name in self.children:
@@ -637,6 +638,8 @@ class Copier:
             url = self.nodeurl + "uri/%s" % urllib.quote(rootcap)
             name = None
             if path:
+                if path.endswith("/"):
+                    path = path[:-1]
                 url += "/" + escape_path(path)
                 last_slash = path.rfind(u"/")
                 name = path
@@ -659,13 +662,6 @@ class Copier:
                 writecap = to_str(d.get("rw_uri"))
                 readcap = to_str(d.get("ro_uri"))
                 mutable = d.get("mutable", False) # older nodes don't provide it
-
-                last_slash = source_spec.rfind(u"/")
-                if last_slash != -1:
-                    # TODO: this looks funny and redundant with the 'name'
-                    # assignment above. cf #2329
-                    name = source_spec[last_slash+1:]
-
                 t = TahoeFileSource(self.nodeurl, mutable, writecap, readcap, name)
         return t
 

--- a/src/allmydata/test/test_cli_cp.py
+++ b/src/allmydata/test/test_cli_cp.py
@@ -658,7 +658,9 @@ starting copy, 2 files, 1 directories
 
 # these test cases come from ticket #2329 comment 40
 # trailing slash on target *directory* should not matter, test both
-# trailing slash on files should cause error
+# trailing slash on target files should cause error
+# trailing slash on source directory should not matter, test a few
+# ignore trailing slash on source file, that's easiest
 
 COPYOUT_TESTCASES = """
 cp    $FILECAP          to/existing-file : to/existing-file
@@ -680,16 +682,22 @@ cp    $FILECAP $DIRCAP  to/existing-file/ : E4-NEED-R
 cp -r $FILECAP $DIRCAP  to/existing-file/ : E7-BADSLASH
 
 # single source to a (present) target directory
-cp    $FILECAP       to : E2-DESTNAME
-cp -r $FILECAP       to : E2-DESTNAME
-cp    $DIRCAP/file   to : to/file
-cp -r $DIRCAP/file   to : to/file
-cp    $PARENTCAP/dir to : E4-NEED-R
-cp -r $PARENTCAP/dir to : to/dir/file
-cp    $DIRCAP        to : E4-NEED-R
-cp -r $DIRCAP        to : to/file
-cp    $DIRALIAS      to : E4-NEED-R
-cp -r $DIRALIAS      to : to/file
+cp    $FILECAP        to : E2-DESTNAME
+cp -r $FILECAP        to : E2-DESTNAME
+cp    $DIRCAP/file    to : to/file
+cp -r $DIRCAP/file    to : to/file
+# these two should behave like the two above: ignore trailing slash
+cp    $DIRCAP/file/   to : to/file
+cp -r $DIRCAP/file/   to : to/file
+cp    $PARENTCAP/dir  to : E4-NEED-R
+cp -r $PARENTCAP/dir  to : to/dir/file
+# these two should ignore the trailing source slash too
+cp    $PARENTCAP/dir/ to : E4-NEED-R
+cp -r $PARENTCAP/dir/ to : to/dir/file
+cp    $DIRCAP         to : E4-NEED-R
+cp -r $DIRCAP         to : to/file
+cp    $DIRALIAS       to : E4-NEED-R
+cp -r $DIRALIAS       to : to/file
 
 cp    $FILECAP       to/ : E2-DESTNAME
 cp -r $FILECAP       to/ : E2-DESTNAME

--- a/src/allmydata/test/test_cli_cp.py
+++ b/src/allmydata/test/test_cli_cp.py
@@ -660,7 +660,7 @@ starting copy, 2 files, 1 directories
 # trailing slash on target *directory* should not matter, test both
 # trailing slash on target files should cause error
 # trailing slash on source directory should not matter, test a few
-# ignore trailing slash on source file, that's easiest
+# trailing slash on source files should cause error
 
 COPYOUT_TESTCASES = """
 cp    $FILECAP          to/existing-file : to/existing-file
@@ -686,12 +686,12 @@ cp    $FILECAP        to : E2-DESTNAME
 cp -r $FILECAP        to : E2-DESTNAME
 cp    $DIRCAP/file    to : to/file
 cp -r $DIRCAP/file    to : to/file
-# these two should behave like the two above: ignore trailing slash
-cp    $DIRCAP/file/   to : to/file
-cp -r $DIRCAP/file/   to : to/file
+# these two are errors
+cp    $DIRCAP/file/   to : E8-BADSLASH
+cp -r $DIRCAP/file/   to : E8-BADSLASH
 cp    $PARENTCAP/dir  to : E4-NEED-R
 cp -r $PARENTCAP/dir  to : to/dir/file
-# these two should ignore the trailing source slash too
+# but these two should ignore the trailing source slash
 cp    $PARENTCAP/dir/ to : E4-NEED-R
 cp -r $PARENTCAP/dir/ to : to/dir/file
 cp    $DIRCAP         to : E4-NEED-R
@@ -949,6 +949,8 @@ class CopyOut(GridTestMixin, CLITestMixin, unittest.TestCase):
                     return set(["E6-MANYONE"])
                 if err == "target is not a directory, but ends with a slash":
                     return set(["E7-BADSLASH"])
+                if err == "source is not a directory, but ends with a slash":
+                    return set(["E8-BADSLASH"])
             self.fail("unrecognized error ('%s') %s" % (case, res))
         d.addCallback(_check)
         return d


### PR DESCRIPTION
This avoids an error case where an empty child name resulted in a
duplicate mkdir (closes ticket:2399). It adds a precondition check to
guard against empty child names, and some test cases. It also cleans up
a funny redundancy noticed earlier (refs ticket:2399).