### PR TITLE
2889 tub port listen

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -150,6 +150,14 @@ set the ``tub.location`` option described below.
     Lists of endpoint descriptor strings like the following ``tcp:12345,tcp6:12345``
     are known to not work because an ``Address already in use.`` error.
 
+    If any descriptor begins with ``listen:tor``, or ``listen:i2p``, the
+    corresponding tor/i2p Provider object will construct additional endpoints
+    for the Tub to listen on. This allows the ``[tor]`` or ``[i2p]`` sections
+    in ``tahoe.cfg`` to customize the endpoint; e.g. to add I2CP control
+    options. If you use ``listen:i2p``, you should not also have an
+    ``i2p:..`` endpoint in ``tub.port``, as that would result in multiple
+    I2P-based listeners.
+
     If ``tub.port`` is the string ``disabled``, the node will not listen at
     all, and thus cannot accept connections from other nodes. If ``[storage]
     enabled = true``, or ``[helper] enabled = true``, or the node is an

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -401,6 +401,11 @@ class Node(service.MultiService):
                 if port in ("0", "tcp:0"):
                     raise ValueError("tub.port cannot be 0: you must choose")
                 if port == "listen:i2p":
+                    # the I2P provider will read its section of tahoe.cfg and
+                    # return either a fully-formed Endpoint, or a descriptor
+                    # that will create one, so we don't have to stuff all the
+                    # options into the tub.port string (which would need a lot
+                    # of escaping)
                     port_or_endpoint = self._i2p_provider.get_listener()
                 elif port == "listen:tor":
                     port_or_endpoint = self._tor_provider.get_listener()

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -400,7 +400,13 @@ class Node(service.MultiService):
             for port in tubport.split(","):
                 if port in ("0", "tcp:0"):
                     raise ValueError("tub.port cannot be 0: you must choose")
-                self.tub.listenOn(port)
+                if port == "listen:i2p":
+                    port_or_endpoint = self._i2p_provider.get_listener()
+                elif port == "listen:tor":
+                    port_or_endpoint = self._tor_provider.get_listener()
+                else:
+                    port_or_endpoint = port
+                self.tub.listenOn(port_or_endpoint)
             self.tub.setLocation(location)
             self._tub_is_listening = True
             self.log("Tub location set to %s" % (location,))

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -251,12 +251,12 @@ def write_node_config(c, config):
     else:
         if "tor" in listeners:
             (tor_config, tor_port, tor_location) = \
-                         yield tor_provider.create_onion(reactor, config)
+                         yield tor_provider.create_config(reactor, config)
             tub_ports.append(tor_port)
             tub_locations.append(tor_location)
         if "i2p" in listeners:
             (i2p_config, i2p_port, i2p_location) = \
-                         yield i2p_provider.create_dest(reactor, config)
+                         yield i2p_provider.create_config(reactor, config)
             tub_ports.append(i2p_port)
             tub_locations.append(i2p_location)
         if "tcp" in listeners:

--- a/src/allmydata/test/cli/test_create.py
+++ b/src/allmydata/test/cli/test_create.py
@@ -261,7 +261,7 @@ class Config(unittest.TestCase):
     def test_node_slow_tor(self):
         basedir = self.mktemp()
         d = defer.Deferred()
-        with mock.patch("allmydata.util.tor_provider.create_onion",
+        with mock.patch("allmydata.util.tor_provider.create_config",
                         return_value=d):
             d2 = run_cli("create-node", "--listen=tor", basedir)
             d.callback(({}, "port", "location"))
@@ -274,7 +274,7 @@ class Config(unittest.TestCase):
     def test_node_slow_i2p(self):
         basedir = self.mktemp()
         d = defer.Deferred()
-        with mock.patch("allmydata.util.i2p_provider.create_dest",
+        with mock.patch("allmydata.util.i2p_provider.create_config",
                         return_value=d):
             d2 = run_cli("create-node", "--listen=i2p", basedir)
             d.callback(({}, "port", "location"))
@@ -325,9 +325,9 @@ class Tor(unittest.TestCase):
         tor_config = {"abc": "def"}
         tor_port = "ghi"
         tor_location = "jkl"
-        onion_d = defer.succeed( (tor_config, tor_port, tor_location) )
-        with mock.patch("allmydata.util.tor_provider.create_onion",
-                        return_value=onion_d) as co:
+        config_d = defer.succeed( (tor_config, tor_port, tor_location) )
+        with mock.patch("allmydata.util.tor_provider.create_config",
+                        return_value=config_d) as co:
             rc, out, err = self.successResultOf(
                 run_cli("create-node", "--listen=tor", basedir))
         self.assertEqual(len(co.mock_calls), 1)
@@ -345,9 +345,9 @@ class Tor(unittest.TestCase):
         tor_config = {"abc": "def"}
         tor_port = "ghi"
         tor_location = "jkl"
-        onion_d = defer.succeed( (tor_config, tor_port, tor_location) )
-        with mock.patch("allmydata.util.tor_provider.create_onion",
-                        return_value=onion_d) as co:
+        config_d = defer.succeed( (tor_config, tor_port, tor_location) )
+        with mock.patch("allmydata.util.tor_provider.create_config",
+                        return_value=config_d) as co:
             rc, out, err = self.successResultOf(
                 run_cli("create-node", "--listen=tor", "--tor-launch",
                         basedir))
@@ -361,9 +361,9 @@ class Tor(unittest.TestCase):
         tor_config = {"abc": "def"}
         tor_port = "ghi"
         tor_location = "jkl"
-        onion_d = defer.succeed( (tor_config, tor_port, tor_location) )
-        with mock.patch("allmydata.util.tor_provider.create_onion",
-                        return_value=onion_d) as co:
+        config_d = defer.succeed( (tor_config, tor_port, tor_location) )
+        with mock.patch("allmydata.util.tor_provider.create_config",
+                        return_value=config_d) as co:
             rc, out, err = self.successResultOf(
                 run_cli("create-node", "--listen=tor", "--tor-control-port=mno",
                         basedir))
@@ -400,7 +400,7 @@ class I2P(unittest.TestCase):
         i2p_port = "ghi"
         i2p_location = "jkl"
         dest_d = defer.succeed( (i2p_config, i2p_port, i2p_location) )
-        with mock.patch("allmydata.util.i2p_provider.create_dest",
+        with mock.patch("allmydata.util.i2p_provider.create_config",
                         return_value=dest_d) as co:
             rc, out, err = self.successResultOf(
                 run_cli("create-node", "--listen=i2p", basedir))
@@ -427,7 +427,7 @@ class I2P(unittest.TestCase):
         i2p_port = "ghi"
         i2p_location = "jkl"
         dest_d = defer.succeed( (i2p_config, i2p_port, i2p_location) )
-        with mock.patch("allmydata.util.i2p_provider.create_dest",
+        with mock.patch("allmydata.util.i2p_provider.create_config",
                         return_value=dest_d) as co:
             rc, out, err = self.successResultOf(
                 run_cli("create-node", "--listen=i2p", "--i2p-sam-port=mno",

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -178,7 +178,7 @@ class CreateDest(unittest.TestCase):
                                                           "i2p_dest.privkey"),
                     }
         self.assertEqual(tahoe_config_i2p, expected)
-        self.assertEqual(i2p_port, "i2p:%s:3457:api=SAM:apiEndpoint=goodport" % privkeyfile)
+        self.assertEqual(i2p_port, "listen:i2p")
         self.assertEqual(i2p_location, "i2p:FOOBAR.b32.i2p:3457")
 
 _None = object()
@@ -293,6 +293,28 @@ class Provider(unittest.TestCase):
         h = p.get_i2p_handler()
         self.assertIs(h, handler)
         i2p.default.assert_called_with(reactor, keyfile=None)
+
+class Provider_Listener(unittest.TestCase):
+    def test_listener(self):
+        i2p = mock.Mock()
+        handler = object()
+        i2p.local_i2p = mock.Mock(return_value=handler)
+        reactor = object()
+
+        privkeyfile = os.path.join("private", "i2p_dest.privkey")
+        with mock_i2p(i2p):
+            p = i2p_provider.Provider("basedir",
+                                      FakeConfig(**{
+                                          "i2p.configdir": "configdir",
+                                          "sam.port": "goodport",
+                                          "dest": "true",
+                                          "dest.port": "3457",
+                                          "dest.private_key_file": privkeyfile,
+                                          }),
+                                      reactor)
+            endpoint_or_description = p.get_listener()
+        self.assertEqual(endpoint_or_description,
+                         "i2p:%s:3457:api=SAM:apiEndpoint=goodport" % privkeyfile)
 
 class Provider_CheckI2PConfig(unittest.TestCase):
     def test_default(self):

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -311,7 +311,7 @@ class ProviderListener(unittest.TestCase):
             p = i2p_provider.Provider("basedir",
                                       FakeConfig(**{
                                           "i2p.configdir": "configdir",
-                                          "sam.port": "goodport",
+                                          "sam.port": "good:port",
                                           "dest": "true",
                                           "dest.port": "3457",
                                           "dest.private_key_file": privkeyfile,
@@ -319,7 +319,7 @@ class ProviderListener(unittest.TestCase):
                                       reactor)
             endpoint_or_description = p.get_listener()
         self.assertEqual(endpoint_or_description,
-                         "i2p:%s:3457:api=SAM:apiEndpoint=goodport" % privkeyfile)
+                         "i2p:%s:3457:api=SAM:apiEndpoint=good\\:port" % privkeyfile)
 
 class Provider_CheckI2PConfig(unittest.TestCase):
     def test_default(self):

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -124,7 +124,7 @@ class CreateDest(unittest.TestCase):
     def test_no_txi2p(self):
         with mock.patch("allmydata.util.i2p_provider._import_txi2p",
                         return_value=None):
-            d = i2p_provider.create_dest("reactor", "cli_config")
+            d = i2p_provider.create_config("reactor", "cli_config")
             f = self.failureResultOf(d)
             self.assertIsInstance(f.value, ValueError)
             self.assertEqual(str(f.value),
@@ -164,7 +164,7 @@ class CreateDest(unittest.TestCase):
                             connect_to_i2p):
                 with mock.patch("allmydata.util.i2p_provider.clientFromString",
                                 return_value=ep) as cfs:
-                    d = i2p_provider.create_dest(reactor, cli_config)
+                    d = i2p_provider.create_config(reactor, cli_config)
         tahoe_config_i2p, i2p_port, i2p_location = self.successResultOf(d)
 
         connect_to_i2p.assert_called_with(reactor, cli_config, txi2p)

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -294,8 +294,13 @@ class Provider(unittest.TestCase):
         self.assertIs(h, handler)
         i2p.default.assert_called_with(reactor, keyfile=None)
 
-class Provider_Listener(unittest.TestCase):
+class ProviderListener(unittest.TestCase):
     def test_listener(self):
+        """Does the I2P Provider object's get_listener() method correctly
+        convert the [i2p] section of tahoe.cfg into an
+        endpoint/descriptor?
+        """
+
         i2p = mock.Mock()
         handler = object()
         i2p.local_i2p = mock.Mock(return_value=handler)

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -393,8 +393,12 @@ class Provider(unittest.TestCase):
         self.assertIs(h, handler)
         tor.default_socks.assert_called_with()
 
-class Provider_Listener(unittest.TestCase):
+class ProviderListener(unittest.TestCase):
     def test_listener(self):
+        """Does the Tor Provider object's get_listener() method correctly
+        convert the [tor] section of tahoe.cfg into an
+        endpoint/descriptor?
+        """
         tor = mock.Mock()
         handler = object()
         tor.socks_endpoint = mock.Mock(return_value=handler)

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -393,6 +393,20 @@ class Provider(unittest.TestCase):
         self.assertIs(h, handler)
         tor.default_socks.assert_called_with()
 
+class Provider_Listener(unittest.TestCase):
+    def test_listener(self):
+        tor = mock.Mock()
+        handler = object()
+        tor.socks_endpoint = mock.Mock(return_value=handler)
+        reactor = object()
+
+        with mock_tor(tor):
+            p = tor_provider.Provider("basedir",
+                                      FakeConfig(**{"onion.local_port": "321"}),
+                                      reactor)
+            endpoint_or_description = p.get_listener()
+        self.assertEqual(endpoint_or_description, "tcp:321:interface=127.0.0.1")
+
 class Provider_CheckOnionConfig(unittest.TestCase):
     def test_default(self):
         # default config doesn't start an onion service, so it should be

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -408,8 +408,13 @@ class ProviderListener(unittest.TestCase):
             p = tor_provider.Provider("basedir",
                                       FakeConfig(**{"onion.local_port": "321"}),
                                       reactor)
+        fake_ep = object()
+        with mock.patch("allmydata.util.tor_provider.TCP4ServerEndpoint",
+                        return_value=fake_ep) as e:
             endpoint_or_description = p.get_listener()
-        self.assertEqual(endpoint_or_description, "tcp:321:interface=127.0.0.1")
+        self.assertIs(endpoint_or_description, fake_ep)
+        self.assertEqual(e.mock_calls, [mock.call(reactor, 321,
+                                                  interface="127.0.0.1")])
 
 class Provider_CheckOnionConfig(unittest.TestCase):
     def test_default(self):

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -152,7 +152,7 @@ class CreateOnion(unittest.TestCase):
     def test_no_txtorcon(self):
         with mock.patch("allmydata.util.tor_provider._import_txtorcon",
                         return_value=None):
-            d = tor_provider.create_onion("reactor", "cli_config")
+            d = tor_provider.create_config("reactor", "cli_config")
             f = self.failureResultOf(d)
             self.assertIsInstance(f.value, ValueError)
             self.assertEqual(str(f.value),
@@ -184,7 +184,7 @@ class CreateOnion(unittest.TestCase):
                             launch_tor):
                 with mock.patch("allmydata.util.tor_provider.allocate_tcp_port",
                                 return_value=999999):
-                    d = tor_provider.create_onion(reactor, cli_config)
+                    d = tor_provider.create_config(reactor, cli_config)
         tahoe_config_tor, tor_port, tor_location = self.successResultOf(d)
 
         launch_tor.assert_called_with(reactor, executable,
@@ -238,7 +238,7 @@ class CreateOnion(unittest.TestCase):
                             connect_to_tor):
                 with mock.patch("allmydata.util.tor_provider.allocate_tcp_port",
                                 return_value=999999):
-                    d = tor_provider.create_onion(reactor, cli_config)
+                    d = tor_provider.create_config(reactor, cli_config)
         tahoe_config_tor, tor_port, tor_location = self.successResultOf(d)
 
         connect_to_tor.assert_called_with(reactor, cli_config, txtorcon)

--- a/src/allmydata/util/i2p_provider.py
+++ b/src/allmydata/util/i2p_provider.py
@@ -65,7 +65,7 @@ def _connect_to_i2p(reactor, cli_config, txi2p):
         raise ValueError("unable to reach any default I2P SAM port")
 
 @inlineCallbacks
-def create_dest(reactor, cli_config):
+def create_config(reactor, cli_config):
     txi2p = _import_txi2p()
     if not txi2p:
         raise ValueError("Cannot create I2P Destination without txi2p. "

--- a/src/allmydata/util/tor_provider.py
+++ b/src/allmydata/util/tor_provider.py
@@ -124,7 +124,7 @@ def _connect_to_tor(reactor, cli_config, txtorcon):
         raise ValueError("unable to reach any default Tor control port")
 
 @inlineCallbacks
-def create_onion(reactor, cli_config):
+def create_config(reactor, cli_config):
     txtorcon = _import_txtorcon()
     if not txtorcon:
         raise ValueError("Cannot create onion without txtorcon. "

--- a/src/allmydata/util/tor_provider.py
+++ b/src/allmydata/util/tor_provider.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, with_statement
 import os
 
 from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.internet.endpoints import clientFromString
+from twisted.internet.endpoints import clientFromString, TCP4ServerEndpoint
 from twisted.internet.error import ConnectionRefusedError, ConnectError
 from twisted.application import service
 
@@ -217,9 +217,9 @@ class Provider(service.MultiService):
         return self._node_for_config.get_config("tor", *args, **kwargs)
 
     def get_listener(self):
-        local_port = self._get_tor_config("onion.local_port")
-        tor_port = "tcp:%s:interface=127.0.0.1" % local_port
-        return tor_port
+        local_port = int(self._get_tor_config("onion.local_port"))
+        ep = TCP4ServerEndpoint(self._reactor, local_port, interface="127.0.0.1")
+        return ep
 
     def get_tor_handler(self):
         enabled = self._get_tor_config("enabled", True, boolean=True)

--- a/src/allmydata/util/tor_provider.py
+++ b/src/allmydata/util/tor_provider.py
@@ -216,6 +216,11 @@ class Provider(service.MultiService):
     def _get_tor_config(self, *args, **kwargs):
         return self._node_for_config.get_config("tor", *args, **kwargs)
 
+    def get_listener(self):
+        local_port = self._get_tor_config("onion.local_port")
+        tor_port = "tcp:%s:interface=127.0.0.1" % local_port
+        return tor_port
+
     def get_tor_handler(self):
         enabled = self._get_tor_config("enabled", True, boolean=True)
         if not enabled:


### PR DESCRIPTION
tahoe.cfg: add tub.port=listen:i2p (and/or listen:tor)

This delegates the construction of the server Endpoint object to the i2p/tor
Provider, which can use the i2p/tor section of the config file to add options
which would be awkward to express as text in an endpoint descriptor string.

refs ticket:2889 (but note this merely makes room for a function to be
written that can process I2CP options, it does not actually handle such
options, so it does not close this ticket yet)