### PR TITLE
Add support for binary builds with PyInstaller

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -1,0 +1,102 @@
+# -*- mode: python -*-
+
+from __future__ import print_function
+
+from distutils.sysconfig import get_python_lib
+import hashlib
+import os
+import platform
+import shutil
+import struct
+import sys
+
+
+if not hasattr(sys, 'real_prefix'):
+    sys.exit("Please run inside a virtualenv with Tahoe-LAFS installed.")
+
+
+# Ugly hack to disable the setuptools requirement asserted in '_auto_deps.py'.
+# Without patching out this requirement, frozen binaries will fail at runtime.
+autodeps_path = os.path.join(get_python_lib(), 'allmydata', '_auto_deps.py')
+print("Patching '{}' to remove setuptools check...".format(autodeps_path))
+autodeps_path_backup = autodeps_path + '.backup'
+shutil.copy2(autodeps_path, autodeps_path_backup)
+with open(autodeps_path_backup) as src, open(autodeps_path, 'w+') as dest:
+    dest.write(src.read().replace('"setuptools >=', '#"setuptools >='))
+print("Done!")
+
+
+options = [('u', None, 'OPTION')]  # Unbuffered stdio
+
+added_files = [
+    ('COPYING.*', '.'),
+    ('CREDITS', '.'),
+    ('relnotes.txt', '.'),
+    ('src/allmydata/web/*.xhtml', 'allmydata/web'),
+    ('src/allmydata/web/static/*', 'allmydata/web/static'),
+    ('src/allmydata/web/static/css/*', 'allmydata/web/static/css'),
+    ('src/allmydata/web/static/img/*.png', 'allmydata/web/static/img')]
+
+a = Analysis(
+    ['static/tahoe.py'],
+    pathex=[],
+    binaries=None,
+    datas=added_files,
+    hiddenimports=['characteristic', 'cffi'],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=None)
+
+pyz = PYZ(
+    a.pure,
+    a.zipped_data,
+    cipher=None)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    options,
+    exclude_binaries=True,
+    name='tahoe',
+    debug=False,
+    strip=False,
+    upx=False,
+    console=True)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name='Tahoe-LAFS')
+
+
+# Revert the '_auto_deps.py' patch above
+shutil.move(autodeps_path_backup, autodeps_path)
+
+
+print("Creating archive...")
+platform_tag = platform.system().replace('Darwin', 'MacOS')
+bitness_tag = str(struct.calcsize('P') * 8) + 'bit'
+archive_name = 'Tahoe-LAFS-{}-{}'.format(platform_tag, bitness_tag)
+if sys.platform == 'win32':
+    archive_format = 'zip'
+    archive_suffix = '.zip'
+else:
+    archive_format = 'gztar'
+    archive_suffix = '.tar.gz'
+base_name = os.path.join('dist', archive_name)
+shutil.make_archive(base_name, archive_format, 'dist', 'Tahoe-LAFS')
+
+print("Hashing (SHA256)...")
+archive_path = base_name + archive_suffix
+hasher = hashlib.sha256()
+with open(archive_path, 'rb') as f:
+    for block in iter(lambda: f.read(4096), b''):
+        hasher.update(block)
+print("{}  {}".format(hasher.hexdigest(), archive_path))

--- a/tox.ini
+++ b/tox.ini
@@ -102,3 +102,17 @@ deps =
 skip_install = True
 commands =
          sphinx-build -b html -d {toxinidir}/docs/_build/doctrees {toxinidir}/docs {toxinidir}/docs/_build/html
+
+[testenv:pyinstaller]
+basepython=python2.7
+# Do not use the '--editable' flag for this testenv as the 'pyinstaller.spec'
+# script called below will need patch the source tree at build-time in order
+# to remove the setuptools requirement from '_auto_deps.py' (and we want to
+# avoid race-conditions when running tests in parallel, e.g., with "detox").
+deps =
+    .
+    pyinstaller
+# Setting PYTHONHASHSEED to a known value assists with reproducible builds.
+# See https://pyinstaller.readthedocs.io/en/stable/advanced-topics.html#creating-a-reproducible-build
+setenv=PYTHONHASHSEED=1
+commands=pyinstaller -y --clean pyinstaller.spec


### PR DESCRIPTION
This PR adds support for building portable, self-contained `tahoe` binary distributions for all major desktop platforms (GNU/Linux, Mac, and Windows) via [PyInstaller](http://www.pyinstaller.org/), partly resolving [trac ticket 2729](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2729). This is implementation is similar to what I've used elsewhere (and extensively tested) for [the Gridsync project](http://gridsync.io) but with a some minor cleanups and additions that I thought might be useful for integrating with Tahoe-LAFS' own buildbot/CI/deployment pipeline (like exporting artifacts in platform-prefered archive-formats, labeling their bitness in the resultant filename, and printing out their SH256 hash digests along the way).

Although probably not strictly necessary, I've decided to implement this using a `tox` testenv in order to provide stronger isolation during the build process (since I set `PYTHONHASHSEED=1` to [provide partial reproducibility](https://pyinstaller.readthedocs.io/en/stable/advanced-topics.html#creating-a-reproducible-build) and patch the [`setuptools` check](https://github.com/tahoe-lafs/tahoe-lafs/blob/master/src/allmydata/_auto_deps.py#L23) out of `_auto_deps.py` at buildtime to prevent a runtime exception -- either of which could lead to issues if you're parallelizing your test run with [`detox`](https://pypi.python.org/pypi/detox) or similar); to make a binary distribution, simply run the following command (with `tox` installed):

`tox -e pyinstaller`

Assuming all goes well, when the build process completes, you'll find an appropriately-labeled archive inside of `dist/` (e.g., "Tahoe-LAFS-Windows-32bit.zip", "Tahoe-LAFS-MacOS-64bit.tar.gz") containing everything needed to run Tahoe-LAFS on that target platform. The end-user need only extract the archive _somewhere_ on their system and run the `tahoe` executable contained therein (`tahoe.exe` on Windows); no `python2` installation is required to be present on the host system.

Please note, however, that the various caveats listed in [trac ticket 2729](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2729) still apply. In particular, PyInstaller's binaries are [not guaranteed to be backwards-compatible](https://pyinstaller.readthedocs.io/en/stable/usage.html#making-linux-apps-forward-compatible) and, in some cases, are _certainly_ not (as one example, binaries built with Travis-CI's `osx` images -- which run Mac OS X 10.10 -- will not run on the old iMac in my office -- which runs OS X 10.9 -- _however_, binaries built on my iMac will run without issue on Travis and other machines that I've tested running 10.10). Accordingly, it is recommended to distribute artifacts that were built on older operating systems so as to increase the likelihood of them running on as many systems as possible.

On that note, once this PR lands -- or even if it doesn't -- I would be happy to donate some Mac and Windows VMs/buildslaves to tahoe-lafs.org's buildbot fleet (which I'm already [running for Gridsync](https://buildbot.gridsync.io/waterfall) anyway) and/or help streamline deployments through Travis-CI/AppVeyor (the latter of which, I think, we already depend on for building wheels?).