### PR TITLE
express pypiwin32 dep via a setup.py extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,7 @@ setup(name="tahoe-lafs", # also set in __init__.py
       classifiers=trove_classifiers,
       install_requires=install_requires,
       extras_require={
+          ':sys_platform=="win32"': ["pypiwin32"],
           "test": [
               "pyflakes",
               "coverage",

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -149,10 +149,6 @@ import sys
 if not hasattr(sys, 'frozen'):
     package_imports.append(('setuptools', 'setuptools'))
 
-if sys.platform == "win32":
-    install_requires.append('pypiwin32')
-    package_imports.append(('pypiwin32', 'win32api'))
-
 setup_requires = []
 
 


### PR DESCRIPTION
Previously this looked at sys.platform to decide what dependencies to
include. The problem with that approach is that wheels built on a unix box
won't work on windows (and vice versa), when the (pure-python) Tahoe wheels
aren't supposed to be platform-dependent.

setup.py provides a syntax to express this properly, so wheels created on
either platform will include the pypiwin32 dependency in the metadata, but
marked as only being relevant when installing on a win32 platform.

closes ticket:2763