### PR TITLE
setup.py: use python_requires= to complain about py3, not an exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,6 @@ def read_version_py(infname):
         if mo:
             return mo.group(1)
 
-# make sure we have a proper version of python
-if 2 != sys.version_info.major:
-    raise RuntimeError("Python version 2 is required")
-
 VERSION_PY_FILENAME = 'src/allmydata/_version.py'
 version = read_version_py(VERSION_PY_FILENAME)
 
@@ -255,6 +251,7 @@ setup(name="tahoe-lafs", # also set in __init__.py
       package_dir = {'':'src'},
       packages=find_packages('src'),
       classifiers=trove_classifiers,
+      python_requires="<3.0",
       install_requires=install_requires,
       extras_require={
           ':sys_platform=="win32"': ["pypiwin32"],


### PR DESCRIPTION
This allows a python3-based tox (as is common on modern debian/ubuntu
systems) to test our py2-only package. The first thing Tox does is to build a
wheel to install into the target virtualenv (which is a py2-based venv, for
tahoe). But Tox bug (https://github.com/tox-dev/tox/issues/507) in which this
wheel is built with the same python that Tox is using, instead of the python
from the target environment. Our setup.py would see sys.version_info with py3
and launch a crowbar into the works.

With python_requires=, pip is smart enough to know that it's ok to build
wheels with the wrong python, but "pip install" still throws a sensible error
message:

```
(ve36) ~/stuff/tahoe/tahoe$ pip install .
Processing /home/warner/stuff/tahoe/tahoe
tahoe-lafs requires Python '<3.0' but the running Python is 3.6.1
```

Closes ticket:2876