### PR TITLE
preserve user mtime

### DIFF
--- a/docs/proposed/magic-folder/remote-to-local-sync.rst
+++ b/docs/proposed/magic-folder/remote-to-local-sync.rst
@@ -371,7 +371,7 @@ this procedure for an overwrite in response to a remote change:
    to obtain an initial classification as an overwrite or a
    conflict. (This takes as input the ``last_downloaded_uri``
    field from the directory entry of the changed ``foo``.)
-3. Set the ``mtime`` of the replacement file to be *T* seconds
+3. Set the ``mtime`` of the replacement file to be at least *T* seconds
    before the current local time. Stat the replacement file
    to obtain its ``mtime`` and ``ctime`` as stored in the local
    filesystem, and update the file's last-seen statinfo in

--- a/docs/proposed/magic-folder/remote-to-local-sync.rst
+++ b/docs/proposed/magic-folder/remote-to-local-sync.rst
@@ -460,17 +460,17 @@ On Unix, for the case where the replaced file already exists, we have:
   ``foo.backup``, the other process' changes end up at ``foo``, and
   ours at ``foo.conflicted``. This avoids data loss.
 
-* Interleaving D: its rename happens after our link in step 4c,
-  and causes an ``IN_MOVED_TO`` event for ``foo``. Its rename also
-  changes the ``mtime`` for ``foo`` so that it is different from
-  the ``mtime`` calculated in step 3, and therefore different
-  from the metadata recorded for ``foo`` in the magic folder db.
-  (Assuming no system clock changes, its rename will set an ``mtime``
-  timestamp corresponding to a time after step 4c, which is not
-  equal to the timestamp *T* seconds before step 4a, provided that
-  *T* seconds is sufficiently greater than the timestamp granularity.)
-  Therefore, an upload will be triggered for ``foo`` after its
-  change, which is correct and avoids data loss.
+* Interleaving D: its rename happens after our link in step 4c, and
+  causes an ``IN_MOVED_TO`` event for ``foo``. Its rename also changes
+  the ``mtime`` for ``foo`` so that it is different from the ``mtime``
+  calculated in step 3, and therefore different from the metadata
+  recorded for ``foo`` in the magic folder db.  (Assuming no system
+  clock changes, its rename will set an ``mtime`` timestamp
+  corresponding to a time after step 4c, which is after the timestamp
+  *T* seconds before step 4a, provided that *T* seconds is
+  sufficiently greater than the timestamp granularity.)  Therefore, an
+  upload will be triggered for ``foo`` after its change, which is
+  correct and avoids data loss.
 
 If the replaced file did not already exist, an ``ENOENT`` error
 occurs at step 4b, and we continue with steps 4c and 4d. The other
@@ -560,15 +560,15 @@ we have:
   to rename ``foo.other`` to ``foo`` both happen after all internal
   operations of `ReplaceFileW`_ have completed. This causes deletion
   and rename events for ``foo`` (which will in practice be merged due
-  to the pending delay, although we don't rely on that for correctness).
-  The rename also changes the ``mtime`` for ``foo`` so that it is
-  different from the ``mtime`` calculated in step 3, and therefore
-  different from the metadata recorded for ``foo`` in the magic folder
-  db. (Assuming no system clock changes, its rename will set an
-  ``mtime`` timestamp corresponding to a time after the internal
-  operations of `ReplaceFileW`_ have completed, which is not equal to
-  the timestamp *T* seconds before `ReplaceFileW`_ is called, provided
-  that *T* seconds is sufficiently greater than the timestamp
+  to the pending delay, although we don't rely on that for
+  correctness).  The rename also changes the ``mtime`` for ``foo`` so
+  that it is different from the ``mtime`` calculated in step 3, and
+  therefore different from the metadata recorded for ``foo`` in the
+  magic folder db. (Assuming no system clock changes, its rename will
+  set an ``mtime`` timestamp corresponding to a time after the
+  internal operations of `ReplaceFileW`_ have completed, which is
+  after the timestamp *T* seconds before `ReplaceFileW`_ is called,
+  provided that *T* seconds is sufficiently greater than the timestamp
   granularity.) Therefore, an upload will be triggered for ``foo``
   after its change, which is correct and avoids data loss.
 

--- a/integration/test_smoke.py
+++ b/integration/test_smoke.py
@@ -1,8 +1,8 @@
 import sys
 import time
 import shutil
-from os import mkdir, unlink, listdir
-from os.path import join, exists
+from os import mkdir, unlink, listdir, utime
+from os.path import join, exists, getmtime
 
 import util
 
@@ -20,6 +20,22 @@ def test_alice_writes_bob_receives(magic_folder):
         f.write("alice wrote this")
 
     util.await_file_contents(join(bob_dir, "first_file"), "alice wrote this")
+    return
+
+
+def test_alice_writes_bob_receives_old_timestamp(magic_folder):
+    alice_dir, bob_dir = magic_folder
+    fname = join(alice_dir, "ts_file")
+    ts = time.time() - (60 * 60 * 36)  # 36 hours ago
+
+    with open(fname, "w") as f:
+        f.write("alice wrote this")
+    utime(fname, (time.time(), ts))
+
+    fname = join(bob_dir, "ts_file")
+    util.await_file_contents(fname, "alice wrote this")
+    # make sure the timestamp is correct
+    assert int(getmtime(fname)) == int(ts)
     return
 
 

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -889,7 +889,7 @@ class WriteFileMixin(object):
 
         # FUDGE_SECONDS is used to determine if another process has
         # written to the same file concurrently. This is described in
-        # the Earth Dragon section of our design document ("T" is the
+        # the Earth Dragon section of our design document ("T" in the
         # spec is FUDGE_SECONDS here):
         # docs/proposed/magic-folder/remote-to-local-sync.rst
         fudge_time = now - self.FUDGE_SECONDS


### PR DESCRIPTION
This adds the modification time from the user's machine to the metadata. This is used when syncing a file for magic-folder only-if it is older than `now - FUDGE_SECONDS` (which is `T` from the spec). That is, if the requested timestamp is sufficiently old enough, it becomes the modified time of the synced file.