### PR TITLE
Disable foolscap "gifts"

### DIFF
--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -266,6 +266,7 @@ class Node(service.MultiService):
             "logLocalFailures": True,
             "logRemoteFailures": True,
             "expose-remote-exception-types": False,
+            "accept-gifts": False,
             }
 
         # see #521 for a discussion of how to pick these timeout values.


### PR DESCRIPTION
"gifts" are third-party references (where Alice sends Bob a reference to
Carol, and Carol lives in a different Tub than either Alice or Bob).
Tahoe doesn't currently use these, and they make it possible for e.g. a
server to provoke a client into making a connection to an IP address of
the server's choosing. If the client isn't configured otherwise, this
would use raw TCP (revealing the client's IP address) even if the
connection to the server used Tor.

A connection policy of `tcp: tor` would block this, but it seems like a
good idea to disable gifts entirely.

closes ticket:2810