### PR TITLE
Verifycaps in Web UI

### DIFF
--- a/src/allmydata/immutable/filenode.py
+++ b/src/allmydata/immutable/filenode.py
@@ -87,6 +87,11 @@ class CiphertextFileNode:
         return self._verifycap
     def get_size(self):
         return self._verifycap.size
+    def get_current_size(self):
+        return defer.succeed(self.get_size())
+
+    def get_uri(self):
+        return self._verifycap.to_string()
 
     def raise_error(self):
         pass

--- a/src/allmydata/immutable/filenode.py
+++ b/src/allmydata/immutable/filenode.py
@@ -7,7 +7,8 @@ from twisted.internet import defer
 
 from allmydata import uri
 from twisted.internet.interfaces import IConsumer
-from allmydata.interfaces import IImmutableFileNode, IUploadResults
+from allmydata.interfaces import IImmutableFileNode, IUploadResults, \
+        IVerifyNode
 from allmydata.util import consumer
 from allmydata.check_results import CheckResults, CheckAndRepairResults
 from allmydata.util.dictutil import DictOfSets
@@ -22,6 +23,9 @@ from allmydata.immutable.downloader.node import DownloadNode, \
 from allmydata.immutable.downloader.status import DownloadStatus
 
 class CiphertextFileNode:
+
+    implements(IVerifyNode)
+
     def __init__(self, verifycap, storage_broker, secret_holder,
                  terminator, history):
         assert isinstance(verifycap, uri.CHKFileVerifierURI)

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -938,7 +938,7 @@ class IFilesystemNode(Interface):
 class IVerifyNode(IFilesystemNode):
     """
     I am a node which represents an opaque repairable object. I can be checked
-    and repaired but neither read nor written.
+    and repaired.
     """
 
 

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -831,6 +831,7 @@ class IMutableFileVersion(IReadable):
 
 # The hierarchy looks like this:
 #  IFilesystemNode
+#   IVerifyNode
 #   IFileNode
 #    IMutableFileNode
 #    IImmutableFileNode
@@ -932,6 +933,13 @@ class IFilesystemNode(Interface):
         """I return a Deferred that fires with the length (in bytes) of the
         data this node represents.
         """
+
+
+class IVerifyNode(IFilesystemNode):
+    """
+    I am a node which represents an opaque repairable object. I can be checked
+    and repaired but neither read nor written.
+    """
 
 
 class IFileNode(IFilesystemNode):

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1025,27 +1025,6 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
                              self.GET, "/file")
         return d
 
-    def test_GET_unhandled_URI_named(self):
-        contents, n, newuri = self.makefile(12)
-        verifier_cap = n.get_verify_cap().to_string()
-        base = "/file/%s" % urllib.quote(verifier_cap)
-        # client.create_node_from_uri() can't handle verify-caps
-        d = self.shouldFail2(error.Error, "GET_unhandled_URI_named",
-                             "400 Bad Request", "is not a file-cap",
-                             self.GET, base)
-        return d
-
-    def test_GET_unhandled_URI(self):
-        contents, n, newuri = self.makefile(12)
-        verifier_cap = n.get_verify_cap().to_string()
-        base = "/uri/%s" % urllib.quote(verifier_cap)
-        # client.create_node_from_uri() can't handle verify-caps
-        d = self.shouldFail2(error.Error, "test_GET_unhandled_URI",
-                             "400 Bad Request",
-                             "GET unknown URI type: can only do t=info",
-                             self.GET, base)
-        return d
-
     def test_GET_FILE_URI(self):
         base = "/uri/%s" % urllib.quote(self._bar_txt_uri)
         d = self.GET(base)

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1025,6 +1025,23 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
                              self.GET, "/file")
         return d
 
+    def test_GET_unhandled_URI_named(self):
+        unknown_cap = "URI:UNK:xxx"
+        base = "/file/%s" % urllib.quote(unknown_cap)
+        d = self.shouldFail2(error.Error, "GET_unhandled_URI_named",
+                             "400 Bad Request", "is not a file-cap",
+                             self.GET, base)
+        return d
+
+    def test_GET_unhandled_URI(self):
+        unknown_cap = "URI:UNK:xxx"
+        base = "/uri/%s" % urllib.quote(unknown_cap)
+        d = self.shouldFail2(error.Error, "test_GET_unhandled_URI",
+                             "400 Bad Request",
+                             "GET unknown URI type: can only do t=info",
+                             self.GET, base)
+        return d
+
     def test_GET_FILE_URI(self):
         base = "/uri/%s" % urllib.quote(self._bar_txt_uri)
         d = self.GET(base)

--- a/src/allmydata/unknown.py
+++ b/src/allmydata/unknown.py
@@ -166,7 +166,7 @@ class UnknownNode:
         return None
 
     def get_verify_cap(self):
-        return None
+        return uri.UnknownURI(self.rw_uri or self.ro_uri)
 
     def get_repair_cap(self):
         return None

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -16,7 +16,7 @@ from allmydata.util import base32
 from allmydata.util.encodingutil import to_str
 from allmydata.uri import from_string_dirnode
 from allmydata.interfaces import IDirectoryNode, IFileNode, IFilesystemNode, \
-     IImmutableFileNode, IMutableFileNode, ExistingChildError, \
+     IImmutableFileNode, IMutableFileNode, IVerifyNode, ExistingChildError, \
      NoSuchChildError, EmptyPathnameComponentError, SDMF_VERSION, MDMF_VERSION
 from allmydata.blacklist import ProhibitedNode
 from allmydata.monitor import Monitor, OperationCancelledError
@@ -36,6 +36,7 @@ from allmydata.web.info import MoreInfo
 from allmydata.web.operations import ReloadMixin
 from allmydata.web.check_results import json_check_results, \
      json_check_and_repair_results
+from allmydata.web.verifynode import VerifyNodeHandler
 
 class BlockingFileError(Exception):
     # TODO: catch and transform
@@ -45,6 +46,8 @@ class BlockingFileError(Exception):
 def make_handler_for(node, client, parentnode=None, name=None):
     if parentnode:
         assert IDirectoryNode.providedBy(parentnode)
+    if IVerifyNode.providedBy(node):
+        return VerifyNodeHandler(client, node, parentnode, name)
     if IFileNode.providedBy(node):
         return FileNodeHandler(client, node, parentnode, name)
     if IDirectoryNode.providedBy(node):

--- a/src/allmydata/web/filenode.py
+++ b/src/allmydata/web/filenode.py
@@ -138,6 +138,8 @@ class FileNodeHandler(VerifyNodeHandler, ReplaceMeMixin):
     I handle requests for IFileNodes.
     """
 
+    # NB: __init__() inherited from VerifyNodeHandler.
+
     def childFactory(self, ctx, name):
         req = IRequest(ctx)
         if isinstance(self.node, ProhibitedNode):

--- a/src/allmydata/web/filenode.py
+++ b/src/allmydata/web/filenode.py
@@ -159,7 +159,7 @@ class FileNodeHandler(VerifyNodeHandler, ReplaceMeMixin):
         # urllib.quote(name.encode("utf-8")), while IE7 sometimes does
         # latin-1. Browsers cannot agree on how to interpret the name
         # they see in the Content-Disposition header either, despite some
-        # 11-year old standards (RFC2231) that explain how to do it
+        # 20-year old standards (RFC2231) that explain how to do it
         # properly. So we assume that at least the browser will agree
         # with itself, and echo back the same bytes that we were given.
         filename = get_arg(req, "filename", self.name) or "unknown"

--- a/src/allmydata/web/info.py
+++ b/src/allmydata/web/info.py
@@ -5,7 +5,7 @@ from nevow import rend, tags as T
 from nevow.inevow import IRequest
 
 from allmydata.util import base32
-from allmydata.interfaces import IDirectoryNode, IFileNode, MDMF_VERSION
+from allmydata.interfaces import IDirectoryNode, IFileNode, IVerifyNode, MDMF_VERSION
 from allmydata.web.common import getxmlfile
 from allmydata.mutable.common import UnrecoverableFileError # TODO: move
 
@@ -36,6 +36,8 @@ class MoreInfo(rend.Page):
                     return ret
                 return "immutable file"
             return "immutable LIT file"
+        if IVerifyNode.providedBy(node):
+            return "verifier"
         return "unknown"
 
     def render_title(self, ctx, data):
@@ -209,6 +211,12 @@ class MoreInfo(rend.Page):
     def render_is_directory(self, ctx, data):
         node = self.original
         if IDirectoryNode.providedBy(node):
+            return ctx.tag
+        return ""
+
+    def render_is_readable(self, ctx, data):
+        node = self.original
+        if IFileNode.providedBy(node):
             return ctx.tag
         return ""
 

--- a/src/allmydata/web/info.xhtml
+++ b/src/allmydata/web/info.xhtml
@@ -29,14 +29,18 @@
     </tr>
     </span>
 
+    <span n:render="is_mutable_file">
     <tr>
       <th>File writecap</th>
       <td><tt class="data-chars" n:render="file_writecap" /></td>
     </tr>
+    </span>
+    <span n:render="is_readable">
     <tr>
       <th>File readcap</th>
       <td><tt class="data-chars" n:render="file_readcap" /></td>
     </tr>
+    </span>
     <tr>
       <th>File verifycap</th>
       <td><tt class="data-chars" n:render="file_verifycap" /></td>

--- a/src/allmydata/web/verifynode.py
+++ b/src/allmydata/web/verifynode.py
@@ -22,6 +22,10 @@ from allmydata.web.info import MoreInfo
 
 
 class VerifyNodeHandler(RenderMixin, rend.Page):
+    """
+    I handle requests for verifiable nodes.
+    """
+
     def __init__(self, client, node, parentnode=None, name=None):
         rend.Page.__init__(self)
         self.client = client
@@ -33,6 +37,10 @@ class VerifyNodeHandler(RenderMixin, rend.Page):
     def childFactory(self, ctx, name):
         raise WebError("Verifycaps can't have children, certainly not named %s"
                        % quote_output(name, encoding='utf-8'))
+
+    def render_HEAD(self, ctx):
+        # Just delegate to GET; we have to do pretty much the same work.
+        return self.render_GET(ctx)
 
     def render_GET(self, ctx):
         req = IRequest(ctx)

--- a/src/allmydata/web/verifynode.py
+++ b/src/allmydata/web/verifynode.py
@@ -1,0 +1,234 @@
+
+import simplejson
+
+from twisted.internet import defer
+from nevow import url, rend
+from nevow.inevow import IRequest
+
+from allmydata.interfaces import ExistingChildError, IFileNode
+from allmydata.monitor import Monitor
+from allmydata.mutable.publish import MutableFileHandle
+from allmydata.mutable.common import MODE_READ
+from allmydata.util import base32
+from allmydata.util.encodingutil import quote_output
+
+from allmydata.web.common import text_plain, WebError, RenderMixin, \
+     boolean_of_arg, get_arg, \
+     parse_replace_arg, parse_offset_arg, \
+     get_filenode_metadata
+from allmydata.web.check_results import CheckResultsRenderer, \
+     CheckAndRepairResultsRenderer, LiteralCheckResultsRenderer
+from allmydata.web.info import MoreInfo
+
+
+class VerifyNodeHandler(RenderMixin, rend.Page):
+    def __init__(self, client, node, parentnode=None, name=None):
+        rend.Page.__init__(self)
+        self.client = client
+        assert node
+        self.node = node
+        self.parentnode = parentnode
+        self.name = name
+
+    def childFactory(self, ctx, name):
+        raise WebError("Verifycaps can't have children, certainly not named %s"
+                       % quote_output(name, encoding='utf-8'))
+
+    def render_GET(self, ctx):
+        req = IRequest(ctx)
+        t = get_arg(req, "t", "").strip()
+        isFileNode = IFileNode.providedBy(self.node)
+
+        # t=info contains variable ophandles, so is not allowed an ETag.
+        FIXED_OUTPUT_TYPES = ["", "json", "uri", "readonly-uri"]
+        if isFileNode and not self.node.is_mutable() and t in FIXED_OUTPUT_TYPES:
+            # if the client already has the ETag then we can
+            # short-circuit the whole process.
+            si = self.node.get_storage_index()
+            if si and req.setETag('%s-%s' % (base32.b2a(si), t or "")):
+                return ""
+
+        if not t:
+            # Delegate if our node is an IFileNode; otherwise, assume that
+            # they wanted to see t=info.
+            if isFileNode:
+                # just get the contents
+                return self._get_contents(req)
+            else:
+                t = "info"
+
+        if t == "json":
+            # We do this to make sure that fields like size and
+            # mutable-type (which depend on the file on the grid and not
+            # just on the cap) are filled in. The latter gets used in
+            # tests, in particular.
+            #
+            # TODO: Make it so that the servermap knows how to update in
+            # a mode specifically designed to fill in these fields, and
+            # then update it in that mode.
+            if self.node.is_mutable():
+                d = self.node.get_servermap(MODE_READ)
+            else:
+                d = defer.succeed(None)
+            if self.parentnode and self.name:
+                d.addCallback(lambda ignored:
+                    self.parentnode.get_metadata_for(self.name))
+            else:
+                d.addCallback(lambda ignored: None)
+            d.addCallback(lambda md: FileJSONMetadata(ctx, self.node, md))
+            return d
+        if t == "info":
+            return MoreInfo(self.node)
+        if t == "uri":
+            return FileURI(ctx, self.node)
+        if t == "readonly-uri":
+            return FileReadOnlyURI(ctx, self.node)
+        raise WebError("GET file: bad t=%s" % t)
+
+    def render_PUT(self, ctx):
+        req = IRequest(ctx)
+        t = get_arg(req, "t", "").strip()
+        replace = parse_replace_arg(get_arg(req, "replace", "true"))
+        offset = parse_offset_arg(get_arg(req, "offset", None))
+
+        if not t:
+            if not replace:
+                # this is the early trap: if someone else modifies the
+                # directory while we're uploading, the add_file(overwrite=)
+                # call in replace_me_with_a_child will do the late trap.
+                raise ExistingChildError()
+
+            if self.node.is_mutable():
+                # Are we a readonly filenode? We shouldn't allow callers
+                # to try to replace us if we are.
+                if self.node.is_readonly():
+                    raise WebError("PUT to a mutable file: replace or update"
+                                   " requested with read-only cap")
+                if offset is None:
+                    return self.replace_my_contents(req)
+
+                if offset >= 0:
+                    return self.update_my_contents(req, offset)
+
+                raise WebError("PUT to a mutable file: Invalid offset")
+
+            else:
+                if offset is not None:
+                    raise WebError("PUT to a file: append operation invoked "
+                                   "on an immutable cap")
+
+                assert self.parentnode and self.name
+                return self.replace_me_with_a_child(req, self.client, replace)
+
+        if t == "uri":
+            if not replace:
+                raise ExistingChildError()
+            assert self.parentnode and self.name
+            return self.replace_me_with_a_childcap(req, self.client, replace)
+
+        raise WebError("PUT to a file: bad t=%s" % t)
+
+    def render_POST(self, ctx):
+        req = IRequest(ctx)
+        t = get_arg(req, "t", "").strip()
+        replace = boolean_of_arg(get_arg(req, "replace", "true"))
+        if t == "check":
+            d = self._POST_check(req)
+        elif t == "upload":
+            # like PUT, but get the file data from an HTML form's input field
+            # We could get here from POST /uri/mutablefilecap?t=upload,
+            # or POST /uri/path/file?t=upload, or
+            # POST /uri/path/dir?t=upload&name=foo . All have the same
+            # behavior, we just ignore any name= argument
+            if self.node.is_mutable():
+                d = self.replace_my_contents_with_a_formpost(req)
+            else:
+                if not replace:
+                    raise ExistingChildError()
+                assert self.parentnode and self.name
+                d = self.replace_me_with_a_formpost(req, self.client, replace)
+        else:
+            raise WebError("POST to file: bad t=%s" % t)
+
+        when_done = get_arg(req, "when_done", None)
+        if when_done:
+            d.addCallback(lambda res: url.URL.fromString(when_done))
+        return d
+
+    def _maybe_literal(self, res, Results_Class):
+        if res:
+            return Results_Class(self.client, res)
+        return LiteralCheckResultsRenderer(self.client)
+
+    def _POST_check(self, req):
+        verify = boolean_of_arg(get_arg(req, "verify", "false"))
+        repair = boolean_of_arg(get_arg(req, "repair", "false"))
+        add_lease = boolean_of_arg(get_arg(req, "add-lease", "false"))
+        if repair:
+            d = self.node.check_and_repair(Monitor(), verify, add_lease)
+            d.addCallback(self._maybe_literal, CheckAndRepairResultsRenderer)
+        else:
+            d = self.node.check(Monitor(), verify, add_lease)
+            d.addCallback(self._maybe_literal, CheckResultsRenderer)
+        return d
+
+    def render_DELETE(self, ctx):
+        assert self.parentnode and self.name
+        d = self.parentnode.delete(self.name)
+        d.addCallback(lambda res: self.node.get_uri())
+        return d
+
+    def replace_my_contents(self, req):
+        req.content.seek(0)
+        new_contents = MutableFileHandle(req.content)
+        d = self.node.overwrite(new_contents)
+        d.addCallback(lambda res: self.node.get_uri())
+        return d
+
+
+    def update_my_contents(self, req, offset):
+        req.content.seek(0)
+        added_contents = MutableFileHandle(req.content)
+
+        d = self.node.get_best_mutable_version()
+        d.addCallback(lambda mv:
+            mv.update(added_contents, offset))
+        d.addCallback(lambda ignored:
+            self.node.get_uri())
+        return d
+
+
+    def replace_my_contents_with_a_formpost(self, req):
+        # we have a mutable file. Get the data from the formpost, and replace
+        # the mutable file's contents with it.
+        new_contents = req.fields['file']
+        new_contents = MutableFileHandle(new_contents.file)
+
+        d = self.node.overwrite(new_contents)
+        d.addCallback(lambda res: self.node.get_uri())
+        return d
+
+
+def FileJSONMetadata(ctx, filenode, edge_metadata):
+    rw_uri = filenode.get_write_uri()
+    ro_uri = filenode.get_readonly_uri()
+    data = ("filenode", get_filenode_metadata(filenode))
+    if ro_uri:
+        data[1]['ro_uri'] = ro_uri
+    if rw_uri:
+        data[1]['rw_uri'] = rw_uri
+    verifycap = filenode.get_verify_cap()
+    if verifycap:
+        data[1]['verify_uri'] = verifycap.to_string()
+    if edge_metadata is not None:
+        data[1]['metadata'] = edge_metadata
+
+    return text_plain(simplejson.dumps(data, indent=1) + "\n", ctx)
+
+def FileURI(ctx, filenode):
+    return text_plain(filenode.get_uri(), ctx)
+
+def FileReadOnlyURI(ctx, filenode):
+    if filenode.is_readonly():
+        return text_plain(filenode.get_uri(), ctx)
+    return text_plain(filenode.get_readonly_uri(), ctx)


### PR DESCRIPTION
Hi, here's my second attempt at this problem.

What works: Verifycaps can be manipulated via the Web UI and CLI tool in the expected ways. Based on feedback from last time, opening up a verifycap in the Web UI will default to the "info" view. Tests pass.

What doesn't work: Don't know yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/408)
<!-- Reviewable:end -->
