### PR TITLE
List aliases json

### DIFF
--- a/src/allmydata/scripts/cli.py
+++ b/src/allmydata/scripts/cli.py
@@ -85,6 +85,7 @@ class ListAliasesOptions(FileStoreOptions):
     description = """Display a table of all configured aliases."""
     optFlags = [
         ("readonly-uri", None, "Show read-only dircaps instead of readwrite"),
+        ("json", None, "Show JSON output"),
     ]
 
 class ListOptions(FileStoreOptions):

--- a/src/allmydata/test/cli/test_alias.py
+++ b/src/allmydata/test/cli/test_alias.py
@@ -1,0 +1,69 @@
+import json
+from os.path import join
+
+from twisted.trial import unittest
+from twisted.internet.defer import inlineCallbacks
+
+from allmydata.util.encodingutil import unicode_to_argv
+from allmydata.util import encodingutil
+from allmydata.scripts.common import get_aliases
+from allmydata.test.no_network import GridTestMixin
+from .common import CLITestMixin
+
+
+# see also test_create_alias
+
+
+class ListAlias(GridTestMixin, CLITestMixin, unittest.TestCase):
+
+    @inlineCallbacks
+    def test_list(self):
+        self.basedir = "cli/ListAlias/test_list"
+        self.set_up_grid(oneshare=True)
+        aliasfile = join(self.get_clientdir(), "private", "aliases")
+
+        rc, stdout, stderr = yield self.do_cli(
+            "create-alias",
+            unicode_to_argv(u"tahoe"),
+        )
+
+        self.failUnless(unicode_to_argv(u"Alias 'tahoe' created") in stdout)
+        self.failIf(stderr)
+        aliases = get_aliases(self.get_clientdir())
+        self.failUnless(u"tahoe" in aliases)
+        self.failUnless(aliases[u"tahoe"].startswith("URI:DIR2:"))
+
+        rc, stdout, stderr = yield self.do_cli("list-aliases", "--json")
+
+        self.assertEqual(0, rc)
+        data = json.loads(stdout)
+        self.assertIn(u"tahoe", data)
+        data = data[u"tahoe"]
+        self.assertIn("readwrite", data)
+        self.assertIn("readonly", data)
+
+    @inlineCallbacks
+    def test_list_unicode_mismatch(self):
+        self.basedir = "cli/ListAlias/test_list_unicode_mismatch"
+        self.set_up_grid(oneshare=True)
+        aliasfile = join(self.get_clientdir(), "private", "aliases")
+
+        rc, stdout, stderr = yield self.do_cli(
+            "create-alias",
+            unicode_to_argv(u"tahoe\u263A"),
+        )
+
+        self.failUnless(unicode_to_argv(u"Alias 'tahoe\u263A' created") in stdout)
+        self.failIf(stderr)
+        aliases = get_aliases(self.get_clientdir())
+        self.failUnless(u"tahoe\u263A" in aliases)
+        self.failUnless(aliases[u"tahoe\u263A"].startswith("URI:DIR2:"))
+
+        rc, stdout, stderr = yield self.do_cli("list-aliases", "--json")
+
+        self.assertEqual(0, rc)
+        data = json.loads(stdout)
+        self.assertIn(u"tahoe\u263A", data)
+        data = data[u"tahoe\u263A"]
+        self.assertIn("readwrite", data)
+        self.assertIn("readonly", data)


### PR DESCRIPTION
(Note that this builds upon https://github.com/tahoe-lafs/tahoe-lafs/pull/396 so it's only "really" the last commit, presuming the other gets merged).

It would be nice to have JSON output for "most" low-ish level commands. I see, though, that e.g. "tahoe ls" has a `--json` option, but it just shows the "raw JSON output", i.e. whatever the server sent back .. so maybe this is slightly inconsistent with that? But it seems more-likely to be usable if `--json` output is relevant/comparable to the non-json output...