### PR TITLE
Replace _lazy_tail with iterative loop, cleanup tests (#2412)

### DIFF
--- a/src/allmydata/magicfolderdb.py
+++ b/src/allmydata/magicfolderdb.py
@@ -65,7 +65,7 @@ class MagicFolderDB(object):
                   (relpath_u,))
         row = self.cursor.fetchone()
         if not row:
-            print "found nothing for", relpath_u
+            print "no dbentry for %r" % (relpath_u,)
             return None
         else:
             (size, mtime, ctime, version, last_uploaded_uri, last_downloaded_uri, last_downloaded_timestamp) = row

--- a/src/allmydata/util/fileutil.py
+++ b/src/allmydata/util/fileutil.py
@@ -256,11 +256,8 @@ def write_atomically(target, contents, mode="b"):
     move_into_place(target+".tmp", target)
 
 def write(path, data, mode="wb"):
-    wf = open(path, mode)
-    try:
-        wf.write(data)
-    finally:
-        wf.close()
+    with open(path, mode) as f:
+        f.write(data)
 
 def read(path):
     rf = open(path, "rb")


### PR DESCRIPTION
 * uses ``@inlineCallbacks`` to turn the _lazy_tail recursion into
   a "real" looking loop;
 * remove the need for "immediate" vs delayed iteration of said loop;
 * make it easier for the unit-tests to control the behavior of the
   uploader/downloader;
 * consolidates (some) setup/teardown code into the ``setUp`` and ``tearDown``
   hooks provided by ``unittest`` so unit-tests aren't doing that themselves
 * re-factors some of the unit-tests to use an ``@inlineCallbacks`` style
   so they're easier to follow and debug

This doesn't tackle the "how to know when our ``inotify`` events have arrived"
problem the unit-tests still have, nor does it eliminate the myriad bits
of state that get added to tests via all the MixIns.