### PR TITLE
Add api-version to Json output of deep-manifest

### DIFF
--- a/docs/frontends/webapi.rst
+++ b/docs/frontends/webapi.rst
@@ -1725,6 +1725,9 @@ incorrectly.
   storage-index: list of (base32) storage index strings
   stats: a dictionary with the same keys as the t=start-deep-stats command
          (described below)
+  api-version (int): deep-manifest API version. Will be increased every
+               time backwards-incompatible change is introduced. Current version
+               is 1.
 
 ``POST $DIRURL?t=start-deep-size``   (must add &ophandle=XYZ)
 

--- a/src/allmydata/deep_stats.py
+++ b/src/allmydata/deep_stats.py
@@ -10,6 +10,7 @@ from allmydata.uri import LiteralFileURI
 from allmydata.uri import from_string
 from allmydata.util import mathutil
 
+
 class DeepStats(object):
     """Deep stats object.
 
@@ -36,7 +37,7 @@ class DeepStats(object):
                   "count-directories",
                   "count-unknown",
                   "size-immutable-files",
-                  #"size-mutable-files",
+                  # "size-mutable-files",
                   "size-literal-files",
                   "size-directories",
                   "largest-directory",

--- a/src/allmydata/deep_stats.py
+++ b/src/allmydata/deep_stats.py
@@ -43,12 +43,12 @@ class DeepStats(object):
                   "largest-directory",
                   "largest-directory-children",
                   "largest-immutable-file",
-                  #"largest-mutable-file",
-                 ]:
+                  # "largest-mutable-file",
+                  ]:
             self.stats[k] = 0
         self.histograms = {}
         for k in ["size-files-histogram"]:
-            self.histograms[k] = {} # maps (min,max) to count
+            self.histograms[k] = {}  # Maps (min,max) to count.
         self.buckets = [(0, 0), (1, 3)]
         self.root = math.sqrt(10)
 
@@ -69,7 +69,7 @@ class DeepStats(object):
             self.add("count-mutable-files")
             # TODO: update the servermap, compute a size, add it to
             # size-mutable-files, max it into "largest-mutable-file"
-        elif IImmutableFileNode.providedBy(node): # CHK and LIT
+        elif IImmutableFileNode.providedBy(node):  # CHK and LIT
             self.add("count-files")
             size = node.get_size()
             self.histogram("size-files-histogram", size)
@@ -126,7 +126,7 @@ class DeepStats(object):
         stats = self.stats.copy()
         for key in self.histograms:
             h = self.histograms[key]
-            out = [ (bucket[0], bucket[1], h[bucket]) for bucket in h ]
+            out = [(bucket[0], bucket[1], h[bucket]) for bucket in h]
             out.sort()
             stats[key] = out
         return stats

--- a/src/allmydata/dirnode.py
+++ b/src/allmydata/dirnode.py
@@ -1,5 +1,6 @@
 """Directory Node implementation."""
-import time, unicodedata
+import time
+import unicodedata
 
 from zope.interface import implements
 from twisted.internet import defer
@@ -27,7 +28,7 @@ from allmydata.util.dictutil import AuxValueDict
 
 
 def update_metadata(metadata, new_metadata, now):
-    """Updates 'metadata' in-place with the information in 'new_metadata'.
+    """Update 'metadata' in-place with the information in 'new_metadata'.
 
     Timestamps are set according to the time 'now'.
     """
@@ -55,8 +56,8 @@ def update_metadata(metadata, new_metadata, now):
     sysmd = metadata.get('tahoe', {})
     if 'linkcrtime' not in sysmd:
         # In Tahoe < 1.4.0 we used the word 'ctime' to mean what Tahoe >= 1.4.0
-        # calls 'linkcrtime'. This field is only used if it was in the old metadata,
-        # and 'tahoe:linkcrtime' was not.
+        # calls 'linkcrtime'. This field is only used if it was in the old
+        # metadata, and 'tahoe:linkcrtime' was not.
         if old_ctime is not None:
             sysmd['linkcrtime'] = old_ctime
         else:

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1,4 +1,5 @@
-import os.path, re, urllib, time, cgi
+import os.path
+import re, urllib, time, cgi
 import simplejson
 
 from twisted.application import service
@@ -1759,6 +1760,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
             self.failUnlessIn("storage-index", res)
             self.failUnlessIn("verifycaps", res)
             self.failUnlessIn("stats", res)
+            self.failUnlessIn("api-version", res)
         d.addCallback(_got_json)
         return d
 

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1761,6 +1761,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
             self.failUnlessIn("verifycaps", res)
             self.failUnlessIn("stats", res)
             self.failUnlessIn("api-version", res)
+            self.failUnlessIn("api-version", res["stats"])
         d.addCallback(_got_json)
         return d
 

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -1,3 +1,4 @@
+"""Classes and functions dealing with directory web UI."""
 
 import simplejson
 import urllib
@@ -87,11 +88,13 @@ class DirectoryNodeHandler(RenderMixin, rend.Page, ReplaceMeMixin):
             f = node_or_failure
             f.trap(NoSuchChildError)
             # No child by this name. What should we do about it?
-            if DEBUG: print "no child", name
+            if DEBUG:
+                print "no child", name
             if DEBUG:
                 print "postpath", req.postpath
             if nonterminal:
-                if DEBUG: print " intermediate"
+                if DEBUG:
+                    print " intermediate"
                 if should_create_intermediate_directories(req):
                     # create intermediate directories
                     if DEBUG: print " making intermediate directory"
@@ -814,20 +817,20 @@ class DirectoryAsHTML(rend.Page):
         mkdir_mdmf = T.input(type='radio', name='format',
                              value='mdmf', id='mkdir-mdmf')
 
-        mkdir_form = T.form(action=".", method="post",
-                            enctype="multipart/form-data")[
-            T.fieldset[
-            T.input(type="hidden", name="t", value="mkdir"),
-            T.input(type="hidden", name="when_done", value="."),
-            T.legend(class_="freeform-form-label")["Create a new directory in this directory"],
-            "New directory name:"+SPACE, T.br,
-            T.input(type="text", name="name"), SPACE,
-            T.div(class_="form-inline")[
-                mkdir_sdmf, T.label(for_='mutable-directory-sdmf')[SPACE, "SDMF"], SPACE*2,
-                mkdir_mdmf, T.label(for_='mutable-directory-mdmf')[SPACE, "MDMF (experimental)"]
-            ],
-            T.input(type="submit", class_="btn", value="Create")
-            ]]
+        mkdir_form = T.form(
+            action=".",
+            method="post",
+            enctype="multipart/form-data")[T.fieldset[
+                T.input(type="hidden", name="t", value="mkdir"),
+                T.input(type="hidden", name="when_done", value="."),
+                T.legend(class_="freeform-form-label")["Create a new directory in this directory"],
+                "New directory name:"+SPACE, T.br,
+                T.input(type="text", name="name"), SPACE,
+                T.div(class_="form-inline")[
+                    mkdir_sdmf, T.label(for_='mutable-directory-sdmf')[SPACE, "SDMF"], SPACE*2,
+                    mkdir_mdmf, T.label(for_='mutable-directory-mdmf')[SPACE, "MDMF (experimental)"]
+                    ],
+                T.input(type="submit", class_="btn", value="Create")]]
         forms.append(T.div(class_="freeform-form")[mkdir_form])
 
         upload_chk  = T.input(type='radio', name='format',
@@ -838,21 +841,22 @@ class DirectoryAsHTML(rend.Page):
         upload_mdmf = T.input(type='radio', name='format',
                               value='mdmf', id='upload-mdmf')
 
-        upload_form = T.form(action=".", method="post",
-                             enctype="multipart/form-data")[
-            T.fieldset[
-            T.input(type="hidden", name="t", value="upload"),
-            T.input(type="hidden", name="when_done", value="."),
-            T.legend(class_="freeform-form-label")["Upload a file to this directory"],
-            "Choose a file to upload:"+SPACE,
-            T.input(type="file", name="file", class_="freeform-input-file"), SPACE,
-            T.div(class_="form-inline")[
-                upload_chk,  T.label(for_="upload-chk") [SPACE, "Immutable"], SPACE*2,
-                upload_sdmf, T.label(for_="upload-sdmf")[SPACE, "SDMF"], SPACE*2,
-                upload_mdmf, T.label(for_="upload-mdmf")[SPACE, "MDMF (experimental)"]
-            ],
-            T.input(type="submit", class_="btn", value="Upload"),             SPACE*2,
-            ]]
+        upload_form = T.form(
+            action=".",
+            method="post",
+            enctype="multipart/form-data")[T.fieldset[
+                T.input(type="hidden", name="t", value="upload"),
+                T.input(type="hidden", name="when_done", value="."),
+                T.legend(class_="freeform-form-label")["Upload a file to this directory"],
+                "Choose a file to upload:"+SPACE,
+                T.input(type="file", name="file", class_="freeform-input-file"), SPACE,
+                T.div(class_="form-inline")[
+                    upload_chk,  T.label(for_="upload-chk") [SPACE, "Immutable"], SPACE*2,
+                    upload_sdmf, T.label(for_="upload-sdmf")[SPACE, "SDMF"], SPACE*2,
+                    upload_mdmf, T.label(for_="upload-mdmf")[SPACE, "MDMF (experimental)"]
+                ],
+                T.input(type="submit", class_="btn", value="Upload"),             SPACE*2,
+                ]]
         forms.append(T.div(class_="freeform-form")[upload_form])
 
         attach_form = T.form(action=".", method="post",
@@ -977,9 +981,9 @@ class DeepSizeResults(rend.Page):
         output = "finished: " + {True: "yes", False: "no"}[is_finished] + "\n"
         if is_finished:
             stats = self.monitor.get_status()
-            total = (stats.get("size-immutable-files", 0)
-                     + stats.get("size-mutable-files", 0)
-                     + stats.get("size-directories", 0))
+            total = (stats.get("size-immutable-files", 0) +
+                     stats.get("size-mutable-files", 0) +
+                     stats.get("size-directories", 0))
             output += "size: %d\n" % total
         return output
 

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -77,7 +77,8 @@ class DirectoryNodeHandler(RenderMixin, rend.Page, ReplaceMeMixin):
 
     def got_child(self, node_or_failure, ctx, name):
         DEBUG = False
-        if DEBUG: print "GOT_CHILD", name, node_or_failure
+        if DEBUG:
+            print "GOT_CHILD", name, node_or_failure
         req = IRequest(ctx)
         method = req.method
         nonterminal = len(req.postpath) > 1

--- a/src/allmydata/web/manifest_results.py
+++ b/src/allmydata/web/manifest_results.py
@@ -14,6 +14,14 @@ class ManifestResults(rend.Page, operations.ReloadMixin):
 
     docFactory = common.getxmlfile("manifest.xhtml")
 
+    # Json API version.
+    # Rules:
+    # - increment each time a field is removed or changes meaning.
+    # - it's ok to add a new field without incrementing the version.
+    # Note this does not apply to inner stats object which will have its own
+    # versioning.
+    API_VERSION = 1
+
     def __init__(self, client, monitor):
         """Initialize class."""
         self.client = client
@@ -55,6 +63,7 @@ class ManifestResults(rend.Page, operations.ReloadMixin):
         status = {"stats": s["stats"],
                   "finished": m.is_finished(),
                   "origin": origin_base32,
+                  "api-version": self.API_VERSION
                   }
         if m.is_finished():
             # don't return manifest/verifycaps/SIs unless the operation is

--- a/src/allmydata/web/manifest_results.py
+++ b/src/allmydata/web/manifest_results.py
@@ -1,0 +1,110 @@
+"""Results of the manifest operation."""
+
+from nevow import rend, inevow, tags as T
+import simplejson
+import urllib
+
+from allmydata.util import base32
+from allmydata.web import operations
+from allmydata.web import common
+
+
+class ManifestResults(rend.Page, operations.ReloadMixin):
+    """Container for results of the manifest operation."""
+
+    docFactory = common.getxmlfile("manifest.xhtml")
+
+    def __init__(self, client, monitor):
+        """Initialize class."""
+        self.client = client
+        self.monitor = monitor
+
+    def renderHTTP(self, ctx):
+        """Render HTTP page with the results."""
+        req = inevow.IRequest(ctx)
+        output = common.get_arg(req, "output", "html").lower()
+        if output == "text":
+            return self._text(req)
+        if output == "json":
+            return self._json(req)
+        return rend.Page.renderHTTP(self, ctx)
+
+    def _slashify_path(self, path):
+        if not path:
+            return ""
+        return "/".join([p.encode("utf-8") for p in path])
+
+    def _text(self, req):
+        req.setHeader("content-type", "text/plain")
+        lines = []
+        is_finished = self.monitor.is_finished()
+        lines.append("finished: " + {True: "yes", False: "no"}[is_finished])
+        for (path, cap) in self.monitor.get_status()["manifest"]:
+            lines.append(self._slashify_path(path) + " " + cap)
+        return "\n".join(lines) + "\n"
+
+    def _json(self, req):
+        req.setHeader("content-type", "text/plain")
+        m = self.monitor
+        s = m.get_status()
+
+        if m.origin_si:
+            origin_base32 = base32.b2a(m.origin_si)
+        else:
+            origin_base32 = ""
+        status = {"stats": s["stats"],
+                  "finished": m.is_finished(),
+                  "origin": origin_base32,
+                  }
+        if m.is_finished():
+            # don't return manifest/verifycaps/SIs unless the operation is
+            # done, to save on CPU/memory (both here and in the HTTP client
+            # who has to unpack the JSON). Tests show that the ManifestWalker
+            # needs about 1092 bytes per item, the JSON we generate here
+            # requires about 503 bytes per item, and some internal overhead
+            # (perhaps transport-layer buffers in twisted.web?) requires an
+            # additional 1047 bytes per item.
+            status.update({"manifest": s["manifest"],
+                           "verifycaps": [i for i in s["verifycaps"]],
+                           "storage-index": [i for i in s["storage-index"]],
+                           })
+            # simplejson doesn't know how to serialize a set. We use a
+            # generator that walks the set rather than list(setofthing) to
+            # save a small amount of memory (4B*len) and a moderate amount of
+            # CPU.
+        return simplejson.dumps(status, indent=1)
+
+    def _si_abbrev(self):
+        si = self.monitor.origin_si
+        if not si:
+            return "<LIT>"
+        return base32.b2a(si)[:6]
+
+    def render_title(self, ctx):
+        """Render title of the page."""
+        return T.title["Manifest of SI=%s" % self._si_abbrev()]
+
+    def render_header(self, ctx):
+        """Render page header."""
+        return T.p["Manifest of SI=%s" % self._si_abbrev()]
+
+    def data_items(self, ctx, data):
+        """Return data items."""
+        return self.monitor.get_status()["manifest"]
+
+    def render_row(self, ctx, (path, cap)):
+        """Render row of the manifest."""
+        ctx.fillSlots("path", self._slashify_path(path))
+        root = common.get_root(ctx)
+        # TODO: we need a clean consistent way to get the type of a cap string
+        if cap:
+            if cap.startswith("URI:CHK") or cap.startswith("URI:SSK"):
+                nameurl = urllib.quote(path[-1].encode("utf-8"))
+                uri_link = "%s/file/%s/@@named=/%s" % (root, urllib.quote(cap),
+                                                       nameurl)
+            else:
+                uri_link = "%s/uri/%s" % (root, urllib.quote(cap, safe=""))
+            ctx.fillSlots("cap", T.a(href=uri_link)[cap])
+        else:
+            ctx.fillSlots("cap", "")
+        return ctx.tag


### PR DESCRIPTION
Adds api-version to the JSON result of manifest operation.

Inner 'stats' field of the JSON is covered by earlier change for deep-stats.

Part of the https://tahoe-lafs.org/trac/tahoe-lafs/ticket/567

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/390)
<!-- Reviewable:end -->
