### PR TITLE
Magicfolder backup files

### DIFF
--- a/integration/test_smoke.py
+++ b/integration/test_smoke.py
@@ -114,7 +114,7 @@ def test_bob_creates_alice_deletes_bob_restores(magic_folder):
     # .. she previously deleted it? does that really make sense)
 
     util.await_file_contents(
-        join(alice_dir, "boom.conflict"),
+        join(alice_dir, "boom"),
         "bob wrote this again, because reasons",
     )
 

--- a/src/allmydata/test/cli/test_magic_folder.py
+++ b/src/allmydata/test/cli/test_magic_folder.py
@@ -555,6 +555,14 @@ class CreateMagicFolder(MagicFolderCLITestMixin, unittest.TestCase):
         d.addCallback(lambda ign: self.check_config(0, abs_local_dir_u))
         return d
 
+    def test_help_synopsis(self):
+        self.basedir = "cli/MagicFolder/help_synopsis"
+        os.makedirs(self.basedir)
+
+        o = magic_folder_cli.CreateOptions()
+        o.parent = magic_folder_cli.MagicFolderCommand()
+        o.parent.getSynopsis()
+
     def test_create_invite_join_failure(self):
         self.basedir = "cli/MagicFolder/create-invite-join-failure"
         os.makedirs(self.basedir)

--- a/src/allmydata/util/deferredutil.py
+++ b/src/allmydata/util/deferredutil.py
@@ -83,7 +83,7 @@ def _with_log(op, res):
     """
     try:
         op(res)
-    except defer.AlreadyCalledError, e:
+    except defer.AlreadyCalledError as e:
         log.err(e, op=repr(op), level=log.WEIRD)
 
 def eventually_callback(d):


### PR DESCRIPTION
(Note: this is on top of the "multi-magic folder" branch, so ignore that commit -- and should be re-based once that's merged).

This fixes 2880 along with an integration test. You can trigger the bug the first time (and only this time) you re-start a client *after* a file has been added (and uploaded) in a magic-folder; then, an unnecessary `.backup` file will appear.