### PR TITLE
Base Dockerfile initial version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM python:2.7
 
 ADD . /tahoe-lafs
 RUN \
-  sed -i "s/\# alias/alias/" /root/.bashrc && \
   cd /tahoe-lafs && \
   make && \
   ln -vs /tahoe-lafs/bin/tahoe /usr/local/bin/tahoe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7
+
+ADD . /tahoe-lafs
+RUN \
+  sed -i "s/\# alias/alias/" /root/.bashrc && \
+  cd /tahoe-lafs && \
+  make && \
+  ln -vs /tahoe-lafs/bin/tahoe /usr/local/bin/tahoe
+
+WORKDIR /root


### PR DESCRIPTION
I'm Dockerizing Tahoe-LAFS and working to set up public Docker images on [Docker Hub](https://hub.docker.com). I think that providing [Docker](www.docker.com) images for Tahoe-LAFS would ease installation and deployment and enhance Tahoe-LAFS' visibility. Also, with composition tools in the Docker ecosystem such as Docker Compose, you will be able to start an entire grid with a single command by crafting an appropiate docker-compose.yml file.
I've created [Tahoe-LAFS](https://hub.docker.com/u/tahoelafs) organization repos and set up automated builds linked to my personal github account, by now.
Happily will hand the organization ownership to maintainers and/or link the automated builds to upstream github repos.
Now I'm working on specific -node and -introducer Docker images, based on tahoelafs/base.