### PR TITLE
dictutil: fix bug in str(ValueOrderedDict), and improve test coverage

### DIFF
--- a/src/allmydata/util/dictutil.py
+++ b/src/allmydata/util/dictutil.py
@@ -436,8 +436,12 @@ class ValueOrderedDict:
             s.append(str(x[0])); s.append(": "); s.append(str(x[1]))
             i = 1
             while (n is None) or (i < n):
+                i += 1
                 x = iter.next()
-                s.append(", "); s.append(str(x[0])); s.append(": "); s.append(str(x[1]))
+                s.append(", ");
+                s.append(str(x[0])); s.append(": "); s.append(str(x[1]))
+            # if we get here, we're truncating the repr, so make that clear
+            s.append(", ...")
         except StopIteration:
             pass
         s.append("}")


### PR DESCRIPTION
It looks like str() was meant to truncate the dict, but a missing i+=1 meant
that it never actually did. I also changed the format to include a clear
"..." in case we truncate it, to avoid confusion with a non-truncated dict of
the same size.

This also improves test coverage in subtract() and
NumDict.item_with_largest_value().