### PR TITLE
make node initialization synchronous

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,13 +49,22 @@ The item descriptions below use the following types:
     not specified, Tahoe-LAFS will attempt to bind the port specified on all
     interfaces.
 
+``endpoint specification string``
+
+    a Twisted Endpoint specification string, like "``tcp:80``" or
+    "``tcp:3456:interface=127.0.0.1``". These are replacing strports strings.
+    For a full description of the format, see `the Twisted Endpoints
+    documentation`_. Please note, if interface= is not specified, Tahoe-LAFS
+    will attempt to bind the port specified on all interfaces. Also note that
+    ``tub.port`` only works with TCP endpoints right now.
+
 ``FURL string``
 
     a Foolscap endpoint identifier, like
     ``pb://soklj4y7eok5c3xkmjeqpw@192.168.69.247:44801/eqpwqtzm``
 
 .. _the Twisted strports documentation: https://twistedmatrix.com/documents/current/api/twisted.application.strports.html
-
+.. _the Twisted Endpoints documentation: http://twistedmatrix.com/documents/current/core/howto/endpoints.html#endpoint-types-included-with-twisted
 
 Node Types
 ==========
@@ -128,13 +137,28 @@ set the ``tub.location`` option described below.
     ``http://127.0.0.1:3456/static/foo.html`` will serve the contents of
     ``BASEDIR/public_html/foo.html`` .
 
-``tub.port = (integer, optional)``
+``tub.port = (endpoints specification string, optional)``
 
-    This controls which port the node uses to accept Foolscap connections
-    from other nodes. If not provided, the node will ask the kernel for any
-    available port. The port will be written to a separate file (named
+    This controls the node's "listening port", through which it accepts
+    Foolscap connections from other nodes. If not provided, the node will ask
+    the kernel to allocate an available port, then saves it to a file (named
     ``client.port`` or ``introducer.port``), so that subsequent runs will
-    re-use the same port.
+    re-use the same port. The value should be ``tcp:`` followed by a port
+    number, e.g. ``tcp:3457``.
+
+    Note that the node can advertise an entirely different host+port (with
+    ``tub.location``, below) than the port that it listens on (controlled by
+    ``tub.port``). This is most useful when the node is a storage server and
+    lives behind a firewall that has been configured to forward a TCP port.
+    ``tub.location`` would be set to ``tcp:ADDR1:PORT1`` (where ADDR1 is the
+    external hostname or IP address of the firewall box, and PORT1 is the
+    externally-visible port), while ``tub.port`` would be ``tcp:PORT2``
+    (where the firewall is forwarding external PORT1 to internal PORT2).
+
+    ``tub.port`` cannot be ``tcp:0`` or ``0``: older versions accepted this,
+    but the node is no longer willing to ask Twisted to allocate port numbers
+    in this way. For backwards compatibility, a ``tub.port`` that is an
+    integer (other than 0) will be given a ``tcp:`` prefix.
 
 ``tub.location = (string, optional)``
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -140,15 +140,14 @@ class Client(node.Node, pollmixin.PollMixin):
         self.init_node_key()
         self.init_storage()
         self.init_control()
-        self.helper = None
-        if self.get_config("helper", "enabled", False, boolean=True):
-            self.init_helper()
         self._key_generator = KeyGenerator()
         key_gen_furl = self.get_config("client", "key_generator.furl", None)
         if key_gen_furl:
             self.init_key_gen(key_gen_furl)
         self.init_client()
-        # ControlServer and Helper are attached after Tub startup
+        self.helper = None
+        if self.get_config("helper", "enabled", False, boolean=True):
+            self.init_helper()
         self.init_ftp_server()
         self.init_sftp_server()
         self.init_drop_uploader()

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -48,15 +48,10 @@ class IntroducerNode(node.Node):
                 """
                 raise FurlFileConflictError(textwrap.dedent(msg))
             os.rename(old_public_fn, private_fn)
-        d = self.when_tub_ready()
-        def _publish(res):
-            furl = self.tub.registerReference(introducerservice,
-                                              furlFile=private_fn)
-            self.log(" introducer is at %s" % furl, umid="qF2L9A")
-            self.introducer_url = furl # for tests
-        d.addCallback(_publish)
-        d.addErrback(log.err, facility="tahoe.init",
-                     level=log.BAD, umid="UaNs9A")
+        furl = self.tub.registerReference(introducerservice,
+                                          furlFile=private_fn)
+        self.log(" introducer is at %s" % furl, umid="qF2L9A")
+        self.introducer_url = furl # for tests
 
     def init_web(self, webport):
         self.log("init_web(webport=%s)", args=(webport,), umid="2bUygA")

--- a/src/allmydata/stats.py
+++ b/src/allmydata/stats.py
@@ -148,12 +148,9 @@ class StatsProvider(Referenceable, service.MultiService):
 
     def startService(self):
         if self.node and self.gatherer_furl:
-            d = self.node.when_tub_ready()
-            def connect(junk):
-                nickname_utf8 = self.node.nickname.encode("utf-8")
-                self.node.tub.connectTo(self.gatherer_furl,
-                                        self._connected, nickname_utf8)
-            d.addCallback(connect)
+            nickname_utf8 = self.node.nickname.encode("utf-8")
+            self.node.tub.connectTo(self.gatherer_furl,
+                                    self._connected, nickname_utf8)
         service.MultiService.startService(self)
 
     def count(self, name, delta=1):

--- a/src/allmydata/test/check_memory.py
+++ b/src/allmydata/test/check_memory.py
@@ -116,10 +116,8 @@ class SystemFramework(pollmixin.PollMixin):
         #print "STARTING"
         self.stats = {}
         self.statsfile = open(os.path.join(self.basedir, "stats.out"), "a")
-        d = self.make_introducer()
-        def _more(res):
-            return self.start_client()
-        d.addCallback(_more)
+        self.make_introducer()
+        d = self.start_client()
         def _record_control_furl(control_furl):
             self.control_furl = control_furl
             #print "OBTAINING '%s'" % (control_furl,)
@@ -174,12 +172,7 @@ class SystemFramework(pollmixin.PollMixin):
         os.mkdir(iv_basedir)
         iv = introducer.IntroducerNode(basedir=iv_basedir)
         self.introducer = self.add_service(iv)
-        d = self.introducer.when_tub_ready()
-        def _introducer_ready(res):
-            q = self.introducer
-            self.introducer_furl = q.introducer_url
-        d.addCallback(_introducer_ready)
-        return d
+        self.introducer_furl = self.introducer.introducer_url
 
     def make_nodes(self):
         self.nodes = []

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -184,8 +184,6 @@ class NoNetworkClient(Client):
         service.MultiService.startService(self)
     def stopService(self):
         service.MultiService.stopService(self)
-    def when_tub_ready(self):
-        raise NotImplementedError("NoNetworkClient has no Tub")
     def init_control(self):
         pass
     def init_helper(self):

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -1014,10 +1014,17 @@ class ClientSeqnums(unittest.TestCase):
     def test_client(self):
         basedir = "introducer/ClientSeqnums/test_client"
         fileutil.make_dirs(basedir)
+        # if storage is enabled, the Client will publish its storage server
+        # during startup (although the announcement will wait in a queue
+        # until the introducer connection is established). To avoid getting
+        # confused by this, disable storage.
         f = open(os.path.join(basedir, "tahoe.cfg"), "w")
         f.write("[client]\n")
         f.write("introducer.furl = nope\n")
+        f.write("[storage]\n")
+        f.write("enabled = false\n")
         f.close()
+
         c = TahoeClient(basedir)
         ic = c.introducer_client
         outbound = ic._outbound_announcements

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -47,19 +47,14 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         f.close()
 
         if local_addresses:
-            self.patch(iputil, 'get_local_addresses_async', lambda target=None: defer.succeed(local_addresses))
+            self.patch(iputil, 'get_local_addresses_sync',
+                       lambda: local_addresses)
 
         n = TestNode(basedir)
         n.setServiceParent(self.parent)
-        d = n.when_tub_ready()
-
-        def _check_addresses(ignored_result):
-            furl = n.tub.registerReference(n)
-            for address in expected_addresses:
-                self.failUnlessIn(address, furl)
-
-        d.addCallback(_check_addresses)
-        return d
+        furl = n.tub.registerReference(n)
+        for address in expected_addresses:
+            self.failUnlessIn(address, furl)
 
     def test_location1(self):
         return self._test_location(basedir="test_node/test_location1",
@@ -96,10 +91,8 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
 
         n = TestNode(basedir)
         n.setServiceParent(self.parent)
-        d = n.when_tub_ready()
-        d.addCallback(lambda ign: self.failUnlessEqual(n.get_config("node", "nickname").decode('utf-8'),
-                                                       u"\u2621"))
-        return d
+        self.failUnlessEqual(n.get_config("node", "nickname").decode('utf-8'),
+                             u"\u2621")
 
     def test_tahoe_cfg_hash_in_name(self):
         basedir = "test_node/test_cfg_hash_in_name"

--- a/src/allmydata/test/test_web.py
+++ b/src/allmydata/test/test_web.py
@@ -4465,7 +4465,6 @@ class IntroducerWeb(unittest.TestCase):
 
         d = fireEventually(None)
         d.addCallback(lambda ign: self.node.startService())
-        d.addCallback(lambda ign: self.node.when_tub_ready())
 
         d.addCallback(lambda ign: self.GET("/"))
         def _check(res):

--- a/src/allmydata/util/iputil.py
+++ b/src/allmydata/util/iputil.py
@@ -71,6 +71,8 @@ except ImportError:
     # since one might be shadowing the other. This hack appeases pyflakes.
     increase_rlimits = _increase_rlimits
 
+def get_local_addresses_sync():
+    return _synchronously_find_addresses_via_config()
 
 def get_local_addresses_async(target="198.41.0.4"): # A.ROOT-SERVERS.NET
     """

--- a/topfiles/2491.config
+++ b/topfiles/2491.config
@@ -1,0 +1,14 @@
+* tub.port is now an Endpoint server specification string (which is pretty
+  much just like a strports string, but can be extended by plugins). It now
+  rejects "tcp:0" and "0". The tahoe.cfg value overrides anything stored on
+  disk (in client.port). This should have no effect on most nodes, which do
+  not set tub.port in tahoe.cfg, and wrote an allocated port number to
+  client.port the first time they launched. Folks who want to listen on a
+  specific port number typically set tub.port to "tcp:12345" or "12345", not
+  "0".
+* The "portnumfile" (e.g. NODEDIR/client.port) is written as soon as the port
+  is allocated, before the tub is created, and only if "tub.port" was empty.
+  The old code wrote to it unconditionally, and after Tub startup. So if the
+  user allows NODEDIR/client.port to be written, then later modifies
+  tahoe.cfg to set "tub.port" to a different value, this difference will
+  persist (and the node will honor tahoe.cfg "tub.port" exclusively).

--- a/topfiles/2491.config
+++ b/topfiles/2491.config
@@ -12,3 +12,14 @@
   user allows NODEDIR/client.port to be written, then later modifies
   tahoe.cfg to set "tub.port" to a different value, this difference will
   persist (and the node will honor tahoe.cfg "tub.port" exclusively).
+* We now encourage static allocation of tub.port, and pre-configuration of
+  the node's externally-reachable IP address or hostname (by setting
+  tub.location). Automatic IP-address detection is deprecated. Automatic port
+  allocation is merely discouraged. Eventually both will be managed by "tahoe
+  create-node", but for now we recommend users edit their tahoe.cfg after
+  node creation and before first launch.
+* "tahoe start" now creates the Tub, and all primary software components,
+  before the child process daemonizes. Many configuration errors which would
+  previously have been reported in a logfile (after node startup), will now
+  be signalled immediately, via stderr. In these cases, the "tahoe start"
+  process will exit with a non-zero return code.


### PR DESCRIPTION
This determines the Tub's location before creating the Tub (by allocating ports and detecting IP addresses synchronously), allowing `tub.registerReference` to happen in the Node constructor, thus allowing node initialization to happen synchronously. This simplifies the code considerably, and allows most configuration errors to be reported on the `tahoe start` stderr stream (instead of in a logfile after the process has forked off into a daemon).

Refs ticket:2491, although it only resolves the runtime portions of that ticket, not the `tahoe create-node` aspects.

It also updates the docs for `tub.port` and `tub.location` to discourage automatic port-allocation and IP-address-detection, as discussed in 2491.
