### PR TITLE
stats: Dump a JSON file next to the pickle file.

### DIFF
--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -310,13 +310,14 @@ given port. The portnum file is actually a "strports specification string",
 as described in configuration.rst_.
 
 Once running, the stats gatherer will create a standard python "pickle" file
-in $BASEDIR/stats.pickle . Once a minute, the gatherer will pull stats
+in ``$BASEDIR/stats.pickle``, and a standard JSON file in
+``$BASEDIR/stats.json``. Once a minute, the gatherer will pull stats
 information from every connected node and write them into the pickle. The
 pickle will contain a dictionary, in which node identifiers (known as "tubid"
-strings) are the keys, and the values are a dict with 'timestamp',
-'nickname', and 'stats' keys. d[tubid][stats] will contain the stats
-dictionary as made available at http://localhost:3456/statistics?t=json . The
-pickle file will only contain the most recent update from each node.
+strings) are the keys, and the values are a dict with 'timestamp', 'nickname',
+and 'stats' keys. d[tubid][stats] will contain the stats dictionary as made
+available at http://localhost:3456/statistics?t=json . The pickle file will
+only contain the most recent update from each node.
 
 Other tools can be built to examine these stats and render them into
 something useful. For example, a tool could sum the

--- a/src/allmydata/stats.py
+++ b/src/allmydata/stats.py
@@ -1,4 +1,5 @@
 
+import json
 import os
 import pickle
 import pprint
@@ -250,6 +251,7 @@ class PickleStatsGatherer(StdOutStatsGatherer):
         self.verbose = verbose
         StatsGatherer.__init__(self, basedir)
         self.picklefile = os.path.join(basedir, "stats.pickle")
+        self.jsonfile = os.path.join(basedir, "stats.json")
 
         if os.path.exists(self.picklefile):
             f = open(self.picklefile, 'rb')
@@ -270,6 +272,7 @@ class PickleStatsGatherer(StdOutStatsGatherer):
         s['nickname'] = nickname
         s['stats'] = stats
         self.dump_pickle()
+        self.dump_json()
 
     def dump_pickle(self):
         tmp = "%s.tmp" % (self.picklefile,)
@@ -279,6 +282,16 @@ class PickleStatsGatherer(StdOutStatsGatherer):
         if os.path.exists(self.picklefile):
             os.unlink(self.picklefile)
         os.rename(tmp, self.picklefile)
+
+    def dump_json(self):
+        # Same logic as pickle, but using JSON instead.
+        tmp = "%s.tmp" % (self.jsonfile,)
+        f = open(tmp, 'wb')
+        json.dump(self.gathered_stats, f)
+        f.close()
+        if os.path.exists(self.jsonfile):
+            os.unlink(self.jsonfile)
+        os.rename(tmp, self.jsonfile)
 
 class StatsGathererService(service.MultiService):
     furl_file = "stats_gatherer.furl"


### PR DESCRIPTION
Extremely useful for interoperating with non-Python (e.g. Monte) tooling.

I've tested this change on a private grid; after a minute, ``stats.json`` materializes and contains a valid JSON expression which appears equivalent to the data in ``stats.pickle``.