### PR TITLE
revert the 1d1653d changes from 2857-deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -285,7 +285,6 @@ setup(name="tahoe-lafs", # also set in __init__.py
               "pytest",
               "pytest-twisted",
               "hypothesis >= 3.6.1",
-              "treq",
           ],
           "tor": [
               "foolscap[tor] >= 0.12.5",

--- a/src/allmydata/test/common_web.py
+++ b/src/allmydata/test/common_web.py
@@ -1,9 +1,7 @@
 
 import re
-import treq
 from twisted.internet import defer
 from twisted.web import client
-from twisted.web.error import Error
 from nevow.testutil import FakeRequest
 from nevow import inevow, context
 
@@ -83,13 +81,3 @@ class HTTPClientHEADFactory(client.HTTPClientFactory):
 
 class HTTPClientGETFactory(client.HTTPClientFactory):
     protocol = MyGetter
-
-@defer.inlineCallbacks
-def do_http(method, url, **kwargs):
-    response = yield treq.request(method, url, persistent=False, **kwargs)
-    body = yield treq.content(response)
-    # TODO: replace this with response.fail_for_status when
-    # https://github.com/twisted/treq/pull/159 has landed
-    if 400 <= response.code < 600:
-        raise Error(response.code, response=body)
-    defer.returnValue(body)

--- a/src/allmydata/test/test_deepcheck.py
+++ b/src/allmydata/test/test_deepcheck.py
@@ -2,7 +2,6 @@
 import os, json, urllib
 from twisted.trial import unittest
 from twisted.internet import defer
-from twisted.internet.defer import inlineCallbacks, returnValue
 from allmydata.immutable import upload
 from allmydata.mutable.common import UnrecoverableFileError
 from allmydata.mutable.publish import MutableData
@@ -12,11 +11,11 @@ from allmydata.interfaces import ICheckResults, ICheckAndRepairResults, \
      IDeepCheckResults, IDeepCheckAndRepairResults
 from allmydata.monitor import Monitor, OperationCancelledError
 from allmydata.uri import LiteralFileURI
+from twisted.web.client import getPage
 
 from allmydata.test.common import ErrorMixin, _corrupt_mutable_share_data, \
      ShouldFailMixin
 from .common_util import StallMixin, run_cli
-from .common_web import do_http
 from allmydata.test.no_network import GridTestMixin
 from .cli.common import CLITestMixin
 
@@ -149,47 +148,54 @@ class DeepCheckBase(GridTestMixin, ErrorMixin, StallMixin, ShouldFailMixin,
                 le.args = tuple(le.args + (unit,))
                 raise
 
-    @inlineCallbacks
     def web(self, n, method="GET", **kwargs):
         # returns (data, url)
         url = (self.client_baseurls[0] + "uri/%s" % urllib.quote(n.get_uri())
                + "?" + "&".join(["%s=%s" % (k,v) for (k,v) in kwargs.items()]))
-        data = yield do_http(method, url, browser_like_redirects=True)
-        returnValue((data,url))
+        d = getPage(url, method=method)
+        d.addCallback(lambda data: (data,url))
+        return d
 
-    @inlineCallbacks
-    def wait_for_operation(self, ophandle):
+    def wait_for_operation(self, ignored, ophandle):
         url = self.client_baseurls[0] + "operations/" + ophandle
         url += "?t=status&output=JSON"
-        while True:
-            body = yield do_http("get", url)
-            data = json.loads(body)
-            if data["finished"]:
-                break
-            yield self.stall(delay=0.1)
-        returnValue(data)
+        d = getPage(url)
+        def _got(res):
+            try:
+                data = json.loads(res)
+            except ValueError:
+                self.fail("%s: not JSON: '%s'" % (url, res))
+            if not data["finished"]:
+                d = self.stall(delay=1.0)
+                d.addCallback(self.wait_for_operation, ophandle)
+                return d
+            return data
+        d.addCallback(_got)
+        return d
 
-    @inlineCallbacks
-    def get_operation_results(self, ophandle, output=None):
+    def get_operation_results(self, ignored, ophandle, output=None):
         url = self.client_baseurls[0] + "operations/" + ophandle
         url += "?t=status"
         if output:
             url += "&output=" + output
-        body = yield do_http("get", url)
-        if output and output.lower() == "json":
-            data = json.loads(body)
-        else:
-            data = body
-        returnValue(data)
+        d = getPage(url)
+        def _got(res):
+            if output and output.lower() == "json":
+                try:
+                    return json.loads(res)
+                except ValueError:
+                    self.fail("%s: not JSON: '%s'" % (url, res))
+            return res
+        d.addCallback(_got)
+        return d
 
-    @inlineCallbacks
     def slow_web(self, n, output=None, **kwargs):
         # use ophandle=
         handle = base32.b2a(os.urandom(4))
-        yield self.web(n, "POST", ophandle=handle, **kwargs)
-        yield self.wait_for_operation(handle)
-        data = yield self.get_operation_results(handle, output=output)
-        returnValue(data)
+        d = self.web(n, "POST", ophandle=handle, **kwargs)
+        d.addCallback(self.wait_for_operation, handle)
+        d.addCallback(self.get_operation_results, handle, output=output)
+        return d
 
 
 class DeepCheckWebGood(DeepCheckBase, unittest.TestCase):

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -2,10 +2,10 @@ import os.path
 from twisted.trial import unittest
 from foolscap.api import fireEventually, flushEventualQueue
 from allmydata.util import fileutil
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 from allmydata.introducer import IntroducerNode
 from .common import FAVICON_MARKUP
-from ..common_web import do_http
+from ..common_web import HTTPClientGETFactory
 
 class IntroducerWeb(unittest.TestCase):
     def setUp(self):
@@ -18,7 +18,6 @@ class IntroducerWeb(unittest.TestCase):
         d.addCallback(flushEventualQueue)
         return d
 
-    @defer.inlineCallbacks
     def test_welcome(self):
         basedir = "web.IntroducerWeb.test_welcome"
         os.mkdir(basedir)
@@ -30,12 +29,31 @@ class IntroducerWeb(unittest.TestCase):
         self.node = IntroducerNode(basedir)
         self.ws = self.node.getServiceNamed("webish")
 
-        yield fireEventually(None)
-        self.node.startService()
+        d = fireEventually(None)
+        d.addCallback(lambda ign: self.node.startService())
 
-        url = "http://localhost:%d/" % self.ws.getPortnum()
-        res = yield do_http("get", url)
-        self.failUnlessIn('Welcome to the Tahoe-LAFS Introducer', res)
-        self.failUnlessIn(FAVICON_MARKUP, res)
-        self.failUnlessIn('Page rendered at', res)
-        self.failUnlessIn('Tahoe-LAFS code imported from:', res)
+        d.addCallback(lambda ign: self.GET("/"))
+        def _check(res):
+            self.failUnlessIn('Welcome to the Tahoe-LAFS Introducer', res)
+            self.failUnlessIn(FAVICON_MARKUP, res)
+            self.failUnlessIn('Page rendered at', res)
+            self.failUnlessIn('Tahoe-LAFS code imported from:', res)
+        d.addCallback(_check)
+        return d
+
+    def GET(self, urlpath, followRedirect=False, return_response=False,
+            **kwargs):
+        # if return_response=True, this fires with (data, statuscode,
+        # respheaders) instead of just data.
+        assert not isinstance(urlpath, unicode)
+        url = self.ws.getURL().rstrip('/') + urlpath
+        factory = HTTPClientGETFactory(url, method="GET",
+                                       followRedirect=followRedirect, **kwargs)
+        reactor.connectTCP("localhost", self.ws.getPortnum(), factory)
+        d = factory.deferred
+        def _got_data(data):
+            return (data, factory.status, factory.response_headers)
+        if return_response:
+            d.addCallback(_got_data)
+        return factory.deferred
+

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1,11 +1,9 @@
 import os.path, re, urllib, time, cgi
 import json
-import treq
 
 from twisted.application import service
 from twisted.trial import unittest
 from twisted.internet import defer, reactor
-from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.task import Clock
 from twisted.web import client, error, http
 from twisted.python import failure, log
@@ -29,7 +27,7 @@ from ..common import FakeCHKFileNode, FakeMutableFileNode, \
 from allmydata.interfaces import IMutableFileNode, SDMF_VERSION, MDMF_VERSION
 from allmydata.mutable import servermap, publish, retrieve
 from .. import common_util as testutil
-from ..common_web import HTTPClientGETFactory, do_http, Error
+from ..common_web import HTTPClientGETFactory, HTTPClientHEADFactory
 from allmydata.client import Client, SecretHolder
 from .common import unknown_rwcap, unknown_rocap, unknown_immcap, FAVICON_MARKUP
 # create a fake uploader/downloader, and a couple of fake dirnodes, then
@@ -491,25 +489,25 @@ class WebMixin(testutil.TimezoneMixin):
             d.addCallback(_got_data)
         return factory.deferred
 
-    @inlineCallbacks
-    def HEAD(self, urlpath, return_response=False, headers={}):
-        url = self.webish_url + urlpath
-        response = yield treq.request("head", url, persistent=False,
-                                      headers=headers)
-        if 400 <= response.code < 600:
-            raise Error(response.code, response="")
-        resp_headers = {}
-        for (key, values) in response.headers.getAllRawHeaders():
-            resp_headers[key.lower()] = values
-        returnValue( ("", response.code, resp_headers) )
+    def HEAD(self, urlpath, return_response=False, **kwargs):
+        # this requires some surgery, because twisted.web.client doesn't want
+        # to give us back the response headers.
+        factory = HTTPClientHEADFactory(urlpath, method="HEAD", **kwargs)
+        reactor.connectTCP("localhost", self.webish_port, factory)
+        d = factory.deferred
+        def _got_data(data):
+            return (data, factory.status, factory.response_headers)
+        if return_response:
+            d.addCallback(_got_data)
+        return factory.deferred
 
-    def PUT(self, urlpath, data, headers={}):
+    def PUT(self, urlpath, data, **kwargs):
         url = self.webish_url + urlpath
-        return do_http("put", url, data=data, headers=headers)
+        return client.getPage(url, method="PUT", postdata=data, **kwargs)
 
     def DELETE(self, urlpath):
         url = self.webish_url + urlpath
-        return do_http("delete", url)
+        return client.getPage(url, method="DELETE")
 
     def POST(self, urlpath, followRedirect=False, **fields):
         sepbase = "boogabooga"


### PR DESCRIPTION
Let's see if this also fixes the integration tests

I don't particularly want to land this, but I want to see if the integration test is failing specifically because of these changes, or if something else has broken it. (they were working on the PR)
