### PR TITLE
Multi magic folder

### DIFF
--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -488,9 +488,12 @@ class TokenOnlyWebApi(resource.Resource):
         if t == u'json':
             try:
                 return self.post_json(req)
-            except Exception:
+            except WebError as e:
+                req.setResponseCode(e.code)
+                return json.dumps({"error": e.text})
+            except Exception as e:
                 message, code = humanize_failure(Failure())
-                req.setResponseCode(code)
+                req.setResponseCode(500 if code is None else code)
                 return json.dumps({"error": message})
         else:
             raise WebError("'%s' invalid type for 't' arg" % (t,), http.BAD_REQUEST)

--- a/src/allmydata/web/magic_folder.py
+++ b/src/allmydata/web/magic_folder.py
@@ -1,6 +1,6 @@
 import json
 
-from allmydata.web.common import TokenOnlyWebApi
+from allmydata.web.common import TokenOnlyWebApi, get_arg, WebError
 
 
 class MagicFolderWebApi(TokenOnlyWebApi):
@@ -14,9 +14,18 @@ class MagicFolderWebApi(TokenOnlyWebApi):
 
     def post_json(self, req):
         req.setHeader("content-type", "application/json")
+        nick = get_arg(req, 'name', 'default')
+
+        try:
+            magic_folder = self.client._magic_folders[nick]
+        except KeyError:
+            raise WebError(
+                "No such magic-folder '{}'".format(nick),
+                404,
+            )
 
         data = []
-        for item in self.client._magic_folder.uploader.get_status():
+        for item in magic_folder.uploader.get_status():
             d = dict(
                 path=item.relpath_u,
                 status=item.status_history()[-1][0],
@@ -27,7 +36,7 @@ class MagicFolderWebApi(TokenOnlyWebApi):
             d['percent_done'] = item.progress.progress
             data.append(d)
 
-        for item in self.client._magic_folder.downloader.get_status():
+        for item in magic_folder.downloader.get_status():
             d = dict(
                 path=item.relpath_u,
                 status=item.status_history()[-1][0],

--- a/src/allmydata/web/root.py
+++ b/src/allmydata/web/root.py
@@ -237,12 +237,13 @@ class Root(MultiFormatPage):
         return description
 
 
-    def render_magic_folder(self, ctx, data):
-        if self.client._magic_folder is None:
-            return T.p()
+    def data_magic_folders(self, ctx, data):
+        return self.client._magic_folders.keys()
 
-        (ok, messages) = self.client._magic_folder.get_public_status()
-
+    def render_magic_folder_row(self, ctx, data):
+        magic_folder = self.client._magic_folders[data]
+        (ok, messages) = magic_folder.get_public_status()
+        ctx.fillSlots("magic_folder_name", data)
         if ok:
             ctx.fillSlots("magic_folder_status", "yes")
             ctx.fillSlots("magic_folder_status_alt", "working")
@@ -250,11 +251,15 @@ class Root(MultiFormatPage):
             ctx.fillSlots("magic_folder_status", "no")
             ctx.fillSlots("magic_folder_status_alt", "not working")
 
-        status = T.ul()
+        status = T.ul(class_="magic-folder-status")
         for msg in messages:
             status[T.li[str(msg)]]
-
         return ctx.tag[status]
+
+    def render_magic_folder(self, ctx, data):
+        if not self.client._magic_folders:
+            return T.p()
+        return ctx.tag
 
     def render_services(self, ctx, data):
         ul = T.ul()

--- a/src/allmydata/web/static/css/new-tahoe.css
+++ b/src/allmydata/web/static/css/new-tahoe.css
@@ -53,6 +53,11 @@ body {
 .connection-status {
 }
 
+.magic-folder-status {
+    clear: left;
+    margin-left: 40px;  /* width of status-indicator + margins */
+}
+
 .furl {
     font-size: 0.8em;
     word-wrap: break-word;

--- a/src/allmydata/web/welcome.xhtml
+++ b/src/allmydata/web/welcome.xhtml
@@ -160,10 +160,10 @@
           </div>
 
           <div n:render="magic_folder" class="row-fluid">
-            <h2>
-	      <div class="status-indicator"><img><n:attr name="src">img/connected-<n:slot name="magic_folder_status" />.png</n:attr><n:attr name="alt"><n:slot name="magic_folder_status_alt" /></n:attr></img></div>
-	      Magic Folder
-	    </h2>
+            <h2>Magic Folders</h2>
+            <div n:render="sequence" n:data="magic_folders">
+	      <div n:pattern="item" n:render="magic_folder_row"><div class="status-indicator"><img><n:attr name="src">img/connected-<n:slot name="magic_folder_status" />.png</n:attr><n:attr name="alt"><n:slot name="magic_folder_status_alt" /></n:attr></img></div><h3><n:slot name="magic_folder_name" /></h3></div>
+            </div>
           </div><!--/row-->
 
           <div class="row-fluid">


### PR DESCRIPTION
This allows one Tahoe client to configure and run multiple Magic Folders at once. Also some necessary cleanups of some commands etc.

The main change is to the config. What this is (supposed) to mean is this:

 - new config is all in a single YAML file.
 - magic-folders now have a "name"
 - there is a default name ("default") which is what "legacy" magic-folder will get called
 - all commands have a `--name`/`-n` option now -- but resort to "default" if it's not specified (so all "old" ways of spelling magic-folder commands should still work)
 - each magic folder has its own sqlite database
 - if you have existing magic-folder config, it just works (doesn't mess with config)
 - if you run a command that changes magic-folder config, old config is upgraded to new

