### PR TITLE
explicit Python 2.7 virtualenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ pre-release code), you should create a virtualenv and install into that:
 
 * ``git clone https://github.com/tahoe-lafs/tahoe-lafs.git``
 * ``cd tahoe-lafs``
-* ``virtualenv venv``
+* ``virtualenv --python=python2.7 venv``
 * ``venv/bin/pip install --editable .``
 * ``venv/bin/tahoe --version``
 


### PR DESCRIPTION
Hi there,

I added Python 2.7 as an explicit option to the virtualenv command. I tripped over it and ended up with a non 2.7 version which resulted in more issues down the road.

Cheers,
tpltnt