### PR TITLE
Enable checking verifycaps in Web UI

### DIFF
--- a/src/allmydata/immutable/filenode.py
+++ b/src/allmydata/immutable/filenode.py
@@ -7,7 +7,7 @@ from twisted.internet import defer
 
 from allmydata import uri
 from twisted.internet.interfaces import IConsumer
-from allmydata.interfaces import IImmutableFileNode, IUploadResults
+from allmydata.interfaces import IFileNode, IImmutableFileNode, IUploadResults
 from allmydata.util import consumer
 from allmydata.check_results import CheckResults, CheckAndRepairResults
 from allmydata.util.dictutil import DictOfSets
@@ -22,6 +22,8 @@ from allmydata.immutable.downloader.node import DownloadNode, \
 from allmydata.immutable.downloader.status import DownloadStatus
 
 class CiphertextFileNode:
+    implements(IFileNode)
+
     def __init__(self, verifycap, storage_broker, secret_holder,
                  terminator, history):
         assert isinstance(verifycap, uri.CHKFileVerifierURI)

--- a/src/allmydata/immutable/filenode.py
+++ b/src/allmydata/immutable/filenode.py
@@ -84,6 +84,24 @@ class CiphertextFileNode:
     def get_size(self):
         return self._verifycap.size
 
+    def get_current_size(self):
+        # Our size is fixed.
+        return defer.succeed(self._verifycap.size)
+
+    def get_write_uri(self):
+        # We are not writeable.
+        return None
+
+    def get_readonly_uri(self):
+        # We are not readable, either.
+        return None
+
+    def get_uri(self):
+        return self._verifycap.to_string()
+
+    def is_alleged_immutable(self):
+        return True
+
     def raise_error(self):
         pass
 


### PR DESCRIPTION
It's true that this patch is small. Most of the functionality turned out to already be written!

I have tested this patch, but I have one question: When performing the actual verification, I was unable to actually provoke my server into doing the data retrieval operation. *Some* operations must have happened, because the verifycap checker page correctly listed out the storage indices, but I guess that the actual ciphertext validation wasn't happening for some reason?

This provides the immutable part of [ticket 568](https://www.tahoe-lafs.org/trac/tahoe-lafs/ticket/568).