### PR TITLE
Set minimal tox version to 1.7.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@
 
 [tox]
 envlist = py27
+minversion = 1.7
 
 [testenv]
 passenv = USERPROFILE HOMEDRIVE HOMEPATH


### PR DESCRIPTION
Current LTS Ubuntu ships with 1.6.0 which seems to fail with "Directory
'.' is not installable. File 'setup.py' not found.". Search shows that
it looks like 1.7 is not affected by this
(https://bugs.launchpad.net/cinder/+bug/1484035), although I've only
tested with tox 2.5.0.

Should fix https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2841