### PR TITLE
2774.status api only.0 part2

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -1,5 +1,6 @@
 import os, stat, time, weakref
 from allmydata import node
+from base64 import urlsafe_b64encode
 
 from zope.interface import implements
 from twisted.internet import reactor, defer
@@ -332,6 +333,9 @@ class Client(node.Node, pollmixin.PollMixin):
         DEP["n"] = int(self.get_config("client", "shares.total", DEP["n"]))
         DEP["happy"] = int(self.get_config("client", "shares.happy", DEP["happy"]))
 
+        # for the CLI to authenticate to local JSON endpoints
+        self._create_auth_token()
+
         self.init_client_storage_broker()
         self.history = History(self.stats_provider)
         self.terminator = Terminator()
@@ -340,6 +344,28 @@ class Client(node.Node, pollmixin.PollMixin):
                                   self.history))
         self.init_blacklist()
         self.init_nodemaker()
+
+    def get_auth_token(self):
+        """
+        This returns a local authentication token, which is just some
+        random data in "api_auth_token" which must be echoed to API
+        calls.
+
+        Currently only the URI '/magic' for magic-folder status; other
+        endpoints are invited to include this as well, as appropriate.
+        """
+        return self.get_private_config('api_auth_token')
+
+    def _create_auth_token(self):
+        """
+        Creates new auth-token data written to 'private/api_auth_token'.
+
+        This is intentionally re-created every time the node starts.
+        """
+        self.write_private_config(
+            'api_auth_token',
+            urlsafe_b64encode(os.urandom(32)) + '\n',
+        )
 
     def init_client_storage_broker(self):
         # create a StorageFarmBroker object, for use by Uploader/Downloader

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -235,7 +235,7 @@ class Node(service.MultiService):
         """
         privname = os.path.join(self.basedir, "private", name)
         try:
-            return fileutil.read(privname)
+            return fileutil.read(privname).strip()
         except EnvironmentError:
             if os.path.exists(privname):
                 raise

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -5,7 +5,7 @@ import simplejson
 from twisted.web import http, server
 from twisted.python import log
 from zope.interface import Interface
-from nevow import loaders, appserver
+from nevow import loaders, appserver, rend
 from nevow.inevow import IRequest
 from nevow.util import resource_filename
 from allmydata import blacklist
@@ -15,6 +15,7 @@ from allmydata.interfaces import ExistingChildError, NoSuchChildError, \
      MustBeReadonlyError, MustNotBeUnknownRWError, SDMF_VERSION, MDMF_VERSION
 from allmydata.mutable.common import UnrecoverableFileError
 from allmydata.util import abbreviate
+from allmydata.util.hashutil import timing_safe_compare
 from allmydata.util.time_format import format_time, format_delta
 from allmydata.util.encodingutil import to_str, quote_output
 
@@ -363,8 +364,10 @@ class MyExceptionHandler(appserver.DefaultExceptionHandler):
         traceback = f.getTraceback()
         return self.simple(ctx, traceback, http.INTERNAL_SERVER_ERROR)
 
+
 class NeedOperationHandleError(WebError):
     pass
+
 
 class RenderMixin:
 
@@ -379,6 +382,47 @@ class RenderMixin:
         # do the same thing.
         m = getattr(self, 'render_' + request.method, None)
         if not m:
-            from twisted.web.server import UnsupportedMethod
-            raise UnsupportedMethod(getattr(self, 'allowedMethods', ()))
+            raise server.UnsupportedMethod(getattr(self, 'allowedMethods', ()))
         return m(ctx)
+
+
+class TokenOnlyWebApi(rend.Page):
+    """
+    I provide a rend.Page implementation that only accepts POST calls,
+    and only if they have a 'token=' arg with the correct
+    authentication token (see
+    :meth:`allmydata.client.Client.get_auth_token`). Callers must also
+    provide the "t=" argument to indicate the return-value (the only
+    valid value for this is "json")
+
+    Subclasses should override '_render_json' which should process the
+    API call and return a valid JSON object. This will only be called
+    if the correct token is present and valid (during renderHTTP
+    processing).
+    """
+
+    def __init__(self, client):
+        super(TokenOnlyWebApi, self).__init__()
+        self.client = client
+
+    def post_json(self, req):
+        return NotImplemented
+
+    def renderHTTP(self, ctx):
+        req = IRequest(ctx)
+        if req.method != 'POST':
+            raise server.UnsupportedMethod(('POST',))
+
+        token = get_arg(req, "token", None)
+        if not token:
+            raise WebError("Missing token", http.UNAUTHORIZED)
+        if not timing_safe_compare(token, self.client.get_auth_token()):
+            raise WebError("Invalid token", http.UNAUTHORIZED)
+
+        t = get_arg(req, "t", "").strip()
+        if not t:
+            raise WebError("Must provide 't=' argument")
+        if t == u'json':
+            return self.post_json(req)
+        else:
+            raise WebError("'%s' invalid type for 't' arg" % (t,), http.BAD_REQUEST)


### PR DESCRIPTION
This is the "not magic folders" portion of the magic-folder status API. One thing I changed was to refactor the Web portion a bit so that I could put the "token" code in this pull-request (even though only magic-folders uses it thus far).

See also: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2774#ticket
