### PR TITLE
create-node: add --hide-ip, update docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -336,9 +336,20 @@ set the ``tub.location`` option described below.
 
 ``reveal-IP-address = (boolean, optional, defaults to True)``
 
-    This is a safety flag. If False, any of the following configuration
-    problems will cause ``tahoe start`` to throw a PrivacyError instead of
-    starting the node:
+    This is a safety flag. When set to False (aka "private mode"), the node
+    will refuse to start if any of the other configuration options would
+    reveal the node's IP address to servers or the external network. This
+    flag does not directly affect the node's behavior: its only power is to
+    veto node startup when something looks unsafe.
+
+    The default is True (non-private mode), because setting it to False
+    requires the installation of additional libraries (use ``pip install
+    tahoe-lafs[tor]`` and/or ``pip install tahoe-lafs[i2p]`` to get them) as
+    well as additional non-python software (Tor/I2P daemons). Performance is
+    also generally reduced when operating in private mode.
+
+    When False, any of the following configuration problems will cause
+    ``tahoe start`` to throw a PrivacyError instead of starting the node:
 
     * ``[node] tub.location`` contains any ``tcp:`` hints
 
@@ -347,9 +358,6 @@ set the ``tub.location`` option described below.
 
     * ``[connections] tcp =`` is set to ``tcp`` (or left as the default),
       rather than being set to ``tor``
-
-    These configuration problems would reveal the node's IP address to
-    servers and external networks.
 
 
 Connection Management

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -373,7 +373,15 @@ class Node(service.MultiService):
                                       for ip in local_addresses])
             else:
                 if not self._reveal_ip:
-                    hint_type = loc.split(":")[0]
+                    # Legacy hints are "host:port". We use Foolscap's utility
+                    # function to convert all hints into the modern format
+                    # ("tcp:host:port") because that's what the receiving
+                    # client will probably do. We test the converted hint for
+                    # TCP-ness, but publish the original hint because that
+                    # was the user's intent.
+                    from foolscap.connections.tcp import convert_legacy_hint
+                    converted_hint = convert_legacy_hint(loc)
+                    hint_type = converted_hint.split(":")[0]
                     if hint_type == "tcp":
                         raise PrivacyError("tub.location includes tcp: hint")
                 new_locations.append(loc)

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -20,6 +20,9 @@ def write_tac(basedir, nodetype):
 
 
 class _CreateBaseOptions(BasedirOptions):
+    optFlags = [
+        ("hide-ip", None, "prohibit any configuration that would reveal the node's IP address"),
+        ]
     optParameters = [
         # we provide 'create-node'-time options for the most common
         # configuration knobs. The rest can be controlled by editing
@@ -52,6 +55,9 @@ class CreateNodeOptions(CreateClientOptions):
 class CreateIntroducerOptions(NoDefaultBasedirOptions):
     subcommand_name = "create-introducer"
     description = "Create a Tahoe-LAFS introducer."
+    optFlags = [
+        ("hide-ip", None, "prohibit any configuration that would reveal the node's IP address"),
+        ]
 
 
 def write_node_config(c, config):
@@ -68,6 +74,10 @@ def write_node_config(c, config):
     c.write("[node]\n")
     nickname = argv_to_unicode(config.get("nickname") or "")
     c.write("nickname = %s\n" % (nickname.encode('utf-8'),))
+    if config["hide-ip"]:
+        c.write("reveal-IP-address = false\n")
+    else:
+        c.write("reveal-IP-address = true\n")
 
     # TODO: validate webport
     webport = argv_to_unicode(config.get("webport") or "none")

--- a/src/allmydata/test/cli/test_create.py
+++ b/src/allmydata/test/cli/test_create.py
@@ -1,0 +1,54 @@
+import os
+from StringIO import StringIO
+from twisted.trial import unittest
+from allmydata.scripts import runner
+from allmydata.util import configutil
+
+class Config(unittest.TestCase):
+    def do_cli(self, *args):
+        argv = list(args)
+        stdout, stderr = StringIO(), StringIO()
+        rc = runner.runner(argv, run_by_human=False,
+                           stdout=stdout, stderr=stderr)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def read_config(self, basedir):
+        tahoe_cfg = os.path.join(basedir, "tahoe.cfg")
+        config = configutil.get_config(tahoe_cfg)
+        return config
+
+    def test_client(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-client", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), True)
+
+    def test_client_hide_ip(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-client", "--hide-ip", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), False)
+
+    def test_node(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-node", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), True)
+
+    def test_node_hide_ip(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-node", "--hide-ip", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), False)
+
+    def test_introducer(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-introducer", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), True)
+
+    def test_introducer_hide_ip(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-introducer", "--hide-ip", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), False)

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -295,4 +295,12 @@ class Privacy(unittest.TestCase):
                               None, "tcp:hostname:1234")
         self.assertEqual(str(e), "tub.location includes tcp: hint")
 
+    def test_tub_location_legacy_tcp(self):
+        n = FakeNode(BASECONFIG+"[node]\nreveal-IP-address = false\n")
+        n._portnumfile = "missing"
+        n.check_privacy()
+        e = self.assertRaises(PrivacyError, n.get_tub_portlocation,
+                              None, "hostname:1234")
+        self.assertEqual(str(e), "tub.location includes tcp: hint")
+
 


### PR DESCRIPTION
So "tahoe create-node --hide-ip" causes "reveal-IP-address = false" to
get written into tahoe.cfg . This also changes the default tahoe.cfg to
include "reveal-IP-address = true", for clarity.

refs ticket:1010