### PR TITLE
Pass I2P keyfile to foolscap

### DIFF
--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -158,7 +158,7 @@ class I2P(unittest.TestCase):
         with mock.patch("foolscap.connections.i2p.default",
                         return_value=h1) as f:
             h = n._make_i2p_handler()
-            self.assertEqual(f.mock_calls, [mock.call(reactor)])
+            self.assertEqual(f.mock_calls, [mock.call(reactor, keyfile=None)])
             self.assertIdentical(h, h1)
 
     def test_samport(self):

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -221,7 +221,7 @@ class Provider(unittest.TestCase):
                 h = p.get_i2p_handler()
         cfs.assert_called_with(reactor, "ep_desc")
         self.assertIs(h, handler)
-        i2p.sam_endpoint.assert_called_with(ep)
+        i2p.sam_endpoint.assert_called_with(ep, keyfile=None)
 
     def test_handler_launch(self):
         i2p = mock.Mock()
@@ -292,7 +292,7 @@ class Provider(unittest.TestCase):
             p = i2p_provider.Provider("basedir", FakeConfig(), reactor)
         h = p.get_i2p_handler()
         self.assertIs(h, handler)
-        i2p.default.assert_called_with(reactor)
+        i2p.default.assert_called_with(reactor, keyfile=None)
 
 class Provider_CheckI2PConfig(unittest.TestCase):
     def test_default(self):

--- a/src/allmydata/util/i2p_provider.py
+++ b/src/allmydata/util/i2p_provider.py
@@ -147,13 +147,14 @@ class Provider(service.MultiService):
         sam_port = self._get_i2p_config("sam.port", None)
         launch = self._get_i2p_config("launch", False, boolean=True)
         configdir = self._get_i2p_config("i2p.configdir", None)
+        keyfile = self._get_i2p_config("dest.private_key_file", None)
 
         if sam_port:
             if launch:
                 raise ValueError("tahoe.cfg [i2p] must not set both "
                                  "sam.port and launch")
             ep = clientFromString(self._reactor, sam_port)
-            return self._i2p.sam_endpoint(ep)
+            return self._i2p.sam_endpoint(ep, keyfile=keyfile)
 
         if launch:
             executable = self._get_i2p_config("i2p.executable", None)
@@ -162,7 +163,7 @@ class Provider(service.MultiService):
         if configdir:
             return self._i2p.local_i2p(configdir)
 
-        return self._i2p.default(self._reactor)
+        return self._i2p.default(self._reactor, keyfile=keyfile)
 
     def check_dest_config(self):
         if self._get_i2p_config("dest", False, boolean=True):


### PR DESCRIPTION
If no session management is performed, txi2p starts a process-wide session the
first time a connection (client or server) is opened; all subsequent connections
use that session and its configuration properties.

This commit ensures that the same properties are passed to both client and
server endpoints, so that the correct I2P Destination is started regardless of
whether the first connection made by Tahoe-LAFS is for a client or server.

Closes #2858.