### PR TITLE
use '5 years ago' instead of absolute timestamp

### DIFF
--- a/src/allmydata/test/cli/test_magic_folder.py
+++ b/src/allmydata/test/cli/test_magic_folder.py
@@ -4,6 +4,7 @@ import os.path
 import mock
 import re
 import time
+from datetime import datetime
 
 from twisted.trial import unittest
 from twisted.internet import defer
@@ -294,7 +295,9 @@ class StatusMagicFolder(MagicFolderCLITestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_status(self):
-        secs_per_year = 365 * 24 * 60 * 60.0
+        now = datetime.now()
+        then = now.replace(year=now.year - 5)
+        five_year_interval = (now - then).total_seconds()
 
         def json_for_cap(options, cap):
             if cap.startswith('URI:DIR2:'):
@@ -306,7 +309,7 @@ class StatusMagicFolder(MagicFolderCLITestMixin, unittest.TestCase):
                                 "size": 1234,
                                 "metadata": {
                                     "tahoe": {
-                                        "linkcrtime": (time.time() - (5 * secs_per_year)),
+                                        "linkcrtime": (time.time() - five_year_interval),
                                     },
                                     "version": 1,
                                 },

--- a/src/allmydata/test/cli/test_magic_folder.py
+++ b/src/allmydata/test/cli/test_magic_folder.py
@@ -3,6 +3,7 @@ import shutil
 import os.path
 import mock
 import re
+import time
 
 from twisted.trial import unittest
 from twisted.internet import defer
@@ -293,6 +294,8 @@ class StatusMagicFolder(MagicFolderCLITestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_status(self):
+        secs_per_year = 365 * 24 * 60 * 60.0
+
         def json_for_cap(options, cap):
             if cap.startswith('URI:DIR2:'):
                 return (
@@ -303,7 +306,7 @@ class StatusMagicFolder(MagicFolderCLITestMixin, unittest.TestCase):
                                 "size": 1234,
                                 "metadata": {
                                     "tahoe": {
-                                        "linkcrtime": 0.0,
+                                        "linkcrtime": (time.time() - (5 * secs_per_year)),
                                     },
                                     "version": 1,
                                 },
@@ -332,7 +335,7 @@ class StatusMagicFolder(MagicFolderCLITestMixin, unittest.TestCase):
             self.assertIn("default", stdout)
 
         self.assertIn(
-            "foo (1.23 kB): good, version=1, created 47 years ago",
+            "foo (1.23 kB): good, version=1, created 5 years ago",
             stdout,
         )
 


### PR DESCRIPTION
Fix a test broken by the slow march of time