### PR TITLE
make IServer.get_serverid() use pubkey, not tubid

### DIFF
--- a/src/allmydata/immutable/upload.py
+++ b/src/allmydata/immutable/upload.py
@@ -1323,6 +1323,9 @@ class AssistedUploader:
         now = time.time()
         timings["total"] = now - self._started
 
+        # Note: older Helpers (<=1.11) sent tubids as serverids. Newer ones
+        # send pubkeys. get_stub_server() knows how to map both into
+        # IDisplayableServer instances.
         gss = self._storage_broker.get_stub_server
         sharemap = {}
         servermap = {}

--- a/src/allmydata/test/test_storage_client.py
+++ b/src/allmydata/test/test_storage_client.py
@@ -49,8 +49,8 @@ class TestStorageFarmBroker(unittest.TestCase):
         }
         broker.got_static_announcement(key_s, ann, None)
         self.failUnlessEqual(len(broker.static_servers), 1)
-        self.failUnlessEqual(broker.servers['1'].announcement, ann)
-        self.failUnlessEqual(broker.servers['1'].key_s, key_s)
+        self.failUnlessEqual(broker.servers[key_s].announcement, ann)
+        self.failUnlessEqual(broker.servers[key_s].key_s, key_s)
 
     @inlineCallbacks
     def test_threshold_reached(self):

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -2437,7 +2437,7 @@ class Connections(SystemTestMixin, unittest.TestCase):
         def _start(ign):
             self.c0 = self.clients[0]
             nonclients = [s for s in self.c0.storage_broker.get_connected_servers()
-                          if s.get_serverid() != self.c0.nodeid]
+                          if s.get_serverid() != self.c0.get_long_nodeid()]
             self.failUnlessEqual(len(nonclients), 1)
 
             self.s1 = nonclients[0]  # s1 is the server, not c0

--- a/src/allmydata/web/root.py
+++ b/src/allmydata/web/root.py
@@ -300,13 +300,13 @@ class Root(rend.Page):
         return sorted(sb.get_known_servers(), key=lambda s: s.get_serverid())
 
     def render_service_row(self, ctx, server):
-        nodeid = server.get_serverid()
+        server_id = server.get_serverid()
 
         ctx.fillSlots("peerid", server.get_longname())
         ctx.fillSlots("nickname", server.get_nickname())
         rhost = server.get_remote_host()
         if server.is_connected():
-            if nodeid == self.client.nodeid:
+            if server_id == self.client.get_long_nodeid():
                 rhost_s = "(loopback)"
             elif isinstance(rhost, address.IPv4Address):
                 rhost_s = "%s:%d" % (rhost.host, rhost.port)

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1,5 +1,5 @@
 
-import pprint, itertools
+import pprint, itertools, hashlib
 import simplejson
 from twisted.internet import defer
 from nevow import rend, inevow, tags as T
@@ -597,10 +597,10 @@ class DownloadStatusPage(DownloadResultsRendererMixin, rend.Page):
         return l
 
     def color(self, server):
-        peerid = server.get_serverid() # binary
+        h = hashlib.sha256(server.get_serverid()).digest()
         def m(c):
             return min(ord(c) / 2 + 0x80, 0xff)
-        return "#%02x%02x%02x" % (m(peerid[0]), m(peerid[1]), m(peerid[2]))
+        return "#%02x%02x%02x" % (m(h[0]), m(h[1]), m(h[2]))
 
     def render_results(self, ctx, data):
         d = self.download_results()


### PR DESCRIPTION
This is a change I've wanted to make for many years, because when we get
to HTTP-based servers, we won't have tubids for them. What held me back
was that there's code all over the place that uses the serverid for
various purposes, so I wasn't sure it was safe. I did a big push a few
years ago to use IServer instances instead of serverids in most
places (in #1363), and to split out the values that actually depend upon
tubid into separate accessors (like get_lease_seed and
get_foolscap_write_enabler_seed), which I think took care of all the
important uses.

There are a number of places that use get_serverid() as dictionary key
to track shares (Checker results, mutable servermap). I believe these
are happy to use pubkeys instead of tubids: the only thing they do with
get_serverid() is to compare it to other values obtained from
get_serverid(). A few places in the WUI used serverid to compute display
values: these were fixed.

The main trouble was the Helper: it returns a HelperUploadResults (a
Copyable) with a share->server mapping that's keyed by whatever the
Helper's get_serverid() returns. If the uploader and the helper are on
different sides of this change, the Helper could return values that the
uploader won't recognize. This is cosmetic: that mapping is only used to
display the upload results on the "Recent and Active Operations" page.
I've added code to StorageFarmBroker.get_stub_server() to fall back to
tubids when looking up a server, so this should still work correctly
when the uploader is new and the Helper is old. If the Helper is new and
the uploader is old, the upload results will show unusual server ids.

refs ticket:1363