### PR TITLE
Set total/needed/happy from command-line

### DIFF
--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -288,6 +288,8 @@ def write_node_config(c, config):
 
 
 def write_client_config(c, config):
+    # note, config can be a plain dict, it seems -- see
+    # test_configutil.py in test_create_client_config
     c.write("[client]\n")
     c.write("# Which services should this client connect to?\n")
     introducer = config.get("introducer", None) or ""

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -152,12 +152,23 @@ class CreateClientOptions(_CreateBaseOptions):
          "Specify which TCP port to run the HTTP interface on. Use 'none' to disable."),
         ("basedir", "C", None, "Specify which Tahoe base directory should be used. This has the same effect as the global --node-directory option. [default: %s]"
          % quote_local_unicode_path(_default_nodedir)),
+        ("shares-needed", None, 3, "Needed shares required for uploaded files."),
+        ("shares-happy", None, 7, "How many servers new files must be placed on."),
+        ("shares-total", None, 10, "Total shares required for uploaded files."),
         ]
 
     # This is overridden in order to ensure we get a "Wrong number of
     # arguments." error when more than one argument is given.
     def parseArgs(self, basedir=None):
         BasedirOptions.parseArgs(self, basedir)
+        for name in ["shares-needed", "shares-happy", "shares-total"]:
+            try:
+                int(self[name])
+            except ValueError:
+                raise UsageError(
+                    "--{} must be an integer".format(name)
+                )
+
 
 class CreateNodeOptions(CreateClientOptions):
     optFlags = [
@@ -288,9 +299,9 @@ def write_client_config(c, config):
     c.write("# This can be changed at any time: the encoding is saved in\n")
     c.write("# each filecap, and we can download old files with any encoding\n")
     c.write("# settings\n")
-    c.write("#shares.needed = 3\n")
-    c.write("#shares.happy = 7\n")
-    c.write("#shares.total = 10\n")
+    c.write("shares.needed = {}\n".format(config['shares-needed']))
+    c.write("shares.happy = {}\n".format(config['shares-happy']))
+    c.write("shares.total = {}\n".format(config['shares-total']))
     c.write("\n")
 
     boolstr = {True:"true", False:"false"}

--- a/src/allmydata/test/cli/test_create.py
+++ b/src/allmydata/test/cli/test_create.py
@@ -44,6 +44,32 @@ class Config(unittest.TestCase):
         self.assertFalse(cfg.has_section("connections"))
 
     @defer.inlineCallbacks
+    def test_non_default_storage_args(self):
+        basedir = self.mktemp()
+        rc, out, err = yield run_cli(
+            "create-client",
+            '--shares-total', '19',
+            '--shares-needed', '2',
+            '--shares-happy', '11',
+            basedir,
+        )
+        cfg = read_config(basedir)
+        self.assertEqual(2, cfg.getint("client", "shares.needed"))
+        self.assertEqual(11, cfg.getint("client", "shares.happy"))
+        self.assertEqual(19, cfg.getint("client", "shares.total"))
+
+    @defer.inlineCallbacks
+    def test_illegal_shares_total(self):
+        basedir = self.mktemp()
+        rc, out, err = yield run_cli(
+            "create-client",
+            '--shares-total', 'funballs',
+            basedir,
+        )
+        self.assertNotEqual(0, rc)
+        self.assertTrue('--shares-total must be an integer' in err + out)
+
+    @defer.inlineCallbacks
     def test_client_hide_ip_no_i2p_txtorcon(self):
         # hmm, I must be doing something weird, these don't work as
         # @mock.patch decorators for some reason

--- a/src/allmydata/test/test_configutil.py
+++ b/src/allmydata/test/test_configutil.py
@@ -88,6 +88,9 @@ class ConfigUtilTests(GridTestMixin, unittest.TestCase):
                     "webport": "tcp:3456",
                     "hide-ip": False,
                     "listen": "none",
+                    "shares-needed": "1",
+                    "shares-happy": "1",
+                    "shares-total": "1",
                     }
             create_node.write_node_config(f, opts)
             create_node.write_client_config(f, opts)


### PR DESCRIPTION
This allows you to specify values on the CLI for needed/happy/total shares configuration parameters. This eases scripts that are creating nodes (so they don't have to know how to edit `tahoe.cfg` immediately after creating a node).