### PR TITLE
1432.osx watchdog stable.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,6 +263,7 @@ setup(name="tahoe-lafs", # also set in __init__.py
                 'allmydata.util',
                 'allmydata.web',
                 'allmydata.windows',
+                'allmydata.watchdog',
                 ],
       classifiers=trove_classifiers,
       install_requires=install_requires,

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -152,6 +152,10 @@ if sys.platform == "win32":
     install_requires.append('pypiwin32')
     package_imports.append(('pypiwin32', 'win32api'))
 
+if sys.platform != "win32" and not sys.platform.startswith("linux"):
+    install_requires.append('watchdog')
+    package_imports.append(('watchdog', 'watchdog'))
+
 setup_requires = []
 
 

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -36,6 +36,8 @@ def get_inotify_module():
             from allmydata.windows import inotify
         elif runtime.platform.supportsINotify():
             from twisted.internet import inotify
+        elif sys.platform != "linux":
+            from allmydata.watchdog import inotify
         else:
             raise NotImplementedError("filesystem notification needed for Magic Folder is not supported.\n"
                                       "This currently requires Linux or Windows.")
@@ -372,7 +374,7 @@ class Uploader(QueueMixin):
                     | IN_EXCL_UNLINK
                     )
         self._notifier.watch(self._local_filepath, mask=self.mask, callbacks=[self._notify],
-                             recursive=False)#True)
+                             recursive=True)
 
     def start_monitoring(self):
         self._log("start_monitoring")

--- a/src/allmydata/test/test_inotify.py
+++ b/src/allmydata/test/test_inotify.py
@@ -1,0 +1,31 @@
+
+from twisted.trial import unittest
+
+from allmydata.frontends import magic_folder
+from allmydata.frontends.magic_folder import MagicFolder, get_inotify_module, IN_EXCL_UNLINK
+
+
+class TestInotify(unittest.TestCase, NonASCIIPathMixin):
+    def setUp(self):
+        GridTestMixin.setUp(self)
+        self._local_filepath = abspath_expanduser_unicode(u"Alice-magic", base=self.basedir)
+        self.mkdir_nonascii(self._local_filepath)
+        self._inotify = get_inotify_module()
+        self._notifier = self._inotify.INotify()
+        self.mask = ( self._inotify.IN_CREATE
+                    | self._inotify.IN_CLOSE_WRITE
+                    | self._inotify.IN_MOVED_TO
+                    | self._inotify.IN_MOVED_FROM
+                    | self._inotify.IN_DELETE
+                    | self._inotify.IN_ONLYDIR
+                    | IN_EXCL_UNLINK
+                    )
+        self._notifier.watch(self._local_filepath, mask=self.mask, callbacks=[self._notify],
+                             recursive=True)
+
+    def _notify(self, opaque, path, events_mask):
+        if ((events_mask & self._inotify.IN_CREATE) != 0 and
+            (events_mask & self._inotify.IN_ISDIR) == 0):
+            self._log("ignoring event for %r (creation of non-directory)\n" % (path,))
+            return
+

--- a/src/allmydata/test/test_inotify.py
+++ b/src/allmydata/test/test_inotify.py
@@ -14,8 +14,12 @@ from twisted.internet import defer, reactor
 from twisted.python import filepath
 from twisted.trial import unittest
 
-from allmydata.frontends.magic_folder import get_inotify_module
-inotify = get_inotify_module()
+#from allmydata.frontends.magic_folder import get_inotify_module
+#inotify = get_inotify_module()
+if runtime.platform.supportsINotify():
+    from twisted.internet import inotify
+elif sys.platform != "linux":
+    from allmydata.watchdog import inotify
 
 
 class INotifyTests(unittest.TestCase):

--- a/src/allmydata/test/test_inotify.py
+++ b/src/allmydata/test/test_inotify.py
@@ -1,31 +1,503 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
 
+"""
+Tests for the inotify wrapper in L{twisted.internet.inotify}.
+"""
+import sys
+
+from twisted.internet import defer, reactor
+from twisted.python import filepath, runtime
+from twisted.python.reflect import requireModule
 from twisted.trial import unittest
 
-from allmydata.frontends import magic_folder
-from allmydata.frontends.magic_folder import MagicFolder, get_inotify_module, IN_EXCL_UNLINK
+if requireModule('twisted.python._inotify') is not None:
+    from twisted.internet import inotify
+else:
+    inotify = None
 
 
-class TestInotify(unittest.TestCase, NonASCIIPathMixin):
+
+class INotifyTests(unittest.TestCase):
+    """
+    Define all the tests for the basic functionality exposed by
+    L{inotify.INotify}.
+    """
+    if not runtime.platform.supportsINotify():
+        skip = "This platform doesn't support INotify."
+
     def setUp(self):
-        GridTestMixin.setUp(self)
-        self._local_filepath = abspath_expanduser_unicode(u"Alice-magic", base=self.basedir)
-        self.mkdir_nonascii(self._local_filepath)
-        self._inotify = get_inotify_module()
-        self._notifier = self._inotify.INotify()
-        self.mask = ( self._inotify.IN_CREATE
-                    | self._inotify.IN_CLOSE_WRITE
-                    | self._inotify.IN_MOVED_TO
-                    | self._inotify.IN_MOVED_FROM
-                    | self._inotify.IN_DELETE
-                    | self._inotify.IN_ONLYDIR
-                    | IN_EXCL_UNLINK
-                    )
-        self._notifier.watch(self._local_filepath, mask=self.mask, callbacks=[self._notify],
-                             recursive=True)
+        self.dirname = filepath.FilePath(self.mktemp())
+        self.dirname.createDirectory()
+        self.inotify = inotify.INotify()
+        self.inotify.startReading()
+        self.addCleanup(self.inotify.loseConnection)
 
-    def _notify(self, opaque, path, events_mask):
-        if ((events_mask & self._inotify.IN_CREATE) != 0 and
-            (events_mask & self._inotify.IN_ISDIR) == 0):
-            self._log("ignoring event for %r (creation of non-directory)\n" % (path,))
-            return
 
+    def test_initializationErrors(self):
+        """
+        L{inotify.INotify} emits a C{RuntimeError} when initialized
+        in an environment that doesn't support inotify as we expect it.
+
+        We just try to raise an exception for every possible case in
+        the for loop in L{inotify.INotify._inotify__init__}.
+        """
+        class FakeINotify:
+            def init(self):
+                raise inotify.INotifyError()
+        self.patch(inotify.INotify, '_inotify', FakeINotify())
+        self.assertRaises(inotify.INotifyError, inotify.INotify)
+
+
+    def _notificationTest(self, mask, operation, expectedPath=None):
+        """
+        Test notification from some filesystem operation.
+
+        @param mask: The event mask to use when setting up the watch.
+
+        @param operation: A function which will be called with the
+            name of a file in the watched directory and which should
+            trigger the event.
+
+        @param expectedPath: Optionally, the name of the path which is
+            expected to come back in the notification event; this will
+            also be passed to C{operation} (primarily useful when the
+            operation is being done to the directory itself, not a
+            file in it).
+
+        @return: A L{Deferred} which fires successfully when the
+            expected event has been received or fails otherwise.
+        """
+        if expectedPath is None:
+            expectedPath = self.dirname.child("foo.bar")
+        notified = defer.Deferred()
+        def cbNotified(result):
+            (watch, filename, events) = result
+            self.assertEqual(filename.asBytesMode(), expectedPath.asBytesMode())
+            self.assertTrue(events & mask)
+        notified.addCallback(cbNotified)
+
+        self.inotify.watch(
+            self.dirname, mask=mask,
+            callbacks=[lambda *args: notified.callback(args)])
+        operation(expectedPath)
+        return notified
+
+
+    def test_access(self):
+        """
+        Reading from a file in a monitored directory sends an
+        C{inotify.IN_ACCESS} event to the callback.
+        """
+        def operation(path):
+            path.setContent(b"foo")
+            path.getContent()
+
+        return self._notificationTest(inotify.IN_ACCESS, operation)
+
+
+    def test_modify(self):
+        """
+        Writing to a file in a monitored directory sends an
+        C{inotify.IN_MODIFY} event to the callback.
+        """
+        def operation(path):
+            with path.open("w") as fObj:
+                fObj.write(b'foo')
+
+        return self._notificationTest(inotify.IN_MODIFY, operation)
+
+
+    def test_attrib(self):
+        """
+        Changing the metadata of a file in a monitored directory
+        sends an C{inotify.IN_ATTRIB} event to the callback.
+        """
+        def operation(path):
+            path.touch()
+            path.touch()
+
+        return self._notificationTest(inotify.IN_ATTRIB, operation)
+
+
+    def test_closeWrite(self):
+        """
+        Closing a file which was open for writing in a monitored
+        directory sends an C{inotify.IN_CLOSE_WRITE} event to the
+        callback.
+        """
+        def operation(path):
+            path.open("w").close()
+
+        return self._notificationTest(inotify.IN_CLOSE_WRITE, operation)
+
+
+    def test_closeNoWrite(self):
+        """
+        Closing a file which was open for reading but not writing in a
+        monitored directory sends an C{inotify.IN_CLOSE_NOWRITE} event
+        to the callback.
+        """
+        def operation(path):
+            path.touch()
+            path.open("r").close()
+
+        return self._notificationTest(inotify.IN_CLOSE_NOWRITE, operation)
+
+
+    def test_open(self):
+        """
+        Opening a file in a monitored directory sends an
+        C{inotify.IN_OPEN} event to the callback.
+        """
+        def operation(path):
+            path.open("w").close()
+
+        return self._notificationTest(inotify.IN_OPEN, operation)
+
+
+    def test_movedFrom(self):
+        """
+        Moving a file out of a monitored directory sends an
+        C{inotify.IN_MOVED_FROM} event to the callback.
+        """
+        def operation(path):
+            path.open("w").close()
+            path.moveTo(filepath.FilePath(self.mktemp()))
+
+        return self._notificationTest(inotify.IN_MOVED_FROM, operation)
+
+
+    def test_movedTo(self):
+        """
+        Moving a file into a monitored directory sends an
+        C{inotify.IN_MOVED_TO} event to the callback.
+        """
+        def operation(path):
+            p = filepath.FilePath(self.mktemp())
+            p.touch()
+            p.moveTo(path)
+
+        return self._notificationTest(inotify.IN_MOVED_TO, operation)
+
+
+    def test_create(self):
+        """
+        Creating a file in a monitored directory sends an
+        C{inotify.IN_CREATE} event to the callback.
+        """
+        def operation(path):
+            path.open("w").close()
+
+        return self._notificationTest(inotify.IN_CREATE, operation)
+
+
+    def test_delete(self):
+        """
+        Deleting a file in a monitored directory sends an
+        C{inotify.IN_DELETE} event to the callback.
+        """
+        def operation(path):
+            path.touch()
+            path.remove()
+
+        return self._notificationTest(inotify.IN_DELETE, operation)
+
+
+    def test_deleteSelf(self):
+        """
+        Deleting the monitored directory itself sends an
+        C{inotify.IN_DELETE_SELF} event to the callback.
+        """
+        def operation(path):
+            path.remove()
+
+        return self._notificationTest(
+            inotify.IN_DELETE_SELF, operation, expectedPath=self.dirname)
+
+
+    def test_moveSelf(self):
+        """
+        Renaming the monitored directory itself sends an
+        C{inotify.IN_MOVE_SELF} event to the callback.
+        """
+        def operation(path):
+            path.moveTo(filepath.FilePath(self.mktemp()))
+
+        return self._notificationTest(
+            inotify.IN_MOVE_SELF, operation, expectedPath=self.dirname)
+
+
+    def test_simpleSubdirectoryAutoAdd(self):
+        """
+        L{inotify.INotify} when initialized with autoAdd==True adds
+        also adds the created subdirectories to the watchlist.
+        """
+        def _callback(wp, filename, mask):
+            # We are notified before we actually process new
+            # directories, so we need to defer this check.
+            def _():
+                try:
+                    self.assertTrue(self.inotify._isWatched(subdir))
+                    d.callback(None)
+                except Exception:
+                    d.errback()
+            reactor.callLater(0, _)
+
+        checkMask = inotify.IN_ISDIR | inotify.IN_CREATE
+        self.inotify.watch(
+            self.dirname, mask=checkMask, autoAdd=True,
+            callbacks=[_callback])
+        subdir = self.dirname.child('test')
+        d = defer.Deferred()
+        subdir.createDirectory()
+        return d
+
+
+    def test_simpleDeleteDirectory(self):
+        """
+        L{inotify.INotify} removes a directory from the watchlist when
+        it's removed from the filesystem.
+        """
+        calls = []
+        def _callback(wp, filename, mask):
+            # We are notified before we actually process new
+            # directories, so we need to defer this check.
+            def _():
+                try:
+                    self.assertTrue(self.inotify._isWatched(subdir))
+                    subdir.remove()
+                except Exception:
+                    d.errback()
+            def _eb():
+                # second call, we have just removed the subdir
+                try:
+                    self.assertFalse(self.inotify._isWatched(subdir))
+                    d.callback(None)
+                except Exception:
+                    d.errback()
+
+            if not calls:
+                # first call, it's the create subdir
+                calls.append(filename)
+                reactor.callLater(0, _)
+
+            else:
+                reactor.callLater(0, _eb)
+
+        checkMask = inotify.IN_ISDIR | inotify.IN_CREATE
+        self.inotify.watch(
+            self.dirname, mask=checkMask, autoAdd=True,
+            callbacks=[_callback])
+        subdir = self.dirname.child('test')
+        d = defer.Deferred()
+        subdir.createDirectory()
+        return d
+
+
+    def test_ignoreDirectory(self):
+        """
+        L{inotify.INotify.ignore} removes a directory from the watchlist
+        """
+        self.inotify.watch(self.dirname, autoAdd=True)
+        self.assertTrue(self.inotify._isWatched(self.dirname))
+        self.inotify.ignore(self.dirname)
+        self.assertFalse(self.inotify._isWatched(self.dirname))
+
+
+    def test_humanReadableMask(self):
+        """
+        L{inotify.humaReadableMask} translates all the possible event
+        masks to a human readable string.
+        """
+        for mask, value in inotify._FLAG_TO_HUMAN:
+            self.assertEqual(inotify.humanReadableMask(mask)[0], value)
+
+        checkMask = (
+            inotify.IN_CLOSE_WRITE | inotify.IN_ACCESS | inotify.IN_OPEN)
+        self.assertEqual(
+            set(inotify.humanReadableMask(checkMask)),
+            set(['close_write', 'access', 'open']))
+
+
+    def test_recursiveWatch(self):
+        """
+        L{inotify.INotify.watch} with recursive==True will add all the
+        subdirectories under the given path to the watchlist.
+        """
+        subdir = self.dirname.child('test')
+        subdir2 = subdir.child('test2')
+        subdir3 = subdir2.child('test3')
+        subdir3.makedirs()
+        dirs = [subdir, subdir2, subdir3]
+        self.inotify.watch(self.dirname, recursive=True)
+        # let's even call this twice so that we test that nothing breaks
+        self.inotify.watch(self.dirname, recursive=True)
+        for d in dirs:
+            self.assertTrue(self.inotify._isWatched(d))
+
+
+    def test_connectionLostError(self):
+        """
+        L{inotify.INotify.connectionLost} if there's a problem while closing
+        the fd shouldn't raise the exception but should log the error
+        """
+        import os
+        in_ = inotify.INotify()
+        os.close(in_._fd)
+        in_.loseConnection()
+        self.flushLoggedErrors()
+
+    def test_noAutoAddSubdirectory(self):
+        """
+        L{inotify.INotify.watch} with autoAdd==False will stop inotify
+        from watching subdirectories created under the watched one.
+        """
+        def _callback(wp, fp, mask):
+            # We are notified before we actually process new
+            # directories, so we need to defer this check.
+            def _():
+                try:
+                    self.assertFalse(self.inotify._isWatched(subdir))
+                    d.callback(None)
+                except Exception:
+                    d.errback()
+            reactor.callLater(0, _)
+
+        checkMask = inotify.IN_ISDIR | inotify.IN_CREATE
+        self.inotify.watch(
+            self.dirname, mask=checkMask, autoAdd=False,
+            callbacks=[_callback])
+        subdir = self.dirname.child('test')
+        d = defer.Deferred()
+        subdir.createDirectory()
+        return d
+
+
+    def test_seriesOfWatchAndIgnore(self):
+        """
+        L{inotify.INotify} will watch a filepath for events even if the same
+        path is repeatedly added/removed/re-added to the watchpoints.
+        """
+        expectedPath = self.dirname.child("foo.bar2")
+        expectedPath.touch()
+
+        notified = defer.Deferred()
+        def cbNotified(result):
+            (ignored, filename, events) = result
+            self.assertEqual(filename.asBytesMode(), expectedPath.asBytesMode())
+            self.assertTrue(events & inotify.IN_DELETE_SELF)
+
+        def callIt(*args):
+            notified.callback(args)
+
+        # Watch, ignore, watch again to get into the state being tested.
+        self.assertTrue(self.inotify.watch(expectedPath, callbacks=[callIt]))
+        self.inotify.ignore(expectedPath)
+        self.assertTrue(
+            self.inotify.watch(
+                expectedPath, mask=inotify.IN_DELETE_SELF, callbacks=[callIt]))
+
+        notified.addCallback(cbNotified)
+
+        # Apparently in kernel version < 2.6.25, inofify has a bug in the way
+        # similar events are coalesced.  So, be sure to generate a different
+        # event here than the touch() at the top of this method might have
+        # generated.
+        expectedPath.remove()
+
+        return notified
+
+
+    def test_ignoreFilePath(self):
+        """
+        L{inotify.INotify} will ignore a filepath after it has been removed from
+        the watch list.
+        """
+        expectedPath = self.dirname.child("foo.bar2")
+        expectedPath.touch()
+        expectedPath2 = self.dirname.child("foo.bar3")
+        expectedPath2.touch()
+
+        notified = defer.Deferred()
+        def cbNotified(result):
+            (ignored, filename, events) = result
+            self.assertEqual(filename.asBytesMode(), expectedPath2.asBytesMode())
+            self.assertTrue(events & inotify.IN_DELETE_SELF)
+
+        def callIt(*args):
+            notified.callback(args)
+
+        self.assertTrue(
+            self.inotify.watch(
+                expectedPath, inotify.IN_DELETE_SELF, callbacks=[callIt]))
+        notified.addCallback(cbNotified)
+
+        self.assertTrue(
+            self.inotify.watch(
+                expectedPath2, inotify.IN_DELETE_SELF, callbacks=[callIt]))
+
+        self.inotify.ignore(expectedPath)
+
+        expectedPath.remove()
+        expectedPath2.remove()
+
+        return notified
+
+
+    def test_ignoreNonWatchedFile(self):
+        """
+        L{inotify.INotify} will raise KeyError if a non-watched filepath is
+        ignored.
+        """
+        expectedPath = self.dirname.child("foo.ignored")
+        expectedPath.touch()
+
+        self.assertRaises(KeyError, self.inotify.ignore, expectedPath)
+
+
+    def test_complexSubdirectoryAutoAdd(self):
+        """
+        L{inotify.INotify} with autoAdd==True for a watched path
+        generates events for every file or directory already present
+        in a newly created subdirectory under the watched one.
+
+        This tests that we solve a race condition in inotify even though
+        we may generate duplicate events.
+        """
+        calls = set()
+        def _callback(wp, filename, mask):
+            calls.add(filename)
+            if len(calls) == 6:
+                try:
+                    self.assertTrue(self.inotify._isWatched(subdir))
+                    self.assertTrue(self.inotify._isWatched(subdir2))
+                    self.assertTrue(self.inotify._isWatched(subdir3))
+                    created = someFiles + [subdir, subdir2, subdir3]
+                    created = {f.asBytesMode() for f in created}
+                    self.assertEqual(len(calls), len(created))
+                    self.assertEqual(calls, created)
+                except Exception:
+                    d.errback()
+                else:
+                    d.callback(None)
+
+        checkMask = inotify.IN_ISDIR | inotify.IN_CREATE
+        self.inotify.watch(
+            self.dirname, mask=checkMask, autoAdd=True,
+            callbacks=[_callback])
+        subdir = self.dirname.child('test')
+        subdir2 = subdir.child('test2')
+        subdir3 = subdir2.child('test3')
+        d = defer.Deferred()
+        subdir3.makedirs()
+
+        someFiles = [subdir.child('file1.dat'),
+                     subdir2.child('file2.dat'),
+                     subdir3.child('file3.dat')]
+        # Add some files in pretty much all the directories so that we
+        # see that we process all of them.
+        for i, filename in enumerate(someFiles):
+            filename.setContent(
+                filename.path.encode(sys.getfilesystemencoding()))
+        return d

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -1477,32 +1477,3 @@ class MockTest(SingleMagicFolderTestMixin, unittest.TestCase):
             self.failUnlessEqual(data["counters"]["magic_folder.uploader.objects_queued"], 0)
         d.addCallback(_got_stats_json)
         return d
-
-
-class RealTest(SingleMagicFolderTestMixin, unittest.TestCase):
-    """This is skipped unless both Twisted and the platform support inotify."""
-    inject_inotify = False
-
-    def setUp(self):
-        d = super(RealTest, self).setUp()
-        self.inotify = magic_folder.get_inotify_module()
-        return d
-
-
-class RealTestAliceBob(MagicFolderAliceBobTestMixin, unittest.TestCase):
-    """This is skipped unless both Twisted and the platform support inotify."""
-    inject_inotify = False
-
-    def setUp(self):
-        d = super(RealTestAliceBob, self).setUp()
-        self.inotify = magic_folder.get_inotify_module()
-        return d
-
-
-try:
-    magic_folder.get_inotify_module()
-except NotImplementedError:
-    msg = "Magic Folder support can only be tested for-real on an OS that " + \
-          "supports inotify or equivalent."
-    for klass in [RealTest, MockTest, MockTestAliceBob, RealTestAliceBob]:
-        klass.skip = msg

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -1287,6 +1287,13 @@ class SingleMagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, Reall
         self.assertTrue(node is not None, "Failed to find %r in DMD" % (path,))
         self.failUnlessEqual(metadata['version'], 2)
 
+    def test_write_short_file(self):
+        self.magicfolder.enable_debug_log()
+        d = defer.succeed(None)
+        # Write something short enough for a LIT file.
+        d.addCallback(lambda ign: self._check_file(u"short", "test"))
+        return d
+
     def test_magic_folder(self):
         d = defer.succeed(None)
         # Write something short enough for a LIT file.

--- a/src/allmydata/watchdog/inotify.py
+++ b/src/allmydata/watchdog/inotify.py
@@ -1,0 +1,146 @@
+
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler, DirCreatedEvent, FileCreatedEvent
+
+
+from twisted.internet import reactor
+from twisted.python.filepath import FilePath
+from allmydata.util.fileutil import abspath_expanduser_unicode
+
+from allmydata.util.pollmixin import PollMixin
+from allmydata.util.assertutil import _assert, precondition
+from allmydata.util import log, encodingutil
+from allmydata.util.fake_inotify import humanReadableMask, \
+    IN_WATCH_MASK, IN_ACCESS, IN_MODIFY, IN_ATTRIB, IN_CLOSE_NOWRITE, IN_CLOSE_WRITE, \
+    IN_OPEN, IN_MOVED_FROM, IN_MOVED_TO, IN_CREATE, IN_DELETE, IN_DELETE_SELF, \
+    IN_MOVE_SELF, IN_UNMOUNT, IN_Q_OVERFLOW, IN_IGNORED, IN_ONLYDIR, IN_DONT_FOLLOW, \
+    IN_MASK_ADD, IN_ISDIR, IN_ONESHOT, IN_CLOSE, IN_MOVED, IN_CHANGED
+[humanReadableMask, \
+    IN_WATCH_MASK, IN_ACCESS, IN_MODIFY, IN_ATTRIB, IN_CLOSE_NOWRITE, IN_CLOSE_WRITE, \
+    IN_OPEN, IN_MOVED_FROM, IN_MOVED_TO, IN_CREATE, IN_DELETE, IN_DELETE_SELF, \
+    IN_MOVE_SELF, IN_UNMOUNT, IN_Q_OVERFLOW, IN_IGNORED, IN_ONLYDIR, IN_DONT_FOLLOW, \
+    IN_MASK_ADD, IN_ISDIR, IN_ONESHOT, IN_CLOSE, IN_MOVED, IN_CHANGED]
+
+
+TRUE  = 0
+FALSE = 1
+
+NOT_STARTED = "NOT_STARTED"
+STARTED     = "STARTED"
+STOPPING    = "STOPPING"
+STOPPED     = "STOPPED"
+
+class INotifyEventHandler(FileSystemEventHandler):
+
+    def __init__(self, path, mask, callbacks, pending_delay):
+        print "init INotifyEventHandler"
+        FileSystemEventHandler.__init__(self)
+        self._path = path
+        self._mask = mask
+        self._callbacks = callbacks
+        self._pending_delay = pending_delay
+        self._pending = set()
+
+    def process(self, event):
+        print "FILESYSTEM ENCODING: %s" % encodingutil.get_filesystem_encoding()
+        event_filepath_u = event.src_path.decode(encodingutil.get_filesystem_encoding())
+        event_filepath_u = abspath_expanduser_unicode(event_filepath_u, base=self._path)
+
+        if event_filepath_u == self._path:
+            # ignore events for parent directory
+            return
+
+        def _maybe_notify(path):
+            try:
+                if path in self._pending:
+                    return
+                self._pending.add(path)
+                def _do_callbacks():
+                    print "DO CALLBACKS"
+                    self._pending.remove(path)
+                    event_mask = IN_CHANGED
+                    if isinstance(event, (DirCreatedEvent, FileCreatedEvent)):
+                        event_mask = event_mask | IN_CREATE
+                    if event.is_directory:
+                        event_mask = event_mask | IN_ISDIR
+                    for cb in self._callbacks:
+                        try:
+                            cb(None, FilePath(path), event_mask)
+                        except Exception, e:
+                            print e
+                            log.err(e)
+                _do_callbacks()
+            except Exception as e:
+                print("BAD STUFF", e)
+        reactor.callFromThread(_maybe_notify, event_filepath_u)
+
+    def on_any_event(self, event):
+        print "PROCESS EVENT %r" % (event,)
+        self.process(event)
+
+class INotify(PollMixin):
+    """
+    I am a prototype INotify, made to work on Mac OS X (Darwin)
+    using the Watchdog python library. This is actually a simplified subset
+    of the twisted Linux INotify class because we do not utilize the watch mask
+    and only implement the following methods:
+     - watch
+     - startReading
+     - stopReading
+     - wait_until_stopped
+     - set_pending_delay
+    """
+    def __init__(self):
+        self._pending_delay = 1.0
+        self.recursive_includes_new_subdirectories = False
+        self._observer = Observer(timeout=self._pending_delay)
+        self._callbacks = {}
+        self._state = NOT_STARTED
+
+    def set_pending_delay(self, delay):
+        print "set pending delay"
+        assert self._state != STARTED
+        self._pending_delay = delay
+        self._observer = Observer(timeout=self._pending_delay)
+
+    def startReading(self):
+        print "START READING BEGIN"
+        assert self._state != STARTED
+        try:
+            _assert(len(self._callbacks) != 0, "no watch set")
+            self._observer.start()
+            self._state = STARTED
+        except Exception, e:
+            log.err(e)
+            self._state = STOPPED
+            raise
+        print "START READING END"
+
+    def stopReading(self):
+        print "stopReading begin"
+        if self._state != STOPPED:
+            self._state = STOPPING
+        self._observer.stop()
+        self._observer.join()
+        self._state = STOPPED
+        print "stopReading end"
+
+    def wait_until_stopped(self):
+        print "wait until stopped"
+        return self.poll(lambda: self._state == STOPPED)
+
+    def watch(self, path, mask=IN_WATCH_MASK, autoAdd=False, callbacks=None, recursive=False):
+        precondition(isinstance(autoAdd, bool), autoAdd=autoAdd)
+        precondition(isinstance(recursive, bool), recursive=recursive)
+        assert autoAdd == False
+
+        recursive = False
+        self._recursive = TRUE if recursive else FALSE
+        path_u = path.path
+        if not isinstance(path_u, unicode):
+            path_u = path_u.decode('utf-8')
+            _assert(isinstance(path_u, unicode), path_u=path_u)
+
+        if path_u not in self._callbacks.keys():
+            self._callbacks[path_u] = callbacks or []
+            self._observer.schedule(INotifyEventHandler(path_u, mask, self._callbacks[path_u], self._pending_delay), path=path_u, recursive=recursive)


### PR DESCRIPTION

Add inotify test suite inspired by the twisted inotify test suite. This is a small set of tests for the inotify functionality which we can use to test our windows and watchdog (OSX compatible) implementations.

Removed magic-folder "real" inotify tests. The remaining magic-folder tests use a mock inotify implementation.