### PR TITLE
Make the grid status display the location hints

### DIFF
--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -413,7 +413,7 @@ class NativeStorageServer(service.MultiService):
                 level=log.NOISY, parent=lp)
 
         self.last_connect_time = time.time()
-        self.remote_host = rref.getPeer()
+        self.remote_host = rref.getLocationHints()
         self.rref = rref
         self._is_connected = True
         rref.notifyOnDisconnect(self._lost)


### PR DESCRIPTION
Instead of displaying what appears to be the remote peer address
we display the list of connection hints.

closes ticket:2818