### PR TITLE
Fix: Make Dockerfile actually build a tahoe binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ADD . /tahoe-lafs
 RUN \
   cd /tahoe-lafs && \
   git pull --depth=100 && \
-  pip install .
+  pip install . && \
+  rm -rf ~/.cache/
 
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ADD . /tahoe-lafs
 RUN \
   cd /tahoe-lafs && \
   git pull --depth=100 && \
-  make && \
-  ln -vs /tahoe-lafs/bin/tahoe /usr/local/bin/tahoe
+  pip install .
 
 WORKDIR /root


### PR DESCRIPTION
As I've started to use 1.11 Docker image, I've found no tahoe binary. However, the image build succeeds, so no image build error notification is sent. ```:latest``` (devel) tag is also affected, but 1.10 image tag has a working binary.
```
docker run --rm -it tahoelafs/base:1.11 bash
root@384ea29ff8e0:~# tahoe
bash: tahoe: command not found
```

The cause is that ```make``` no longer builds and, added to that, the default target does not returns a non-zero exit code, so the build apparently succeeds.
Fixed it updating the Dockerfile to build with ```pip install .```, but skipping all the virtenv stuff.
Also, perhaps an ```exit -1``` at the default make target would be in order, if make is used again to build the Docker image. 