### PR TITLE
setup.py: allow py3 to run `sdist`, so tox3 still works

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,10 @@ def read_version_py(infname):
         if mo:
             return mo.group(1)
 
-# make sure we have a proper version of python
-if 2 != sys.version_info.major:
-    raise RuntimeError("Python version 2 is required")
+if len(sys.argv) > 1 and sys.argv[1] in ("install", "egg_info"):
+    # make sure we have a proper version of python
+    if 2 != sys.version_info.major:
+        raise RuntimeError("Python version 2 is required")
 
 VERSION_PY_FILENAME = 'src/allmydata/_version.py'
 version = read_version_py(VERSION_PY_FILENAME)


### PR DESCRIPTION
The previous blanket prohibition on py3 for any invocation of setup.py was
breaking our recommended "just run 'tox'" test process on e.g. Ubuntu-16.04
LTS "xenial", which ships with a /usr/bin/tox that is based on py3. This tox
runs "setup.py sdist" to build a tahoe tarball, then uses its py2
virtualenv's "pip" to install it (into the py2 virtualenv). Forbidding even
"setup.py sdist" from running under py3 was causing tox to fail unless it was
a py2-based tox.

This new approach only enforces the py2 check if setup.py was invoked as
"setup.py install" (which users might do), or "setup.py egg_info" (which pip
will do before it does anything else).

I experimented with doing the check inside an EggInfo or "build_py"
subcommand, but the EggInfo class is invoked internally during an sdist. And
we need pip3's egg_info to fail, because if it succeeds, it will proceed to
run egg_info on our dependencies (like zfec, whose setup.py contains
old-style py2-only 'print "foo"' statements, which causes a syntax error,
which is the confusing thing we were trying to head off by providing a
clean+instructional error message early).

closes ticket:2876