### PR TITLE
Local Test Environment with Docker Compose 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+venv
+
+# vim swap files
+*.swp
+*.swo
+
 *.pyc
 *.pyo
 *~

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+FROM debian:9
+LABEL maintainer "gordon@leastauthority.com"
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yq upgrade
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yq install build-essential python-dev libffi-dev libssl-dev python-virtualenv git
+RUN \
+  git clone https://github.com/tahoe-lafs/tahoe-lafs.git /root/tahoe-lafs; \
+  cd /root/tahoe-lafs; \
+  virtualenv --python=python2.7 venv; \
+  ./venv/bin/pip install --upgrade setuptools; \
+  ./venv/bin/pip install --editable .; \
+  ./venv/bin/tahoe --version;
+RUN \
+  cd /root; \
+  mkdir /root/.tahoe-client; \
+  mkdir /root/.tahoe-introducer; \
+  mkdir /root/.tahoe-server;
+RUN /root/tahoe-lafs/venv/bin/tahoe create-introducer --location=tcp:introducer:3458 --port=tcp:3458 /root/.tahoe-introducer
+RUN /root/tahoe-lafs/venv/bin/tahoe start /root/.tahoe-introducer
+RUN /root/tahoe-lafs/venv/bin/tahoe create-node --location=tcp:server:3457 --port=tcp:3457 --introducer=$(cat /root/.tahoe-introducer/private/introducer.furl) /root/.tahoe-server
+RUN /root/tahoe-lafs/venv/bin/tahoe create-client --webport=3456 --introducer=$(cat /root/.tahoe-introducer/private/introducer.furl) --basedir=/root/.tahoe-client --shares-needed=1 --shares-happy=1 --shares-total=1
+VOLUME ["/root/.tahoe-client", "/root/.tahoe-server", "/root/.tahoe-introducer"]
+EXPOSE 3456 3457 3458
+ENTRYPOINT ["/root/tahoe-lafs/venv/bin/tahoe"]
+CMD []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '2'
+services:
+  client:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./misc:/root/tahoe-lafs/misc
+      - ./integration:/root/tahoe-lafs/integration
+      - ./src:/root/tahoe-lafs/static
+      - ./setup.cfg:/root/tahoe-lafs/setup.cfg
+      - ./setup.py:/root/tahoe-lafs/setup.py
+    ports:
+      - "127.0.0.1:3456:3456"
+    depends_on:
+      - "introducer"
+      - "server"
+    entrypoint: /root/tahoe-lafs/venv/bin/tahoe
+    command: ["run", "/root/.tahoe-client"]
+  server:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./misc:/root/tahoe-lafs/misc
+      - ./integration:/root/tahoe-lafs/integration
+      - ./src:/root/tahoe-lafs/static
+      - ./setup.cfg:/root/tahoe-lafs/setup.cfg
+      - ./setup.py:/root/tahoe-lafs/setup.py
+    ports:
+      - "127.0.0.1:3457:3457" 
+    depends_on: 
+      - "introducer"
+    entrypoint: /root/tahoe-lafs/venv/bin/tahoe
+    command: ["run", "/root/.tahoe-server"]
+  introducer:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./misc:/root/tahoe-lafs/misc
+      - ./integration:/root/tahoe-lafs/integration
+      - ./src:/root/tahoe-lafs/static
+      - ./setup.cfg:/root/tahoe-lafs/setup.cfg
+      - ./setup.py:/root/tahoe-lafs/setup.py
+    ports:
+      - "127.0.0.1:3458:3458" 
+    entrypoint: /root/tahoe-lafs/venv/bin/tahoe
+    command: ["run", "/root/.tahoe-introducer"]

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -138,6 +138,19 @@ uploads will succeed. To fix this, see :doc:`configuration` to learn how
 to set ``shares.happy`` to a more suitable value for your grid.
 
 
+Development with Docker
+-----------------------
+
+If you want to stand up a small local test environment, you can install 
+`Docker`_ and `Docker Compose`_. Once you have cloned the repository, run 
+``docker-compose up`` from the project's root directory. This will start a 
+introducer, server, and a client configured to connect to them. After the 
+containers start, you can access the WUI by navigating to 
+``http://localhost:3456`` in your browser.
+
+.. _Docker: https://docs.docker.com/
+.. _Docker Compose: https://docs.docker.com/compose/
+
 Do Stuff With It
 ================
 


### PR DESCRIPTION
This PR includes a `Dockerfile.dev` and `docker-compose.yml` configured to give folks who want to hack on Tahoe-LAFS the option to stand up a minimal test environment by cloning the repository and simply running:

```
docker-compose up
```

The environment does the following:

* Create and run an introducer
* Create and run a storage server configured to connect to the introducer via docker's virtual network
* Create and run a client configured to connect to both of the above via docker's virtual network
* Publish ports for all three to the host
* Volume mount the repository on the host to the containers so changes are reflected

---

![tahoe](https://user-images.githubusercontent.com/1188875/30561786-32000040-9c8a-11e7-8f50-0717a18008d5.gif)
