### PR TITLE
travis: see what fails if we turn off sudo mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: required
+sudo: false
 os:
  - "linux"
  - "osx"


### PR DESCRIPTION
not for merge, I just want to see what currently happens without 'sudo'

My thought is that the OS-X build has sudo already (and wants it to install pip), so that should work even without the `.travis.yml` asking for it. The linux build wants sudo so the integration test can apt-install Tor, but maybe we could use a system tor, or maybe we could move the integration test into a separate environment.

My hope is to let the main tests run faster, by using a container instead of a full sudo-capable VM.