### PR TITLE
remove _appname.py file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 
 # these are generated at build time, and never checked in
 /src/allmydata/_version.py
-/src/allmydata/_appname.py
 
 # these are generated too
 /bin/tahoe

--- a/setup.py
+++ b/setup.py
@@ -30,19 +30,6 @@ def read_version_py(infname):
 VERSION_PY_FILENAME = 'src/allmydata/_version.py'
 version = read_version_py(VERSION_PY_FILENAME)
 
-APPNAME='tahoe-lafs'
-APPNAMEFILE = os.path.join('src', 'allmydata', '_appname.py')
-APPNAMEFILESTR = "__appname__ = '%s'" % (APPNAME,)
-try:
-    curappnamefilestr = open(APPNAMEFILE, 'rU').read()
-except EnvironmentError:
-    # No file, or unreadable or something, okay then let's try to write one.
-    open(APPNAMEFILE, "w").write(APPNAMEFILESTR)
-else:
-    if curappnamefilestr.strip() != APPNAMEFILESTR:
-        print("Error -- this setup.py file is configured with the 'application name' to be '%s', but there is already a file in place in '%s' which contains the contents '%s'.  If the file is wrong, please remove it and setup.py will regenerate it and write '%s' into it." % (APPNAME, APPNAMEFILE, curappnamefilestr, APPNAMEFILESTR))
-        sys.exit(-1)
-
 # Tahoe's dependencies are managed by the find_links= entry in setup.cfg and
 # the _auto_deps.install_requires list, which is used in the call to setup()
 # below.
@@ -214,8 +201,8 @@ Warning: no version information found. This may cause tests to fail.
 """)
 
     def try_from_git(self):
-        # If we change APPNAME, the release tag names should also change from then on.
-        versions = versions_from_git(APPNAME + '-')
+        # If we change the release tag names, we must change this too
+        versions = versions_from_git("tahoe-lafs-")
 
         # setup.py might be run by either py2 or py3 (when run by tox, which
         # uses py3 on modern debian/ubuntu distros). We want this generated
@@ -241,7 +228,7 @@ setup_args = {}
 if version:
     setup_args["version"] = version
 
-setup(name=APPNAME,
+setup(name="tahoe-lafs", # also set in __init__.py
       description='secure, decentralized, fault-tolerant file store',
       long_description=open('README.rst', 'rU').read(),
       author='the Tahoe-LAFS project',

--- a/src/allmydata/__init__.py
+++ b/src/allmydata/__init__.py
@@ -30,15 +30,10 @@ except ImportError:
     # branch is. This should not happen very often.
     pass
 
-__appname__ = "unknown"
-try:
-    from allmydata._appname import __appname__
-except ImportError:
-    # We're running in a tree that hasn't run "./setup.py".  This shouldn't happen.
-    pass
+__appname__ = "tahoe-lafs"
 
-# __full_version__ is the one that you ought to use when identifying yourself in the
-# "application" part of the Tahoe versioning scheme:
+# __full_version__ is the one that you ought to use when identifying yourself
+# in the "application" part of the Tahoe versioning scheme:
 # https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Versioning
 __full_version__ = __appname__ + '/' + str(__version__)
 

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -14,7 +14,7 @@ from allmydata.scripts import runner
 from allmydata.client import Client
 from allmydata.test import common_util
 import allmydata
-from allmydata._appname import __appname__
+from allmydata import __appname__
 
 
 timeout = 240


### PR DESCRIPTION
We no longer need the complexity of choosing the application name at
runtime. This removes the setup.py code which populates the `_appname.py`
file, and the code in `__init__.py` which reads it. It does not yet remove
the tests which compare the output of e.g. `tahoe --version` against
`allmydata.__appname__`, which I think could be removed, but that's more
invasive than I want to do right now.

refs ticket:2754