### PR TITLE
fix crash when stopping/restarting with an invalid pidfile

### DIFF
--- a/src/allmydata/scripts/startstop_node.py
+++ b/src/allmydata/scripts/startstop_node.py
@@ -185,7 +185,16 @@ def stop(config):
         return 2
     with open(pidfile, "r") as f:
         pid = f.read()
-    pid = int(pid)
+
+    try:
+        pid = int(pid)
+    except ValueError:
+        # The error message below mimics a Twisted error message, which is
+        # displayed when starting a node with an invalid pidfile.
+        print >>err, "Pidfile %s contains non-numeric value" % pidfile
+        # we define rc=2 to mean "nothing is running, but it wasn't me who
+        # stopped it"
+        return 2
 
     # kill it hard (SIGKILL), delete the twistd.pid file, then wait for the
     # process itself to go away. If it hasn't gone away after 20 seconds, warn


### PR DESCRIPTION
I use Tahoe as an vehicle for some fault injection experiments.
For a reason I am not interested in, a node ended up with an empty PID file in its directory (maybe due to a forced VM crash?).
When trying to stop or restart the node, it crashed since it did not handle non-numeric values in the PID file.
This PR attempts to fix this issue.
I decided to not remove the broken PID file, so operators can investigate if they wish to do so.