### PR TITLE
Disable bridging of foolscap logging to the Twisted log...

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -198,23 +198,6 @@ the outbound TCP queue), publishing nodes will start dropping log events when
 the outbound queue grows too large. When this occurs, there will be gaps
 (non-sequential event numbers) in the log-gatherer's flogfiles.
 
-Local twistd.log files
-======================
-
-[TODO: not yet true, requires foolscap-0.3.1 and a change to ``allmydata.node``]
-
-In addition to the foolscap-based event logs, certain high-level events will
-be recorded directly in human-readable text form, in the
-``BASEDIR/logs/twistd.log`` file (and its rotated old versions:
-``twistd.log.1``, ``twistd.log.2``, etc). This form does not contain as much
-information as the flogfiles available through the means described
-previously, but they are immediately available to the curious developer, and
-are retained until the twistd.log.NN files are explicitly deleted.
-
-Only events at the ``log.OPERATIONAL`` level or higher are bridged to
-``twistd.log`` (i.e. not the ``log.NOISY`` debugging events). In addition,
-foolscap internal events (like connection negotiation messages) are not
-bridged to ``twistd.log``.
 
 Adding log messages
 ===================

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -381,7 +381,7 @@ class Node(service.MultiService):
             self.tub.setOption("log-gatherer-furl", lgfurl)
         self.tub.setOption("log-gatherer-furlfile",
                            os.path.join(self.basedir, "log_gatherer.furl"))
-        self.tub.setOption("bridge-twisted-logs", True)
+
         incident_dir = os.path.join(self.basedir, "logs", "incidents")
         foolscap.logging.log.setLogDir(incident_dir.encode(get_filesystem_encoding()))
 


### PR DESCRIPTION
… and remove docs for it. fixes ticket:2567

Signed-off-by: Daira Hopwood <daira@jacaranda.org>