### PR TITLE
1010 config flag

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -324,6 +324,23 @@ set the ``tub.location`` option described below.
     used for files that usually (on a Unix system) go into ``/tmp``. The
     string will be interpreted relative to the node's base directory.
 
+``reveal-IP-address = (boolean, optional, defaults to True)``
+
+    This is a safety flag. If False, any of the following configuration
+    problems will cause ``tahoe start`` to throw a PrivacyError instead of
+    starting the node:
+
+    * ``[node] tub.location`` contains any ``tcp:`` hints
+
+    * ``[node] tub.location`` uses ``AUTO``, or is missing/empty (because
+      that defaults to AUTO)
+
+    * ``[connections] tcp =`` is set to ``tcp`` (or left as the default),
+      rather than being set to ``tor``
+
+    These configuration problems would reveal the node's IP address to
+    servers and external networks.
+
 
 Connection Management
 =====================
@@ -333,6 +350,10 @@ Tahoe node makes outbound connections. Tor and I2P are configured here. This
 also controls when Tor and I2P are used: for all TCP connections (to hide
 your IP address), or only when necessary (just for servers which declare that
 they need Tor, because they use ``.onion`` addresses).
+
+Note that if you want to protect your node's IP address, you should set
+``[node] reveal-IP-address = False``, which will refuse to launch the node if
+any of the other configuration settings might violate this privacy property.
 
 ``[connections]``
 -----------------

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -29,6 +29,12 @@ class Tor(unittest.TestCase):
         h = n._make_tor_handler()
         self.assertEqual(h, None)
 
+    def test_unimportable(self):
+        n = FakeNode(BASECONFIG)
+        with mock.patch("allmydata.node._import_tor", return_value=None):
+            h = n._make_tor_handler()
+        self.assertEqual(h, None)
+
     def test_default(self):
         n = FakeNode(BASECONFIG)
         h1 = mock.Mock()
@@ -107,6 +113,12 @@ class I2P(unittest.TestCase):
     def test_disabled(self):
         n = FakeNode(BASECONFIG+"[i2p]\nenable = false\n")
         h = n._make_i2p_handler()
+        self.assertEqual(h, None)
+
+    def test_unimportable(self):
+        n = FakeNode(BASECONFIG)
+        with mock.patch("allmydata.node._import_i2p", return_value=None):
+            h = n._make_i2p_handler()
         self.assertEqual(h, None)
 
     def test_default(self):
@@ -203,6 +215,15 @@ class Connections(unittest.TestCase):
         self.assertEqual(n._default_connection_handlers["tcp"], "tor")
         self.assertEqual(n._default_connection_handlers["tor"], "tor")
         self.assertEqual(n._default_connection_handlers["i2p"], "i2p")
+
+    def test_tor_unimportable(self):
+        n = FakeNode(BASECONFIG+"[connections]\ntcp = tor\n")
+        with mock.patch("allmydata.node._import_tor", return_value=None):
+            e = self.assertRaises(ValueError, n.init_connections)
+        self.assertEqual(str(e),
+                         "'tahoe.cfg [connections] tcp='"
+                         " uses unavailable/unimportable handler type 'tor'."
+                         " Please pip install tahoe-lafs[tor] to fix.")
 
     def test_unknown(self):
         n = FakeNode(BASECONFIG+"[connections]\ntcp = unknown\n")


### PR DESCRIPTION
This adds a safety flag named `[node] reveal-IP-address`, for which the default value is True. When this is set to False, any configuration that might reveal the node's IP address (to servers, or the external network) will cause a PrivacyError to be raised at startup, terminating the node before it gets a chance to betray the user's privacy. It also adds docs and tests.

There's also a commit which throw a startup error if you've configured TCP hints to use Tor, but tor support was unavailable (because `txtorcon` wasn't installed).

This is for [tahoe#1010](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1010).
