### PR TITLE
appveyor: no longer need to use tox from upstream git

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,14 +11,10 @@ environment:
     #  DISTUTILS_USE_SDK: "1"
     #  TOX_TESTENV_PASSENV: "DISTUTILS_USE_SDK INCLUDE LIB"
 
-# tox-2.3.1 has a windows bug (#314), fixed in git but not yet released. When
-# the next release comes out, replace this with just:
-#   %PYTHON%\python.exe -m pip install wheel tox
-
 install:
   - |
-    %PYTHON%\python.exe -m pip install -U pip virtualenv
-    %PYTHON%\python.exe -m pip install wheel git+https://github.com/tox-dev/tox
+    %PYTHON%\python.exe -m pip install -U pip
+    %PYTHON%\python.exe -m pip install wheel tox virtualenv
 
 # note:
 # %PYTHON% has: python.exe


### PR DESCRIPTION
The most recent Tox release fixed the bug (issue314).