### PR TITLE
Show the connection-status of all hints until we're connected to one

### DIFF
--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -2857,7 +2857,7 @@ class IConnectionStatus(Interface):
         negotiation was successful. Otherwise it is None.
         """)
 
-    last_connection_summary = Attribute(
+    summary = Attribute(
         """
         A string with a brief summary of the current status, suitable for
         display on an informational page. The more complete text from
@@ -2865,25 +2865,21 @@ class IConnectionStatus(Interface):
         popup.
         """)
 
-    last_connection_description = Attribute(
-        """
-        A string with a description of the results of the most recent
-        connection attempt. For Foolscap connections, this indicates the
-        winning hint and the connection handler which used it, e.g.
-        'tcp:HOST:PORT via tcp' or 'tor:HOST.onion:PORT via tor':
-
-        * 'Connection successful: HINT via HANDLER (other hints: ..)'
-        * 'Connection failed: HINT->HANDLER->FAILURE, ...'
-
-        Note that this describes the last *completed* connection attempt. If
-        a connection attempt is currently in progress, this method will
-        describe the results of the previous attempt.
-        """)
-
     last_received_time = Attribute(
         """
         A timestamp (seconds-since-epoch) describing the last time we heard
         anything (including low-level keep-alives or inbound requests) from
         the other side.
+        """)
+
+    non_connected_statuses = Attribute(
+        """
+        A dictionary, describing all connections that are not (yet)
+        successful. When connected is True, this will only be the losing
+        attempts. When connected is False, this will include all attempts.
+
+        This maps a connection description string (for foolscap this is a
+        connection hint and the handler it is using) to the status string
+        (pending, connected, refused, or other errors).
         """)
 

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -2845,29 +2845,29 @@ class IConnectionStatus(Interface):
 
     connected = Attribute(
         """
-        Returns True if we appear to be connected: we've been successful
-        in communicating with our target at some point in the past, and we
+        True if we appear to be connected: we've been successful in
+        communicating with our target at some point in the past, and we
         haven't experienced any errors since then.""")
 
     last_connection_time = Attribute(
         """
-        If is_connected() is True, this returns a number
-        (seconds-since-epoch) when we last transitioned from 'not connected'
-        to 'connected', such as when a TCP connect() operation completed and
-        subsequent negotiation was successful. Otherwise it returns None.
+        If is_connected() is True, this is a timestamp (seconds-since-epoch)
+        when we last transitioned from 'not connected' to 'connected', such
+        as when a TCP connect() operation completed and subsequent
+        negotiation was successful. Otherwise it is None.
         """)
 
     last_connection_summary = Attribute(
         """
-        Returns a string with a brief summary of the current status, suitable
-        for display on an informational page. The more complete text from
+        A string with a brief summary of the current status, suitable for
+        display on an informational page. The more complete text from
         last_connection_description would be appropriate for a tool-tip
         popup.
         """)
 
     last_connection_description = Attribute(
         """
-        Returns a string with a description of the results of the most recent
+        A string with a description of the results of the most recent
         connection attempt. For Foolscap connections, this indicates the
         winning hint and the connection handler which used it, e.g.
         'tcp:HOST:PORT via tcp' or 'tor:HOST.onion:PORT via tor':
@@ -2882,8 +2882,8 @@ class IConnectionStatus(Interface):
 
     last_received_time = Attribute(
         """
-        Returns a number (seconds-since-epoch) describing the last time we
-        heard anything (including low-level keep-alives or inbound requests)
-        from the other side.
+        A timestamp (seconds-since-epoch) describing the last time we heard
+        anything (including low-level keep-alives or inbound requests) from
+        the other side.
         """)
 

--- a/src/allmydata/test/web/test_root.py
+++ b/src/allmydata/test/web/test_root.py
@@ -27,7 +27,7 @@ class RenderServiceRow(unittest.TestCase):
                "permutation-seed-base32": "w2hqnbaa25yw4qgcvghl5psa3srpfgw3",
                }
         s = NativeStorageServer("server_id", ann, None, {})
-        cs = ConnectionStatus(False, "summary", "description", 0, 0)
+        cs = ConnectionStatus(False, "summary", {}, 0, 0)
         s.get_connection_status = lambda: cs
 
         r = FakeRoot()

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -178,7 +178,7 @@ class FakeDisplayableServer(StubServer):
     def get_available_space(self):
         return 123456
     def get_connection_status(self):
-        return ConnectionStatus(self.connected, "summary", "description",
+        return ConnectionStatus(self.connected, "summary", {},
                                 self.last_connect_time, self.last_rx_time)
 
 class FakeBucketCounter(object):
@@ -667,8 +667,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
             def __init__(self, connected):
                 self.connected = connected
             def connection_status(self):
-                return ConnectionStatus(self.connected,
-                                        "summary", "description", 0, 0)
+                return ConnectionStatus(self.connected, "summary", {}, 0, 0)
 
         d = defer.succeed(None)
 
@@ -680,7 +679,6 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
         d.addCallback(_set_introducer_not_connected_unguessable)
         def _check_introducer_not_connected_unguessable(res):
             html = res.replace('\n', ' ')
-            self.failUnlessIn('<div class="connection-status" title="description">summary</div>', html)
             self.failIfIn('pb://someIntroducer/secret', html)
             self.failUnless(re.search('<img (alt="Disconnected" |src="img/connected-no.png" ){2}/></div>[ ]*<div>No introducers connected</div>', html), res)
 
@@ -694,7 +692,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
         d.addCallback(_set_introducer_connected_unguessable)
         def _check_introducer_connected_unguessable(res):
             html = res.replace('\n', ' ')
-            self.failUnlessIn('<div class="connection-status" title="description">summary</div>', html)
+            self.failUnlessIn('<div class="connection-status" title="(no other hints)">summary</div>', html)
             self.failIfIn('pb://someIntroducer/secret', html)
             self.failUnless(re.search('<img (src="img/connected-yes.png" |alt="Connected" ){2}/></div>[ ]*<div>1 introducer connected</div>', html), res)
         d.addCallback(_check_introducer_connected_unguessable)
@@ -707,7 +705,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
         d.addCallback(_set_introducer_connected_guessable)
         def _check_introducer_connected_guessable(res):
             html = res.replace('\n', ' ')
-            self.failUnlessIn('<div class="connection-status" title="description">summary</div>', html)
+            self.failUnlessIn('<div class="connection-status" title="(no other hints)">summary</div>', html)
             self.failUnless(re.search('<img (src="img/connected-yes.png" |alt="Connected" ){2}/></div>[ ]*<div>1 introducer connected</div>', html), res)
         d.addCallback(_check_introducer_connected_guessable)
         return d

--- a/src/allmydata/util/connection_status.py
+++ b/src/allmydata/util/connection_status.py
@@ -6,12 +6,13 @@ from ..interfaces import IConnectionStatus
 class ConnectionStatus:
     def __init__(self, connected, summary,
                  last_connection_description, last_connection_time,
-                 last_received_time):
+                 last_received_time, statuses):
         self.connected = connected
         self.last_connection_summary = summary
         self.last_connection_description = last_connection_description
         self.last_connection_time = last_connection_time
         self.last_received_time = last_received_time
+        self.statuses = statuses
 
 def _describe_statuses(hints, handlers, statuses):
     descriptions = []
@@ -77,5 +78,5 @@ def from_foolscap_reconnector(rc, last_received):
         last_connected = None
 
     cs = ConnectionStatus(connected, summary, details,
-                          last_connected, last_received)
+                          last_connected, last_received, statuses)
     return cs

--- a/src/allmydata/web/welcome.xhtml
+++ b/src/allmydata/web/welcome.xhtml
@@ -188,20 +188,16 @@
                 <div class="nickname"><n:slot name="nickname"/></div>
                 <div class="nodeid"><n:slot name="peerid"/></div>
               </td>
-              <td class="connection-status">
 
+              <td class="connection-status">
                 <n:attr name="title"><n:slot name="details"/></n:attr>
                 <n:slot name="summary"/>
                 <a class="timestamp">
                   <n:attr name="title"><n:slot name="service_connection_status_abs_time"/></n:attr>
                   <n:slot name="service_connection_status_rel_time"/>
                 </a>
-
-                <ul n:render="sequence" n:data="connections" class="details">
-                  <li n:pattern="item" n:render="connection_item"><n:attr name="title"><n:slot name="details"/></n:attr><n:slot name="summary"/></li>
-                </ul>
-
               </td>
+
               <td class="service-last-received-data"><a class="timestamp"><n:attr name="title"><n:slot name="last_received_data_abs_time"/></n:attr><n:slot name="last_received_data_rel_time"/></a></td>
               <td class="service-version"><n:slot name="version"/></td>
               <td class="service-available-space"><n:slot name="available_space"/></td>

--- a/src/allmydata/web/welcome.xhtml
+++ b/src/allmydata/web/welcome.xhtml
@@ -72,7 +72,7 @@
                 <input type="file" class="freeform-input-file" name="file" />
                 <input type="hidden" name="t" value="upload" />
 
-                <label for="upload-chk" class="radio"> 
+                <label for="upload-chk" class="radio">
                   <input type="radio" checked="checked" id="upload-chk" value="chk" name="format" />
                   Immutable
                 </label>
@@ -95,7 +95,7 @@
             <div class="nav-header">Create Directory</div>
             <div class="nav-form">
               <form action="uri" method="post" enctype="multipart/form-data">
-                <label for="mkdir-sdmf" class="radio"> 
+                <label for="mkdir-sdmf" class="radio">
                   <input type="radio" checked="checked" id="mkdir-sdmf" value="sdmf" name="format" />
                   <acronym title="Small Distributed Mutable File">SDMF</acronym>
                 </label>
@@ -189,12 +189,18 @@
                 <div class="nodeid"><n:slot name="peerid"/></div>
               </td>
               <td class="connection-status">
+
                 <n:attr name="title"><n:slot name="details"/></n:attr>
                 <n:slot name="summary"/>
                 <a class="timestamp">
                   <n:attr name="title"><n:slot name="service_connection_status_abs_time"/></n:attr>
                   <n:slot name="service_connection_status_rel_time"/>
                 </a>
+
+                <ul n:render="sequence" n:data="connections" class="details">
+                  <li n:pattern="item" n:render="connection_item"><n:attr name="title"><n:slot name="details"/></n:attr><n:slot name="summary"/></li>
+                </ul>
+
               </td>
               <td class="service-last-received-data"><a class="timestamp"><n:attr name="title"><n:slot name="last_received_data_abs_time"/></n:attr><n:slot name="last_received_data_rel_time"/></a></td>
               <td class="service-version"><n:slot name="version"/></td>


### PR DESCRIPTION
This shows the connection-status of each individual hint for any connections that have not yet succeeded.

![connections-screenshot](https://cloud.githubusercontent.com/assets/145599/21063353/64acce62-be12-11e6-8377-fae97c4c7aa9.png)
