### PR TITLE
Only accept 'token' in POST fields (stop using get_arg())

### DIFF
--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -412,8 +412,13 @@ class TokenOnlyWebApi(rend.Page):
         req = IRequest(ctx)
         if req.method != 'POST':
             raise server.UnsupportedMethod(('POST',))
-
-        token = get_arg(req, "token", None)
+        if req.args.get('token', False):
+            raise WebError("Do not pass 'token' as URL argument", http.BAD_REQUEST)
+        # not using get_arg() here because we *don't* want the token
+        # argument to work if you passed it as a GET-style argument
+        token = None
+        if req.fields and 'token' in req.fields:
+            token = req.fields['token'].value[0]
         if not token:
             raise WebError("Missing token", http.UNAUTHORIZED)
         if not timing_safe_compare(token, self.client.get_auth_token()):


### PR DESCRIPTION
Regarding daira's and warner's comments in #tahoe-def (freenode), stop using ``get_arg()`` so this definitely won't work if the client is broken and tries args in the URL (i.e. GET-style).