### PR TITLE
Improve error-reporting from JSON APIs, and use it better in CLI

### DIFF
--- a/src/allmydata/test/web/test_grid.py
+++ b/src/allmydata/test/web/test_grid.py
@@ -1162,7 +1162,7 @@ class Grid(GridTestMixin, WebErrorMixin, ShouldFailMixin, testutil.ReallyEqualMi
                    "was corrupt, or that shares have been lost due to server "
                    "departure, hard drive failure, or disk corruption. You "
                    "should perform a filecheck on this object to learn more.")
-            self.failUnlessReallyEqual(exp, body)
+            self.failUnlessIn(exp, body)
         d.addCallback(_check_unrecoverable_file)
 
         d.addCallback(lambda ignored:

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -4,6 +4,7 @@ import simplejson
 
 from twisted.web import http, server, resource
 from twisted.python import log
+from twisted.python.failure import Failure
 from zope.interface import Interface
 from nevow import loaders, appserver
 from nevow.inevow import IRequest
@@ -426,6 +427,11 @@ class TokenOnlyWebApi(resource.Resource):
         if not t:
             raise WebError("Must provide 't=' argument")
         if t == u'json':
-            return self.post_json(req)
+            try:
+                return self.post_json(req)
+            except Exception:
+                message, code = humanize_failure(Failure())
+                req.setResponseCode(code)
+                return simplejson.dumps({"error": message})
         else:
             raise WebError("'%s' invalid type for 't' arg" % (t,), http.BAD_REQUEST)

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -911,6 +911,15 @@ def DirectoryJSONMetadata(ctx, dirnode):
         return json
     d.addCallback(_got)
     d.addCallback(text_plain, ctx)
+
+    def error(f):
+        message, code = humanize_failure(f)
+        req = IRequest(ctx)
+        req.setResponseCode(code)
+        return simplejson.dumps({
+            "error": message,
+        })
+    d.addErrback(error)
     return d
 
 

--- a/src/allmydata/web/magic_folder.py
+++ b/src/allmydata/web/magic_folder.py
@@ -16,26 +16,31 @@ class MagicFolderWebApi(TokenOnlyWebApi):
         req.setHeader("content-type", "application/json")
 
         data = []
-        for item in self.client._magic_folder.uploader.get_status():
-            d = dict(
-                path=item.relpath_u,
-                status=item.status_history()[-1][0],
-                kind='upload',
-            )
-            for (status, ts) in item.status_history():
-                d[status + '_at'] = ts
-            d['percent_done'] = item.progress.progress
-            data.append(d)
+        try:
+            for item in self.client._magic_folder.uploader.get_status():
+                d = dict(
+                    path=item.relpath_u,
+                    status=item.status_history()[-1][0],
+                    kind='upload',
+                )
+                for (status, ts) in item.status_history():
+                    d[status + '_at'] = ts
+                d['percent_done'] = item.progress.progress
+                data.append(d)
 
-        for item in self.client._magic_folder.downloader.get_status():
-            d = dict(
-                path=item.relpath_u,
-                status=item.status_history()[-1][0],
-                kind='download',
-            )
-            for (status, ts) in item.status_history():
-                d[status + '_at'] = ts
-            d['percent_done'] = item.progress.progress
-            data.append(d)
+            for item in self.client._magic_folder.downloader.get_status():
+                d = dict(
+                    path=item.relpath_u,
+                    status=item.status_history()[-1][0],
+                    kind='download',
+                )
+                for (status, ts) in item.status_history():
+                    d[status + '_at'] = ts
+                d['percent_done'] = item.progress.progress
+                data.append(d)
+        except Exception as e:
+            data.append({
+                "error": str(e),
+            })
 
         return simplejson.dumps(data)


### PR DESCRIPTION
Improve error-handling for directories if you ask for JSON from
the /uri endpoint, but an error occurs (you get a proper HTTP
status code and a valid JSON object).

For 'tahoe magic-folder status' we now retrieve *all* the remote data
required in the CLI before doing anything else so that errors can be
shown immediately. Use the improved JSON endpoints to print better
errors.