### PR TITLE
2568.make-join-useable.1

### DIFF
--- a/src/allmydata/scripts/magic_folder_cli.py
+++ b/src/allmydata/scripts/magic_folder_cli.py
@@ -153,6 +153,9 @@ def join(options):
     dmd_cap_file = os.path.join(options["node-directory"], u"private", u"magic_folder_dircap")
     collective_readcap_file = os.path.join(options["node-directory"], u"private", u"collective_dircap")
 
+    if os.path.exists(dmd_cap_file) or os.path.exists(collective_readcap_file):
+        raise usage.UsageError("Cannot join. Already joined.")
+
     fileutil.write(dmd_cap_file, dmd_write_cap)
     fileutil.write(collective_readcap_file, magic_readonly_cap)
 

--- a/src/allmydata/scripts/magic_folder_cli.py
+++ b/src/allmydata/scripts/magic_folder_cli.py
@@ -152,8 +152,9 @@ def join(options):
 
     dmd_cap_file = os.path.join(options["node-directory"], u"private", u"magic_folder_dircap")
     collective_readcap_file = os.path.join(options["node-directory"], u"private", u"collective_dircap")
+    magic_folder_db_file = os.path.join(options["node-directory"], u"private", u"magicfolderdb.sqlite")
 
-    if os.path.exists(dmd_cap_file) or os.path.exists(collective_readcap_file):
+    if os.path.exists(dmd_cap_file) or os.path.exists(collective_readcap_file) or os.path.exists(magic_folder_db_file):
         raise usage.UsageError("Cannot join. Already joined.")
 
     fileutil.write(dmd_cap_file, dmd_write_cap)

--- a/src/allmydata/scripts/magic_folder_cli.py
+++ b/src/allmydata/scripts/magic_folder_cli.py
@@ -166,11 +166,28 @@ def join(options):
                    % (options.local_dir.encode('utf-8'),), mode="ab")
     return 0
 
+class LeaveOptions(BasedirOptions):
+    synopsis = ""
+    def parseArgs(self):
+        BasedirOptions.parseArgs(self)
+
+def leave(options):
+    dmd_cap_file = os.path.join(options["node-directory"], u"private", u"magic_folder_dircap")
+    collective_readcap_file = os.path.join(options["node-directory"], u"private", u"collective_dircap")
+    magic_folder_db_file = os.path.join(options["node-directory"], u"private", u"magicfolderdb.sqlite")
+    for f in [dmd_cap_file, collective_readcap_file, magic_folder_db_file]:
+        try:
+            os.remove(f)
+        except OSError,e:
+            pass
+    return 0
+
 class MagicFolderCommand(BaseOptions):
     subCommands = [
         ["create", None, CreateOptions, "Create a Magic Folder."],
         ["invite", None, InviteOptions, "Invite someone to a Magic Folder."],
         ["join", None, JoinOptions, "Join a Magic Folder."],
+        ["leave", None, LeaveOptions, "Leave a Magic Folder."],
     ]
     def postOptions(self):
         if not hasattr(self, 'subOptions'):
@@ -189,6 +206,7 @@ subDispatch = {
     "create": create,
     "invite": invite,
     "join": join,
+    "leave": leave,
 }
 
 def do_magic_folder(options):

--- a/src/allmydata/scripts/magic_folder_cli.py
+++ b/src/allmydata/scripts/magic_folder_cli.py
@@ -172,9 +172,19 @@ class LeaveOptions(BasedirOptions):
         BasedirOptions.parseArgs(self)
 
 def leave(options):
+    from ConfigParser import SafeConfigParser
+
     dmd_cap_file = os.path.join(options["node-directory"], u"private", u"magic_folder_dircap")
     collective_readcap_file = os.path.join(options["node-directory"], u"private", u"collective_dircap")
     magic_folder_db_file = os.path.join(options["node-directory"], u"private", u"magicfolderdb.sqlite")
+
+    parser = SafeConfigParser()
+    parser.read(os.path.join(options["node-directory"], u"tahoe.cfg"))
+    parser.remove_section("magic_folder")
+    f = open(os.path.join(options["node-directory"], u"tahoe.cfg"), "w")
+    parser.write(f)
+    f.close()
+
     for f in [dmd_cap_file, collective_readcap_file, magic_folder_db_file]:
         try:
             os.remove(f)


### PR DESCRIPTION
Make 'tahoe magic-folder join' fail if we're already joined, and add a 'tahoe magic-folder leave' command. refs ticket:2568