### PR TITLE
Referrer-Policy

### DIFF
--- a/src/allmydata/webish.py
+++ b/src/allmydata/webish.py
@@ -28,6 +28,7 @@ class MyRequest(appserver.NevowRequest):
         self.content.seek(0,0)
         self.args = {}
         self.stack = []
+        self.setHeader("Referrer-Policy", "no-referrer")
 
         self.method, self.uri = command, path
         self.clientproto = version


### PR DESCRIPTION
This turns on "Referrer-Policy: no-referrer" for all pages (note that this only works in Firefox 50+ anyway). See #378 for more (and/or https://tahoe-lafs.org/trac/tahoe-lafs/ticket/127)