### PR TITLE
ls -d: do not recurse into directories

### DIFF
--- a/src/allmydata/scripts/cli.py
+++ b/src/allmydata/scripts/cli.py
@@ -86,6 +86,7 @@ class ListAliasesOptions(FilesystemOptions):
 class ListOptions(FilesystemOptions):
     optFlags = [
         ("long", "l", "Use long format: show file sizes, and timestamps."),
+	("directory", "d", "List directories themselves, not their contents."),
         ("uri", "u", "Show file/directory URIs."),
         ("readonly-uri", None, "Show read-only file/directory URIs."),
         ("classify", "F", "Append '/' to directory names, and '*' to mutable."),

--- a/src/allmydata/scripts/cli.py
+++ b/src/allmydata/scripts/cli.py
@@ -86,7 +86,7 @@ class ListAliasesOptions(FilesystemOptions):
 class ListOptions(FilesystemOptions):
     optFlags = [
         ("long", "l", "Use long format: show file sizes, and timestamps."),
-	("directory", "d", "List directories themselves, not their contents."),
+	("directory", None, "List directories themselves, not their contents."),
         ("uri", "u", "Show file/directory URIs."),
         ("readonly-uri", None, "Show read-only file/directory URIs."),
         ("classify", "F", "Append '/' to directory names, and '*' to mutable."),

--- a/src/allmydata/scripts/tahoe_ls.py
+++ b/src/allmydata/scripts/tahoe_ls.py
@@ -61,7 +61,7 @@ def list(options):
 
     nodetype, d = parsed
     children = {}
-    if nodetype == "dirnode":
+    if nodetype == "dirnode" and not options['directory']:
         children = d['children']
     else:
         # paths returned from get_alias are always valid UTF-8

--- a/src/allmydata/test/test_cli_list.py
+++ b/src/allmydata/test/test_cli_list.py
@@ -99,7 +99,7 @@ class List(GridTestMixin, CLITestMixin, unittest.TestCase):
             d.addCallback(lambda ign: self.do_cli("ls", "-l", self.rooturi + ":./" + good_arg))
             d.addCallback(_check4)
             # listing a directory with the -d option should return just the cap of the directory
-            d.addCallback(lambda ign: self.do_cli("ls", "-d", "--uri"))
+            d.addCallback(lambda ign: self.do_cli("ls", "--directory", "--uri"))
             d.addCallback(lambda (_, out, err): self.failUnlessReallyEqual(len(out.splitlines()), 1))
 
         def _check5((rc, out, err)):

--- a/src/allmydata/test/test_cli_list.py
+++ b/src/allmydata/test/test_cli_list.py
@@ -98,6 +98,9 @@ class List(GridTestMixin, CLITestMixin, unittest.TestCase):
             # and similarly for $DIRCAP:./filename
             d.addCallback(lambda ign: self.do_cli("ls", "-l", self.rooturi + ":./" + good_arg))
             d.addCallback(_check4)
+            # listing a directory with the -d option should return just the cap of the directory
+            d.addCallback(lambda ign: self.do_cli("ls", "-d", "--uri"))
+            d.addCallback(lambda (_, out, err): self.failUnlessReallyEqual(len(out.splitlines()), 1))
 
         def _check5((rc, out, err)):
             # listing a raw filecap should not explode, but it will have no


### PR DESCRIPTION
This is useful when wanting to get a single cap for either of

```
ls --readonly-uri -d somefile.txt
ls --readonly-uri -d somedir
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/226)
<!-- Reviewable:end -->
