### PR TITLE
remove introducer's set_encoding_parameters

### DIFF
--- a/src/allmydata/introducer/client.py
+++ b/src/allmydata/introducer/client.py
@@ -28,9 +28,6 @@ class WrapV2ClientInV1Interface(Referenceable): # for_v1
                        for ann_v1 in announcements])
         return self.original.got_announcements(anns_v1, lp)
 
-    def remote_set_encoding_parameters(self, parameters):
-        self.original.remote_set_encoding_parameters(parameters)
-
 class RIStubClient(RemoteInterface): # for_v1
     """Each client publishes a service announcement for a dummy object called
     the StubClient. This object doesn't actually offer any services, but the
@@ -88,8 +85,6 @@ class IntroducerClient(service.Service, Referenceable):
         # from updates. It also provides memory for clients who subscribe
         # after startup.
         self._inbound_announcements = {}
-
-        self.encoding_parameters = None
 
         # hooks for unit tests
         self._debug_counts = {
@@ -353,9 +348,6 @@ class IntroducerClient(service.Service, Referenceable):
         for (service_name2,cb,args,kwargs) in self._local_subscribers:
             if service_name2 == service_name:
                 eventually(cb, key_s, ann, *args, **kwargs)
-
-    def remote_set_encoding_parameters(self, parameters):
-        self.encoding_parameters = parameters
 
     def connected_to_introducer(self):
         return bool(self._publisher)

--- a/src/allmydata/introducer/interfaces.py
+++ b/src/allmydata/introducer/interfaces.py
@@ -31,23 +31,6 @@ class RIIntroducerSubscriberClient_v2(RemoteInterface):
         """I accept announcements from the publisher."""
         return None
 
-    def set_encoding_parameters(parameters=(int, int, int)):
-        """Advise the client of the recommended k-of-n encoding parameters
-        for this grid. 'parameters' is a tuple of (k, desired, n), where 'n'
-        is the total number of shares that will be created for any given
-        file, while 'k' is the number of shares that must be retrieved to
-        recover that file, and 'desired' is the minimum number of shares that
-        must be placed before the uploader will consider its job a success.
-        n/k is the expansion ratio, while k determines the robustness.
-
-        Introducers should specify 'n' according to the expected size of the
-        grid (there is no point to producing more shares than there are
-        peers), and k according to the desired reliability-vs-overhead goals.
-
-        Note that setting k=1 is equivalent to simple replication.
-        """
-        return None
-
 SubscriberInfo = DictOf(str, Any())
 
 class RIIntroducerPublisherAndSubscriberService_v2(RemoteInterface):

--- a/src/allmydata/introducer/old.py
+++ b/src/allmydata/introducer/old.py
@@ -37,23 +37,6 @@ class RIIntroducerSubscriberClient_v1(RemoteInterface):
         """I accept announcements from the publisher."""
         return None
 
-    def set_encoding_parameters(parameters=(int, int, int)):
-        """Advise the client of the recommended k-of-n encoding parameters
-        for this grid. 'parameters' is a tuple of (k, desired, n), where 'n'
-        is the total number of shares that will be created for any given
-        file, while 'k' is the number of shares that must be retrieved to
-        recover that file, and 'desired' is the minimum number of shares that
-        must be placed before the uploader will consider its job a success.
-        n/k is the expansion ratio, while k determines the robustness.
-
-        Introducers should specify 'n' according to the expected size of the
-        grid (there is no point to producing more shares than there are
-        peers), and k according to the desired reliability-vs-overhead goals.
-
-        Note that setting k=1 is equivalent to simple replication.
-        """
-        return None
-
 # When Foolscap can handle multiple interfaces (Foolscap#17), the
 # full-powered introducer will implement both RIIntroducerPublisher and
 # RIIntroducerSubscriberService. Until then, we define
@@ -163,8 +146,6 @@ class IntroducerClient_v1(service.Service, Referenceable):
         # distinguish re-announcement from updates. It also provides memory
         # for clients who subscribe after startup.
         self._current_announcements = {}
-
-        self.encoding_parameters = None
 
         # hooks for unit tests
         self._debug_counts = {
@@ -344,9 +325,6 @@ class IntroducerClient_v1(service.Service, Referenceable):
         for (service_name2,cb,args,kwargs) in self._local_subscribers:
             if service_name2 == service_name:
                 eventually(cb, nodeid, ann_d, *args, **kwargs)
-
-    def remote_set_encoding_parameters(self, parameters):
-        self.encoding_parameters = parameters
 
     def connected_to_introducer(self):
         return bool(self._publisher)

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -95,9 +95,6 @@ class WrapV1SubscriberInV2Interface: # for_v1
     def wrap_announce_v2(self, announcements):
         anns_v1 = [convert_announcement_v2_to_v1(ann) for ann in announcements]
         return self.original.callRemote("announce", set(anns_v1))
-    def wrap_set_encoding_parameters(self, parameters):
-        # note: unused
-        return self.original.callRemote("set_encoding_parameters", parameters)
     def notifyOnDisconnect(self, *args, **kwargs):
         return self.original.notifyOnDisconnect(*args, **kwargs)
 


### PR DESCRIPTION
I'm not sure why this ever existed, but it doesn't appear to be used.

(If an introducer called a client's set_encoding_parameters method it would
keep the provided parameters in an instance attribute but would not actually
use them.)