### PR TITLE
speedy unit tests

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -517,7 +517,7 @@ class Client(node.Node, pollmixin.PollMixin):
             s.startService()
 
             # start processing the upload queue when we've connected to enough servers
-            self.connected_enough_d.addCallback(s.ready)
+            self.connected_enough_d.addCallback(lambda ign: s.ready())
 
     def _check_exit_trigger(self, exit_trigger_file):
         if os.path.exists(exit_trigger_file):

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -378,6 +378,8 @@ class Uploader(QueueMixin):
 
 
 class Downloader(QueueMixin):
+    REMOTE_SCAN_INTERVAL = 3  # facilitates tests
+
     def __init__(self, client, local_path_u, db, collective_dircap, clock):
         QueueMixin.__init__(self, client, local_path_u, db, 'downloader', clock)
 
@@ -389,7 +391,7 @@ class Downloader(QueueMixin):
         if self._collective_dirnode.is_unknown() or not self._collective_dirnode.is_readonly():
             raise AssertionError("The URI in 'private/collective_dircap' is not a readonly cap to a directory.")
 
-        self._turn_delay = 3 # delay between remote scans
+        self._turn_delay = self.REMOTE_SCAN_INTERVAL
         self._download_scan_batch = {} # path -> [(filenode, metadata)]
 
     def start_scanning(self):

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -31,6 +31,7 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
         temp = self.mktemp()
         self.basedir = abspath_expanduser_unicode(temp.decode(get_filesystem_encoding()))
         self.magicfolder = None
+        Downloader.REMOTE_SCAN_INTERVAL = 0
 
     def _get_count(self, name, client=None):
         counters = (client or self.get_client()).stats_provider.get_stats()["counters"]


### PR DESCRIPTION
This properly time-warps the unit-tests using a task.Clock() instance (one each, for Alice and Bob). I also moved the default Downloader delay (3 seconds) to a class-variable so the ``setUp`` for the CLI-based tests get a chance to make it zero early on.

Ten times faster! (~8s versus ~80s previously).

Note that it's based on 2438.magic-folder-stable.3 but includes the ``ready`` fix also...