### PR TITLE
move 'shutilwhich' dependency out to the [test] extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -279,6 +279,7 @@ setup(name="tahoe-lafs", # also set in __init__.py
               "txi2p >= 0.3.1", # in case pip's resolver doesn't work
               "pytest",
               "pytest-twisted",
+              "shutilwhich >= 1.1.0", # in Python 3.3 stdlib
           ],
           "tor": [
               "foolscap[tor] >= 0.12.5",

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -91,9 +91,6 @@ install_requires = [
     #   <https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2474>.
     "pyOpenSSL >= 0.14",
     "PyYAML >= 3.11",
-
-    # in Python 3.3 stdlib
-    "shutilwhich >= 1.1.0",
 ]
 
 # Includes some indirect dependencies, but does not include allmydata.


### PR DESCRIPTION
This is only used by integration/conftest.py, so we don't need an
unconditional dependency on it.
