### PR TITLE
2597.windows integration.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
 script:
   - tox -e codechecks
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then tox; else tox -e coverage; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then tox -e integration; fi
 after_success:
   coveralls
 notifications:

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -66,14 +66,6 @@ def temp_dir(request):
 
 
 @pytest.fixture(scope='session')
-def tahoe_binary():
-    """
-    Finds the 'tahoe' binary, yields complete path
-    """
-    return which('tahoe')
-
-
-@pytest.fixture(scope='session')
 def flog_binary():
     return which('flogtool')
 
@@ -224,7 +216,7 @@ def flog_gatherer(reactor, temp_dir, flog_binary, request):
 
 
 @pytest.fixture(scope='session')
-def introducer(reactor, temp_dir, tahoe_binary, flog_gatherer, request):
+def introducer(reactor, temp_dir, flog_gatherer, request):
     config = '''
 [node]
 nickname = introducer0
@@ -240,8 +232,8 @@ log_gatherer.furl = {log_furl}
         done_proto = _ProcessExitedProtocol()
         reactor.spawnProcess(
             done_proto,
-            tahoe_binary,
-            ('tahoe', 'create-introducer', '--listen=tcp', '--hostname=localhost', intro_dir),
+            sys.executable,
+            ('python', '-m', 'allmydata.scripts.runner', 'create-introducer', '--listen=tcp', '--hostname=localhost', intro_dir),
         )
         pytest.blockon(done_proto.done)
 
@@ -255,8 +247,8 @@ log_gatherer.furl = {log_furl}
     protocol = _MagicTextProtocol('introducer running')
     process = reactor.spawnProcess(
         protocol,
-        tahoe_binary,
-        ('tahoe', 'run', intro_dir),
+        sys.executable,
+        ('python', '-m', 'allmydata.scripts.runner', 'run', intro_dir),
     )
 
     def cleanup():
@@ -281,7 +273,7 @@ def introducer_furl(introducer, temp_dir):
     return furl
 
 
-def _run_node(reactor, tahoe_binary, node_dir, request, magic_text):
+def _run_node(reactor, node_dir, request, magic_text):
     if magic_text is None:
         magic_text = "client running"
     protocol = _MagicTextProtocol(magic_text)
@@ -291,9 +283,10 @@ def _run_node(reactor, tahoe_binary, node_dir, request, magic_text):
     # between platforms.
     process = reactor.spawnProcess(
         protocol,
-        tahoe_binary,
-        ('tahoe', 'run', node_dir),
+        sys.executable,
+        ('python', '-m', 'allmydata.scripts.runner', 'run', node_dir),
     )
+    process.exited = protocol.exited
 
     def cleanup():
         try:
@@ -309,7 +302,7 @@ def _run_node(reactor, tahoe_binary, node_dir, request, magic_text):
     return protocol.magic_seen
 
 
-def _create_node(reactor, request, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, name, web_port, storage=True, magic_text=None):
+def _create_node(reactor, request, temp_dir, introducer_furl, flog_gatherer, name, web_port, storage=True, magic_text=None):
     """
     Helper to create a single node, run it and return the instance
     spawnProcess returned (ITransport)
@@ -322,7 +315,7 @@ def _create_node(reactor, request, temp_dir, tahoe_binary, introducer_furl, flog
         mkdir(node_dir)
         done_proto = _ProcessExitedProtocol()
         args = [
-            'tahoe',
+            'python', '-m', 'allmydata.scripts.runner',
             'create-node',
             '--nickname', name,
             '--introducer', introducer_furl,
@@ -335,7 +328,7 @@ def _create_node(reactor, request, temp_dir, tahoe_binary, introducer_furl, flog
 
         reactor.spawnProcess(
             done_proto,
-            tahoe_binary,
+            sys.executable,
             args,
         )
         pytest.blockon(done_proto.done)
@@ -362,11 +355,11 @@ shares.total = 4
     'log_furl': flog_gatherer,
 })
 
-    return _run_node(reactor, tahoe_binary, node_dir, request, magic_text)
+    return _run_node(reactor, node_dir, request, magic_text)
 
 
 @pytest.fixture(scope='session')
-def storage_nodes(reactor, temp_dir, tahoe_binary, introducer, introducer_furl, flog_gatherer, request):
+def storage_nodes(reactor, temp_dir, introducer, introducer_furl, flog_gatherer, request):
     nodes = []
     # start all 5 nodes in parallel
     for x in range(5):
@@ -375,7 +368,7 @@ def storage_nodes(reactor, temp_dir, tahoe_binary, introducer, introducer_furl, 
         nodes.append(
             pytest.blockon(
                 _create_node(
-                    reactor, request, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, name,
+                    reactor, request, temp_dir, introducer_furl, flog_gatherer, name,
                     web_port=None, storage=True,
                 )
             )
@@ -385,7 +378,7 @@ def storage_nodes(reactor, temp_dir, tahoe_binary, introducer, introducer_furl, 
 
 
 @pytest.fixture(scope='session')
-def alice(reactor, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, storage_nodes, request):
+def alice(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, request):
     try:
         mkdir(join(temp_dir, 'magic-alice'))
     except OSError:
@@ -393,7 +386,7 @@ def alice(reactor, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, stora
 
     process = pytest.blockon(
         _create_node(
-            reactor, request, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, "alice",
+            reactor, request, temp_dir, introducer_furl, flog_gatherer, "alice",
             web_port="tcp:9980:interface=localhost",
             storage=False,
         )
@@ -402,7 +395,7 @@ def alice(reactor, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, stora
 
 
 @pytest.fixture(scope='session')
-def bob(reactor, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, storage_nodes, request):
+def bob(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, request):
     try:
         mkdir(join(temp_dir, 'magic-bob'))
     except OSError:
@@ -410,7 +403,7 @@ def bob(reactor, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, storage
 
     process = pytest.blockon(
         _create_node(
-            reactor, request, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, "bob",
+            reactor, request, temp_dir, introducer_furl, flog_gatherer, "bob",
             web_port="tcp:9981:interface=localhost",
             storage=False,
         )
@@ -419,7 +412,7 @@ def bob(reactor, temp_dir, tahoe_binary, introducer_furl, flog_gatherer, storage
 
 
 @pytest.fixture(scope='session')
-def alice_invite(reactor, alice, tahoe_binary, temp_dir, request):
+def alice_invite(reactor, alice, temp_dir, request):
     node_dir = join(temp_dir, 'alice')
 
     # FIXME XXX by the time we see "client running" in the logs, the
@@ -429,9 +422,10 @@ def alice_invite(reactor, alice, tahoe_binary, temp_dir, request):
     proto = _CollectOutputProtocol()
     transport = reactor.spawnProcess(
         proto,
-        tahoe_binary,
+        sys.executable,
         [
-            'tahoe', 'magic-folder', 'create',
+            'python', '-m', 'allmydata.scripts.runner',
+            'magic-folder', 'create',
             '--basedir', node_dir, 'magik:', 'alice',
             join(temp_dir, 'magic-alice'),
         ]
@@ -441,9 +435,10 @@ def alice_invite(reactor, alice, tahoe_binary, temp_dir, request):
     proto = _CollectOutputProtocol()
     transport = reactor.spawnProcess(
         proto,
-        tahoe_binary,
+        sys.executable,
         [
-            'tahoe', 'magic-folder', 'invite',
+            'python', '-m', 'allmydata.scripts.runner',
+            'magic-folder', 'invite',
             '--basedir', node_dir, 'magik:', 'bob',
         ]
     )
@@ -453,31 +448,27 @@ def alice_invite(reactor, alice, tahoe_binary, temp_dir, request):
 
     # before magic-folder works, we have to stop and restart (this is
     # crappy for the tests -- can we fix it in magic-folder?)
-    proto = _CollectOutputProtocol()
-    transport = reactor.spawnProcess(
-        proto,
-        tahoe_binary,
-        [
-            'tahoe', 'stop', node_dir
-        ]
-    )
-    pytest.blockon(proto.done)
-
+    try:
+        alice.signalProcess('TERM')
+        pytest.blockon(alice.exited)
+    except ProcessExitedAlready:
+        pass
     magic_text = 'Completed initial Magic Folder scan successfully'
-    pytest.blockon(_run_node(reactor, tahoe_binary, node_dir, request, magic_text))
+    pytest.blockon(_run_node(reactor, node_dir, request, magic_text))
     return invite
 
 
 @pytest.fixture(scope='session')
-def magic_folder(reactor, alice_invite, alice, bob, tahoe_binary, temp_dir, request):
+def magic_folder(reactor, alice_invite, alice, bob, temp_dir, request):
     print("pairing magic-folder")
     bob_dir = join(temp_dir, 'bob')
     proto = _CollectOutputProtocol()
     transport = reactor.spawnProcess(
         proto,
-        tahoe_binary,
+        sys.executable,
         [
-            'tahoe', 'magic-folder', 'join',
+            'python', '-m', 'allmydata.scripts.runner',
+            'magic-folder', 'join',
             '--basedir', bob_dir,
             alice_invite,
             join(temp_dir, 'magic-bob'),
@@ -487,16 +478,13 @@ def magic_folder(reactor, alice_invite, alice, bob, tahoe_binary, temp_dir, requ
 
     # before magic-folder works, we have to stop and restart (this is
     # crappy for the tests -- can we fix it in magic-folder?)
-    proto = _CollectOutputProtocol()
-    transport = reactor.spawnProcess(
-        proto,
-        tahoe_binary,
-        [
-            'tahoe', 'stop', bob_dir
-        ]
-    )
-    pytest.blockon(proto.done)
+    try:
+        print("Sending TERM to Bob")
+        bob.signalProcess('TERM')
+        pytest.blockon(bob.exited)
+    except ProcessExitedAlready:
+        pass
 
     magic_text = 'Completed initial Magic Folder scan successfully'
-    pytest.blockon(_run_node(reactor, tahoe_binary, bob_dir, request, magic_text))
+    pytest.blockon(_run_node(reactor, bob_dir, request, magic_text))
     return (join(temp_dir, 'magic-alice'), join(temp_dir, 'magic-bob'))

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -241,7 +241,7 @@ log_gatherer.furl = {log_furl}
         reactor.spawnProcess(
             done_proto,
             tahoe_binary,
-            ('tahoe', 'create-introducer', intro_dir),
+            ('tahoe', 'create-introducer', '--listen=tcp', '--hostname=localhost', intro_dir),
         )
         pytest.blockon(done_proto.done)
 
@@ -326,6 +326,8 @@ def _create_node(reactor, request, temp_dir, tahoe_binary, introducer_furl, flog
             'create-node',
             '--nickname', name,
             '--introducer', introducer_furl,
+            '--hostname', 'localhost',
+            '--listen', 'tcp',
         ]
         if not storage:
             args.append('--no-storage')

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -233,7 +233,13 @@ log_gatherer.furl = {log_furl}
         reactor.spawnProcess(
             done_proto,
             sys.executable,
-            ('python', '-m', 'allmydata.scripts.runner', 'create-introducer', '--listen=tcp', '--hostname=localhost', intro_dir),
+            (
+                sys.executable, '-m', 'allmydata.scripts.runner',
+                'create-introducer',
+                '--listen=tcp',
+                '--hostname=localhost',
+                intro_dir,
+            ),
         )
         pytest.blockon(done_proto.done)
 
@@ -248,7 +254,11 @@ log_gatherer.furl = {log_furl}
     process = reactor.spawnProcess(
         protocol,
         sys.executable,
-        ('python', '-m', 'allmydata.scripts.runner', 'run', intro_dir),
+        (
+            sys.executable, '-m', 'allmydata.scripts.runner',
+            'run',
+            intro_dir,
+        ),
     )
 
     def cleanup():
@@ -284,7 +294,11 @@ def _run_node(reactor, node_dir, request, magic_text):
     process = reactor.spawnProcess(
         protocol,
         sys.executable,
-        ('python', '-m', 'allmydata.scripts.runner', 'run', node_dir),
+        (
+            sys.executable, '-m', 'allmydata.scripts.runner',
+            'run',
+            node_dir,
+        ),
     )
     process.exited = protocol.exited
 
@@ -315,7 +329,7 @@ def _create_node(reactor, request, temp_dir, introducer_furl, flog_gatherer, nam
         mkdir(node_dir)
         done_proto = _ProcessExitedProtocol()
         args = [
-            'python', '-m', 'allmydata.scripts.runner',
+            sys.executable, '-m', 'allmydata.scripts.runner',
             'create-node',
             '--nickname', name,
             '--introducer', introducer_furl,
@@ -424,7 +438,7 @@ def alice_invite(reactor, alice, temp_dir, request):
         proto,
         sys.executable,
         [
-            'python', '-m', 'allmydata.scripts.runner',
+            sys.executable, '-m', 'allmydata.scripts.runner',
             'magic-folder', 'create',
             '--basedir', node_dir, 'magik:', 'alice',
             join(temp_dir, 'magic-alice'),
@@ -437,7 +451,7 @@ def alice_invite(reactor, alice, temp_dir, request):
         proto,
         sys.executable,
         [
-            'python', '-m', 'allmydata.scripts.runner',
+            sys.executable, '-m', 'allmydata.scripts.runner',
             'magic-folder', 'invite',
             '--basedir', node_dir, 'magik:', 'bob',
         ]
@@ -467,7 +481,7 @@ def magic_folder(reactor, alice_invite, alice, bob, temp_dir, request):
         proto,
         sys.executable,
         [
-            'python', '-m', 'allmydata.scripts.runner',
+            sys.executable, '-m', 'allmydata.scripts.runner',
             'magic-folder', 'join',
             '--basedir', bob_dir,
             alice_invite,

--- a/integration/test_smoke.py
+++ b/integration/test_smoke.py
@@ -177,7 +177,7 @@ def test_bob_conflicts_with_alice_preexisting(magic_folder):
     # this one by giving him a massive head start
     with open(join(bob_dir, 'beta'), 'w') as f:
         f.write("this is bob's beta\n")
-    time.sleep(0.2)
+    time.sleep(0.5)
     with open(join(alice_dir, 'beta'), 'w') as f:
         f.write("this is alice's beta\n")
 

--- a/integration/test_smoke.py
+++ b/integration/test_smoke.py
@@ -114,9 +114,6 @@ def test_bob_creates_alice_deletes_bob_restores(magic_folder):
         "bob wrote this again, because reasons",
     )
 
-    # fix the conflict
-    shutil.move(join(alice_dir, "boom.conflict"), join(alice_dir, "boom"))
-
 
 def test_bob_creates_alice_deletes_alice_restores(magic_folder):
     alice_dir, bob_dir = magic_folder

--- a/integration/util.py
+++ b/integration/util.py
@@ -2,7 +2,7 @@ import time
 from os.path import exists
 
 
-def await_file_contents(path, contents, timeout=10):
+def await_file_contents(path, contents, timeout=15):
     start_time = time.time()
     while time.time() - start_time < timeout:
         print("  waiting for '{}'".format(path))

--- a/integration/util.py
+++ b/integration/util.py
@@ -7,13 +7,17 @@ def await_file_contents(path, contents, timeout=10):
     while time.time() - start_time < timeout:
         print("  waiting for '{}'".format(path))
         if exists(path):
-            with open(path, 'r') as f:
-                current = f.read()
-            if current == contents:
-                return True
-            print("  file contents still mismatched")
-            print("  wanted: {}".format(contents.replace('\n', ' ')))
-            print("     got: {}".format(current.replace('\n', ' ')))
+            try:
+                with open(path, 'r') as f:
+                    current = f.read()
+            except IOError:
+                print("IOError; trying again")
+            else:
+                if current == contents:
+                    return True
+                print("  file contents still mismatched")
+                print("  wanted: {}".format(contents.replace('\n', ' ')))
+                print("     got: {}".format(current.replace('\n', ' ')))
         time.sleep(1)
     if exists(path):
         raise Exception("Contents of '{}' mismatched after {}s".format(path, timeout))

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 
 [testenv:integration]
 commands =
-	 echo 'run with "py.test --keep-tempdir -s -v integration/" to debug failures'
+	 # NOTE: 'run with "py.test --keep-tempdir -s -v integration/" to debug failures'
 	 py.test -v integration/
 
 [testenv:coverage]


### PR DESCRIPTION
Fixes integration tests to run properly on windows. Killing subprocesses might be NP-Hard on windows, I think. In any case, the `tahoe.exe` things generated by `pip` don't correctly kill their own subprocess ("or something") so I bypass that by running via `python -m allmydata.scripts.runner` ... which is non-ideal from integration test perspective, but on the upside it works.

I also had to lengthen the default timeouts a bit, at least for my VM.

I added `tox -e integration` to the travis config to see if travis will run these against this PR. "Exercise for the merge" if we actually want that longer-term (I can rebase it out if you want).