### PR TITLE
drop Python 2.6 (.travis.yml, doc, setup.py)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "2.6"
   - "pypy"
 before_install:
   - sh -c set

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,13 +31,13 @@ Install Python
 --------------
 
 Check if you already have an adequate version of Python installed by running
-``python -V``. Python v2.6 (v2.6.6 or greater recommended) or Python v2.7
-will work. Python v3 does not work. On Windows, we recommend the use of
-native Python v2.7, not Cygwin Python. If you don't have one of these
-versions of Python installed, `download`_ and install the latest version of
-Python v2.7. Make sure that the path to the installation directory has no
-spaces in it (e.g. on Windows, do not install Python in the "Program Files"
-directory).
+``python -V``. The latest version of Python v2.7 is recommended. Python v2.6.x
+is no longer officially supported, but might still work. Python v3 does not
+work. On Windows, we recommend the use of native Python v2.7, not Cygwin
+Python. If you don't have one of these versions of Python installed,
+`download`_ and install the latest version of Python v2.7. Make sure that the
+path to the installation directory has no spaces in it (e.g. on Windows, do not
+install Python in the "Program Files" directory).
 
 .. _download: https://www.python.org/downloads/
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys; assert sys.version_info < (3,), ur"Tahoe-LAFS does not run under Python 3. Please use a version of Python between 2.6 and 2.7.x inclusive."
+import sys; assert sys.version_info < (3,), ur"Tahoe-LAFS does not run under Python 3. Please use Python 2.7.x."
 
 # Tahoe-LAFS -- secure, distributed storage grid
 #
@@ -101,7 +101,6 @@ trove_classifiers=[
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.6",
     "Programming Language :: Python :: 2.7",
     "Topic :: Utilities",
     "Topic :: System :: Systems Administration",
@@ -249,7 +248,7 @@ def run_command(args, cwd=None):
     use_shell = sys.platform == "win32"
     try:
         p = subprocess.Popen(args, stdout=subprocess.PIPE, cwd=cwd, shell=use_shell)
-    except EnvironmentError as e:  # if this gives a SyntaxError, note that Tahoe-LAFS requires Python 2.6+
+    except EnvironmentError as e:  # if this gives a SyntaxError, note that Tahoe-LAFS requires Python 2.7+
         print("Warning: unable to run %r." % (" ".join(args),))
         print(e)
         return None


### PR DESCRIPTION
Twisted 15 dropped support for it, which causes Travis CI tests to fail on 2.6.
We still theoretically support older versions of Twisted, so perhaps we should
configure Travis to test with those? I think we should drop Python 2.6 in any
case since distros are all on 2.7 now.

I'm leaving Travis running (and ignoring) the failing PyPy tests because I
don't know why that is there.