### PR TITLE
explicit path to tahoe.cfg in creation message

### DIFF
--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -351,10 +351,10 @@ def create_node(config):
 
     print >>out, "Node created in %s" % quote_local_unicode_path(basedir)
     if not config.get("introducer", ""):
-        print >>out, " Please set [client]introducer.furl= in tahoe.cfg!"
+        print >>out, " Please set [client]introducer.furl= in %s/tahoe.cfg'!" % quote_local_unicode_path(basedir)[:-1]
         print >>out, " The node cannot connect to a grid without it."
     if not config.get("nickname", ""):
-        print >>out, " Please set [node]nickname= in tahoe.cfg"
+        print >>out, " Please set [node]nickname= in %s/tahoe.cfg'" % quote_local_unicode_path(basedir)[:-1]
     defer.returnValue(0)
 
 def create_client(config):


### PR DESCRIPTION
Hi there,

I changed the message of `tahoe create-client` to be explicit about the location of the configuration file. The old message is:
```(venv)foo% tahoe create-client
Node created in '/home/foo/.tahoe'
 Please set [client]introducer.furl= in tahoe.cfg!
 The node cannot connect to a grid without it.
 Please set [node]nickname= in tahoe.cfg
```
The new message is:
```
(venv)foo% tahoe create-client                           
Node created in '/home/foo/.tahoe'
 Please set [client]introducer.furl= in '/home/foo/.tahoe/tahoe.cfg'!
 The node cannot connect to a grid without it.
 Please set [node]nickname= in '/home/foo/.tahoe/tahoe.cfg'
```
This should speed up locating the `tahoe.cfg` file for newcomers.

Cheers,
tpltnt