### PR TITLE
Add Tor and I2p options for storage and introducer servers

### DIFF
--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -20,6 +20,9 @@ def write_tac(basedir, nodetype):
 
 
 class _CreateBaseOptions(BasedirOptions):
+    optFlags = [
+        ("hide-ip", None, "prohibit any configuration that would reveal the node's IP address"),
+        ]
     optParameters = [
         # we provide 'create-node'-time options for the most common
         # configuration knobs. The rest can be controlled by editing
@@ -52,6 +55,9 @@ class CreateNodeOptions(CreateClientOptions):
 class CreateIntroducerOptions(NoDefaultBasedirOptions):
     subcommand_name = "create-introducer"
     description = "Create a Tahoe-LAFS introducer."
+    optFlags = [
+        ("hide-ip", None, "prohibit any configuration that would reveal the node's IP address"),
+        ]
 
 
 def write_node_config(c, config):
@@ -68,6 +74,10 @@ def write_node_config(c, config):
     c.write("[node]\n")
     nickname = argv_to_unicode(config.get("nickname") or "")
     c.write("nickname = %s\n" % (nickname.encode('utf-8'),))
+    if config["hide-ip"]:
+        c.write("reveal-IP-address = false\n")
+    else:
+        c.write("reveal-IP-address = true\n")
 
     # TODO: validate webport
     webport = argv_to_unicode(config.get("webport") or "none")

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -1,6 +1,7 @@
 
 import os, sys
 from twisted.python import usage
+from twisted.internet.protofol import Protocol
 
 from allmydata.scripts.common import BasedirOptions, NoDefaultBasedirOptions
 from allmydata.scripts.default_nodedir import _default_nodedir
@@ -141,6 +142,19 @@ def write_node_config(c, config):
     elif config['location']:
         c.write("tub.port = %s\n" % config.get('port').encode('utf-8'))
         c.write("tub.location = %s\n" % config.get('location').encode('utf-8'))
+    elif config['listen-tor']:
+        if config['tor-controlport']:
+            # use system tor
+            hs_port = iputil.allocate_tcp_port()
+            hs_string = '%s 127.0.0.1:%d' % (hs_public_port, hs_port)
+            hs = txtorcon.EphemeralHiddenService([hs_string])
+            d = hs.add_to_tor(Protocol())
+            # XXX how to fix?
+        else:
+            # XXX todo: launch a new tor
+            pass
+    elif config['listen-i2p']:
+        pass # XXX fix me
     else:
         c.write("tub.port = disabled\n")
         c.write("tub.location = disabled\n")

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -30,6 +30,7 @@ class _CreateBaseOptions(BasedirOptions):
         # we provide 'create-node'-time options for the most common
         # configuration knobs. The rest can be controlled by editing
         # tahoe.cfg before node startup.
+        ("hostname", "", None, "Specify the hostname for listening and advertising for this node."),
         ("location", "", None, "Specify the location to advertise for this node."),
         ("port", "", None, "Specify the server endpoint to listen on for this node."),
         ("nickname", "n", None, "Specify the nickname for this node."),
@@ -45,8 +46,11 @@ class _CreateBaseOptions(BasedirOptions):
     # arguments." error when more than one argument is given.
     def parseArgs(self, basedir=None):
         BasedirOptions.parseArgs(self, basedir)
-        if (self['listen-tor'] or self['listen-i2p']) and (self['port'] or self['location']):
-            raise usage.UsageError("The --listen-tor or --listen-i2p option cannot be used with --port or --location options.")
+        if self['hostname'] and (self['port'] or self['location']):
+            raise usage.UsageError("The --hostname option cannot be used with --port or --location options.")
+        if (self['listen-tor'] or self['listen-i2p']) and (self['port'] or self['location'] or self['hostname']):
+            raise usage.UsageError("The --listen-tor or --listen-i2p option cannot be used with\n" +
+                                   "--port or --location or --hostname options.")
 
 class CreateClientOptions(_CreateBaseOptions):
     synopsis = "[options] [NODEDIR]"
@@ -68,14 +72,18 @@ class CreateIntroducerOptions(NoDefaultBasedirOptions):
         ("listen-tor", None, "Specify that this node listens using a Tor onions service."),
     ]
     optParameters = [
+        ("hostname", "", None, "Specify the hostname for listening and advertising for this node."),
         ("location", "", None, "Specify the location to advertise for this node."),
         ("port", "", None, "Specify the server endpoint to listen on for this node."),
     ]
 
     def parseArgs(self, basedir=None):
         NoDefaultBasedirOptions.parseArgs(self, basedir)
-        if (self['listen-tor'] or self['listen-i2p']) and (self['port'] or self['location']):
-            raise usage.UsageError("The --listen-tor or --listen-i2p option cannot be used with --port or --location options.")
+        if self['hostname'] and (self['port'] or self['location']):
+            raise usage.UsageError("The --hostname option cannot be used with --port or --location options.")
+        if (self['listen-tor'] or self['listen-i2p']) and (self['port'] or self['location'] or self['hostname']):
+            raise usage.UsageError("The --listen-tor or --listen-i2p option cannot be used with\n" +
+                                   "--port or --location or --hostname options.")
 
 
 def write_node_config(c, config):

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -1,5 +1,6 @@
 
 import os, sys
+from twisted.python import usage
 
 from allmydata.scripts.common import BasedirOptions, NoDefaultBasedirOptions
 from allmydata.scripts.default_nodedir import _default_nodedir
@@ -22,11 +23,15 @@ def write_tac(basedir, nodetype):
 class _CreateBaseOptions(BasedirOptions):
     optFlags = [
         ("hide-ip", None, "prohibit any configuration that would reveal the node's IP address"),
-        ]
+        ("listen-i2p", None, "Specify that this node listens using an I2p service."),
+        ("listen-tor", None, "Specify that this node listens using a Tor onions service."),
+    ]
     optParameters = [
         # we provide 'create-node'-time options for the most common
         # configuration knobs. The rest can be controlled by editing
         # tahoe.cfg before node startup.
+        ("location", "", None, "Specify the location to advertise for this node."),
+        ("port", "", None, "Specify the server endpoint to listen on for this node."),
         ("nickname", "n", None, "Specify the nickname for this node."),
         ("introducer", "i", None, "Specify the introducer FURL to use."),
         ("webport", "p", "tcp:3456:interface=127.0.0.1",
@@ -40,6 +45,8 @@ class _CreateBaseOptions(BasedirOptions):
     # arguments." error when more than one argument is given.
     def parseArgs(self, basedir=None):
         BasedirOptions.parseArgs(self, basedir)
+        if (self['listen-tor'] or self['listen-i2p']) and (self['port'] or self['location']):
+            raise usage.UsageError("The --listen-tor or --listen-i2p option cannot be used with --port or --location options.")
 
 class CreateClientOptions(_CreateBaseOptions):
     synopsis = "[options] [NODEDIR]"
@@ -57,7 +64,18 @@ class CreateIntroducerOptions(NoDefaultBasedirOptions):
     description = "Create a Tahoe-LAFS introducer."
     optFlags = [
         ("hide-ip", None, "prohibit any configuration that would reveal the node's IP address"),
-        ]
+        ("listen-i2p", None, "Specify that this node listens using an I2p service."),
+        ("listen-tor", None, "Specify that this node listens using a Tor onions service."),
+    ]
+    optParameters = [
+        ("location", "", None, "Specify the location to advertise for this node."),
+        ("port", "", None, "Specify the server endpoint to listen on for this node."),
+    ]
+
+    def parseArgs(self, basedir=None):
+        NoDefaultBasedirOptions.parseArgs(self, basedir)
+        if (self['listen-tor'] or self['listen-i2p']) and (self['port'] or self['location']):
+            raise usage.UsageError("The --listen-tor or --listen-i2p option cannot be used with --port or --location options.")
 
 
 def write_node_config(c, config):

--- a/src/allmydata/test/cli/test_create.py
+++ b/src/allmydata/test/cli/test_create.py
@@ -1,0 +1,54 @@
+import os
+from StringIO import StringIO
+from twisted.trial import unittest
+from allmydata.scripts import runner
+from allmydata.util import configutil
+
+class Config(unittest.TestCase):
+    def do_cli(self, *args):
+        argv = list(args)
+        stdout, stderr = StringIO(), StringIO()
+        rc = runner.runner(argv, run_by_human=False,
+                           stdout=stdout, stderr=stderr)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def read_config(self, basedir):
+        tahoe_cfg = os.path.join(basedir, "tahoe.cfg")
+        config = configutil.get_config(tahoe_cfg)
+        return config
+
+    def test_client(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-client", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), True)
+
+    def test_client_hide_ip(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-client", "--hide-ip", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), False)
+
+    def test_node(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-node", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), True)
+
+    def test_node_hide_ip(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-node", "--hide-ip", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), False)
+
+    def test_introducer(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-introducer", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), True)
+
+    def test_introducer_hide_ip(self):
+        basedir = self.mktemp()
+        rc, out, err = self.do_cli("create-introducer", "--hide-ip", basedir)
+        cfg = self.read_config(basedir)
+        self.assertEqual(cfg.getboolean("node", "reveal-IP-address"), False)


### PR DESCRIPTION

Here I'm making gradual progress to satisfy the tahoe trac ticket https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2773

`tahoe create-node` should require `--location` and/or `--hostname`, and not autodetect