### PR TITLE
Async startup: pull out config

### DIFF
--- a/src/allmydata/introducer/__init__.py
+++ b/src/allmydata/introducer/__init__.py
@@ -2,7 +2,7 @@
 # This is for compatibilty with old .tac files, which reference
 # allmydata.introducer.IntroducerNode
 
-from allmydata.introducer.server import IntroducerNode
+from allmydata.introducer.server import _IntroducerNode as IntroducerNode
 
 # hush pyflakes
 _unused = [IntroducerNode]

--- a/src/allmydata/scripts/tahoe_daemonize.py
+++ b/src/allmydata/scripts/tahoe_daemonize.py
@@ -6,6 +6,7 @@ from twisted.python import usage
 from twisted.python.reflect import namedAny
 from allmydata.scripts.default_nodedir import _default_nodedir
 from allmydata.util import fileutil
+from allmydata.node import read_config
 from allmydata.util.encodingutil import listdir_unicode, quote_local_unicode_path
 from twisted.application.service import Service
 
@@ -113,9 +114,9 @@ class DaemonizeTheRealService(Service):
 
         def start():
             node_to_instance = {
-                u"client": lambda: namedAny("allmydata.client.Client")(self.basedir),
-                u"introducer": lambda: namedAny("allmydata.introducer.server.IntroducerNode")(self.basedir),
-                u"stats-gatherer": lambda: namedAny("allmydata.stats.StatsGathererService")(self.basedir, verbose=True),
+                u"client": lambda: namedAny("allmydata.client.create_client")(self.basedir),
+                u"introducer": lambda: namedAny("allmydata.introducer.server.create_introducer")(self.basedir),
+                u"stats-gatherer": lambda: namedAny("allmydata.stats.StatsGathererService")(read_config(self.basedir, None), self.basedir, verbose=True),
                 u"key-generator": key_generator_removed,
             }
 

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -26,7 +26,7 @@ import treq
 from allmydata.util.assertutil import _assert
 
 from allmydata import uri as tahoe_uri
-from allmydata.client import Client
+from allmydata.client import _Client
 from allmydata.storage.server import StorageServer, storage_index_to_dir
 from allmydata.util import fileutil, idlib, hashutil
 from allmydata.util.hashutil import permute_server_hash
@@ -183,7 +183,16 @@ class NoNetworkStorageBroker(object):
     def get_known_servers(self):
         return []  # FIXME?
 
-class NoNetworkClient(Client):
+
+def NoNetworkClient(basedir):
+    # XXX FIXME this is just to avoid massive search-replace for now;
+    # should be create_nonetwork_client() or something...
+    from allmydata.node import read_config
+    config = read_config(basedir, u'client.port')
+    return _NoNetworkClient(config, basedir=basedir)
+
+
+class _NoNetworkClient(_Client):
 
     def init_connections(self):
         pass

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -1,20 +1,18 @@
 import os
 import mock
-from io import BytesIO
 from twisted.trial import unittest
 from twisted.internet import reactor, endpoints, defer
 from twisted.internet.interfaces import IStreamClientEndpoint
-from ConfigParser import SafeConfigParser
 from foolscap.connections import tcp
 from ..node import Node, PrivacyError
 from ..util import connection_status
 
 class FakeNode(Node):
     def __init__(self, config_str):
-        self.config = SafeConfigParser()
-        self.config.readfp(BytesIO(config_str))
-        self._reveal_ip = True
+        from allmydata.node import config_from_string
+        self.config = config_from_string(config_str, "fake.port")
         self.basedir = "BASEDIR"
+        self._reveal_ip = True
         self.services = []
         self.create_i2p_provider()
         self.create_tor_provider()

--- a/src/allmydata/test/test_dirnode.py
+++ b/src/allmydata/test/test_dirnode.py
@@ -7,7 +7,7 @@ from twisted.trial import unittest
 from twisted.internet import defer
 from twisted.internet.interfaces import IConsumer
 from allmydata import uri, dirnode
-from allmydata.client import Client
+from allmydata.client import _Client
 from allmydata.immutable import upload
 from allmydata.interfaces import IImmutableFileNode, IMutableFileNode, \
      ExistingChildError, NoSuchChildError, MustNotBeUnknownRWError, \
@@ -1553,7 +1553,7 @@ class FakeNodeMaker(NodeMaker):
     def create_mutable_file(self, contents="", keysize=None, version=None):
         return defer.succeed(FakeMutableFile(contents))
 
-class FakeClient2(Client):
+class FakeClient2(_Client):
     def __init__(self):
         self.nodemaker = FakeNodeMaker(None, None, None,
                                        None, None,

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -16,10 +16,10 @@ from allmydata.introducer.server import IntroducerService, FurlFileConflictError
 from allmydata.introducer.common import get_tubid_string_from_ann, \
      get_tubid_string, sign_to_foolscap, unsign_from_foolscap, \
      UnknownKeyError
-# test compatibility with old introducer .tac files
-from allmydata.introducer import IntroducerNode
+# the "new way" to create introducer node instance
+from allmydata.introducer.server import create_introducer
 from allmydata.web import introweb
-from allmydata.client import Client as TahoeClient
+from allmydata.client import create_client
 from allmydata.util import pollmixin, keyutil, idlib, fileutil, iputil, yamlutil
 import allmydata.test.common_util as testutil
 
@@ -28,13 +28,19 @@ class LoggingMultiService(service.MultiService):
         log.msg(msg, **kw)
 
 class Node(testutil.SignalMixin, testutil.ReallyEqualMixin, unittest.TestCase):
+
+    def test_backwards_compat_import(self):
+        # for old introducer .tac files
+        from allmydata.introducer import IntroducerNode
+        IntroducerNode  # pyflakes
+
     def test_furl(self):
         basedir = "introducer.IntroducerNode.test_furl"
         os.mkdir(basedir)
         public_fn = os.path.join(basedir, "introducer.furl")
         private_fn = os.path.join(basedir, "private", "introducer.furl")
 
-        q1 = IntroducerNode(basedir)
+        q1 = create_introducer(basedir)
         del q1
         # new nodes create unguessable furls in private/introducer.furl
         ifurl = fileutil.read(private_fn)
@@ -48,13 +54,13 @@ class Node(testutil.SignalMixin, testutil.ReallyEqualMixin, unittest.TestCase):
 
         # if we see both files, throw an error
         self.failUnlessRaises(FurlFileConflictError,
-                              IntroducerNode, basedir)
+                              create_introducer, basedir)
 
         # when we see only the public one, move it to private/ and use
         # the existing furl instead of creating a new one
         os.unlink(private_fn)
 
-        q2 = IntroducerNode(basedir)
+        q2 = create_introducer(basedir)
         del q2
         self.failIf(os.path.exists(public_fn))
         ifurl2 = fileutil.read(private_fn)
@@ -68,7 +74,7 @@ class Node(testutil.SignalMixin, testutil.ReallyEqualMixin, unittest.TestCase):
                        "[node]\n" +
                        "web.port = tcp:0:interface=127.0.0.1\n" +
                        "web.static = relative\n")
-        c = IntroducerNode(basedir)
+        c = create_introducer(basedir)
         w = c.getServiceNamed("webish")
         abs_basedir = fileutil.abspath_expanduser_unicode(basedir)
         expected = fileutil.abspath_expanduser_unicode(u"relative", abs_basedir)
@@ -740,7 +746,7 @@ class Announcements(unittest.TestCase):
         f.write("enabled = false\n")
         f.close()
 
-        c = TahoeClient(basedir)
+        c = create_client(basedir)
         ic = c.introducer_clients[0]
         sk_s, vk_s = keyutil.make_keypair()
         sk, _ignored = keyutil.parse_privkey(sk_s)
@@ -808,7 +814,7 @@ class Announcements(unittest.TestCase):
         self.failUnlessEqual(announcements[pub2]["anonymous-storage-FURL"],
                              furl3)
 
-        c2 = TahoeClient(basedir)
+        c2 = create_client(basedir)
         c2.introducer_clients[0]._load_announcements()
         yield flushEventualQueue()
         self.assertEqual(c2.storage_broker.get_all_serverids(),
@@ -829,7 +835,7 @@ class ClientSeqnums(unittest.TestCase):
         f.write("enabled = false\n")
         f.close()
 
-        c = TahoeClient(basedir)
+        c = create_client(basedir)
         ic = c.introducer_clients[0]
         outbound = ic._outbound_announcements
         published = ic._published_announcements

--- a/src/allmydata/test/test_multi_introducers.py
+++ b/src/allmydata/test/test_multi_introducers.py
@@ -4,7 +4,7 @@ import os
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 from allmydata.util import yamlutil
-from allmydata.client import Client
+from allmydata.client import create_client
 from allmydata.scripts.create_node import write_node_config
 
 INTRODUCERS_CFG_FURLS=['furl1', 'furl2']
@@ -44,7 +44,7 @@ class MultiIntroTests(unittest.TestCase):
         }
         self.yaml_path.setContent(yamlutil.safe_dump(connections))
         # get a client and count of introducer_clients
-        myclient = Client(self.basedir)
+        myclient = create_client(self.basedir)
         ic_count = len(myclient.introducer_clients)
 
         # assertions
@@ -56,7 +56,7 @@ class MultiIntroTests(unittest.TestCase):
         commented."""
         self.yaml_path.setContent(INTRODUCERS_CFG_FURLS_COMMENTED)
         # get a client and count of introducer_clients
-        myclient = Client(self.basedir)
+        myclient = create_client(self.basedir)
         ic_count = len(myclient.introducer_clients)
 
         # assertions
@@ -78,7 +78,7 @@ class MultiIntroTests(unittest.TestCase):
         c.close()
 
         # get a client and first introducer_furl
-        myclient = Client(self.basedir)
+        myclient = create_client(self.basedir)
         tahoe_cfg_furl = myclient.introducer_furls[0]
 
         # assertions
@@ -89,7 +89,7 @@ class MultiIntroTests(unittest.TestCase):
             u'default': { 'furl': 'furl1' },
             }}
         self.yaml_path.setContent(yamlutil.safe_dump(connections))
-        e = self.assertRaises(ValueError, Client, self.basedir)
+        e = self.assertRaises(ValueError, create_client, self.basedir)
         self.assertEquals(str(e), "'default' introducer furl cannot be specified in introducers.yaml; please fix impossible configuration.")
 
 SIMPLE_YAML = """
@@ -129,25 +129,25 @@ class NoDefault(unittest.TestCase):
             u'one': { 'furl': 'furl1' },
             }}
         self.yaml_path.setContent(yamlutil.safe_dump(connections))
-        myclient = Client(self.basedir)
+        myclient = create_client(self.basedir)
         tahoe_cfg_furl = myclient.introducer_furls[0]
         self.assertEquals(tahoe_cfg_furl, 'furl1')
 
     def test_real_yaml(self):
         self.yaml_path.setContent(SIMPLE_YAML)
-        myclient = Client(self.basedir)
+        myclient = create_client(self.basedir)
         tahoe_cfg_furl = myclient.introducer_furls[0]
         self.assertEquals(tahoe_cfg_furl, 'furl1')
 
     def test_invalid_equals_yaml(self):
         self.yaml_path.setContent(EQUALS_YAML)
-        e = self.assertRaises(TypeError, Client, self.basedir)
+        e = self.assertRaises(TypeError, create_client, self.basedir)
         self.assertEquals(str(e), "string indices must be integers")
 
     def test_introducerless(self):
         connections = {'introducers': {} }
         self.yaml_path.setContent(yamlutil.safe_dump(connections))
-        myclient = Client(self.basedir)
+        myclient = create_client(self.basedir)
         self.assertEquals(len(myclient.introducer_furls), 0)
 
 if __name__ == "__main__":

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -9,7 +9,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from allmydata.util import fileutil, pollmixin
 from allmydata.util.encodingutil import unicode_to_argv, unicode_to_output, \
     get_filesystem_encoding
-from allmydata.client import Client
+from allmydata.client import _Client
 from allmydata.test import common_util
 import allmydata
 from allmydata import __appname__
@@ -337,7 +337,7 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin,
 
         basedir = self.workdir("test_introducer")
         c1 = os.path.join(basedir, "c1")
-        exit_trigger_file = os.path.join(c1, Client.EXIT_TRIGGER_FILE)
+        exit_trigger_file = os.path.join(c1, _Client.EXIT_TRIGGER_FILE)
         twistd_pid_file = os.path.join(c1, "twistd.pid")
         introducer_furl_file = os.path.join(c1, "private", "introducer.furl")
         node_url_file = os.path.join(c1, "node.url")
@@ -457,7 +457,7 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin,
 
         basedir = self.workdir("test_client_no_noise")
         c1 = os.path.join(basedir, "c1")
-        exit_trigger_file = os.path.join(c1, Client.EXIT_TRIGGER_FILE)
+        exit_trigger_file = os.path.join(c1, _Client.EXIT_TRIGGER_FILE)
         twistd_pid_file = os.path.join(c1, "twistd.pid")
         node_url_file = os.path.join(c1, "node.url")
 
@@ -521,7 +521,7 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin,
 
         basedir = self.workdir("test_client")
         c1 = os.path.join(basedir, "c1")
-        exit_trigger_file = os.path.join(c1, Client.EXIT_TRIGGER_FILE)
+        exit_trigger_file = os.path.join(c1, _Client.EXIT_TRIGGER_FILE)
         twistd_pid_file = os.path.join(c1, "twistd.pid")
         node_url_file = os.path.join(c1, "node.url")
         storage_furl_file = os.path.join(c1, "private", "storage.furl")

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -7,7 +7,7 @@ from twisted.application import service
 
 import allmydata
 from allmydata import client, uri
-from allmydata.introducer.server import IntroducerNode
+from allmydata.introducer.server import create_introducer
 from allmydata.storage.mutable import MutableShareFile
 from allmydata.storage.server import si_a2b
 from allmydata.immutable import offloaded, upload
@@ -423,7 +423,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
                 f = open(os.path.join(iv_dir, "private", "node.pem"), "w")
                 f.write(SYSTEM_TEST_CERTS[0])
                 f.close()
-        iv = IntroducerNode(basedir=iv_dir)
+        iv = create_introducer(basedir=iv_dir)
         self.introducer = self.add_service(iv)
         self._get_introducer_web()
         d = defer.succeed(None)
@@ -520,7 +520,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
 
         # start clients[0], wait for it's tub to be ready (at which point it
         # will have registered the helper furl).
-        c = self.add_service(client.Client(basedir=basedirs[0]))
+        c = self.add_service(client.create_client(basedirs[0]))
         self.clients.append(c)
         c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
 
@@ -537,7 +537,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
 
         # this starts the rest of the clients
         for i in range(1, self.numclients):
-            c = self.add_service(client.Client(basedir=basedirs[i]))
+            c = self.add_service(client.create_client(basedirs[i]))
             self.clients.append(c)
             c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
         log.msg("STARTING")
@@ -569,7 +569,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         # better than blindly waiting for a second.
         d.addCallback(self.stall, 1.0)
         def _stopped(res):
-            new_c = client.Client(basedir=self.getdir("client%d" % num))
+            new_c = client.create_client(self.getdir("client%d" % num))
             self.clients[num] = new_c
             new_c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
             self.add_service(new_c)
@@ -596,7 +596,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
             config += "helper.furl = %s\n" % helper_furl
         fileutil.write(os.path.join(basedir, 'tahoe.cfg'), config)
 
-        c = client.Client(basedir=basedir)
+        c = client.create_client(basedir)
         self.clients.append(c)
         c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
         self.numclients += 1

--- a/src/allmydata/test/test_upload.py
+++ b/src/allmydata/test/test_upload.py
@@ -20,7 +20,7 @@ from allmydata.util.happinessutil import servers_of_happiness, \
     shares_by_server, merge_servers
 from allmydata.storage_client import StorageFarmBroker
 from allmydata.storage.server import storage_index_to_dir
-from allmydata.client import Client
+from allmydata.client import _Client
 
 MiB = 1024*1024
 
@@ -754,7 +754,7 @@ class ServerSelection(unittest.TestCase):
 class StorageIndex(unittest.TestCase):
     def test_params_must_matter(self):
         DATA = "I am some data"
-        PARAMS = Client.DEFAULT_ENCODING_PARAMETERS
+        PARAMS = _Client.DEFAULT_ENCODING_PARAMETERS
 
         u = upload.Data(DATA, convergence="")
         u.set_default_encoding_parameters(PARAMS)

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -1,7 +1,5 @@
-import os.path
 from twisted.trial import unittest
 from foolscap.api import fireEventually, flushEventualQueue
-from allmydata.util import fileutil
 from twisted.internet import defer
 from allmydata.introducer import IntroducerNode
 from .common import FAVICON_MARKUP
@@ -20,14 +18,15 @@ class IntroducerWeb(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_welcome(self):
-        basedir = "web.IntroducerWeb.test_welcome"
-        os.mkdir(basedir)
-        cfg = "\n".join(["[node]",
-                         "tub.location = 127.0.0.1:1",
-                         "web.port = tcp:0",
-                         ]) + "\n"
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"), cfg)
-        self.node = IntroducerNode(basedir)
+        config = (
+            "[node]\n"
+            "tub.location = 127.0.0.1:1\n"
+            "web.port = tcp:0\n"
+        )
+        from allmydata.node import config_from_string
+        self.node = IntroducerNode(
+            config_from_string(config, portnumfile="introducer.port"),
+        )
         self.ws = self.node.getServiceNamed("webish")
 
         yield fireEventually(None)

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -46,7 +46,7 @@ from ..common_web import (
     do_http,
     Error,
 )
-from allmydata.client import Client, SecretHolder
+from allmydata.client import _Client, SecretHolder
 from .common import unknown_rwcap, unknown_rocap, unknown_immcap, FAVICON_MARKUP
 # create a fake uploader/downloader, and a couple of fake dirnodes, then
 # create a webserver that works against them
@@ -238,7 +238,7 @@ class FakeStorageServer(service.MultiService):
     def on_status_changed(self, cb):
         cb(self)
 
-class FakeClient(Client):
+class FakeClient(_Client):
     def __init__(self):
         # don't upcall to Client.__init__, since we only want to initialize a
         # minimal subset

--- a/src/allmydata/util/i2p_provider.py
+++ b/src/allmydata/util/i2p_provider.py
@@ -124,16 +124,16 @@ def create_config(reactor, cli_config):
 # a nice error, and startService will throw an ugly error.
 
 class Provider(service.MultiService):
-    def __init__(self, basedir, node_for_config, reactor):
+    def __init__(self, basedir, config, reactor):
         service.MultiService.__init__(self)
         self._basedir = basedir
-        self._node_for_config = node_for_config
+        self._config = config
         self._i2p = _import_i2p()
         self._txi2p = _import_txi2p()
         self._reactor = reactor
 
     def _get_i2p_config(self, *args, **kwargs):
-        return self._node_for_config.get_config("i2p", *args, **kwargs)
+        return self._config.get_config("i2p", *args, **kwargs)
 
     def get_listener(self):
         # this is relative to BASEDIR, and our cwd should be BASEDIR


### PR DESCRIPTION
Note: this builds on the https://github.com/tahoe-lafs/tahoe-lafs/pull/417 so shouldn't be merged before that.

This pulls out all the "config" handling from `Node`; instead a separate config object is passed in to node instances. Also uses `create_client` and `create_introducer` methods (instead of directly instantiating classes) so that the signature doesn't meaningfully change for most callers.

Before merging:

 - [x] merge 417
 - [x] rebase to master
 - [x] squash/edit commits
