### PR TITLE
enforce Python 2.7 during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ def read_version_py(infname):
         if mo:
             return mo.group(1)
 
+# make sure we have a proper version of python
+if 2 != sys.version_info.major:
+    raise RuntimeError("Python version 2 is required")
+
+# source all the other data
 VERSION_PY_FILENAME = 'src/allmydata/_version.py'
 version = read_version_py(VERSION_PY_FILENAME)
 


### PR DESCRIPTION
Hi there,

this patch raises a RuntimeError if Python 2.7 is not used for the installation. Multiple people recently tried to install tahoe-lafs on Python 3 (despite the hint in the readme) so I made it hard to do the wrong thing.

Cheers,
tpltnt