### PR TITLE
Ticket 2879

### DIFF
--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -1058,7 +1058,7 @@ def _is_empty_filecap(client, cap):
         None,
         cap.encode('ascii'),
     )
-    return (not node.get_size())
+    return not node.get_size()
 
 
 class DownloadItem(QueuedItem):

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -155,7 +155,8 @@ def load_magic_folders(node_directory):
                 # there is something there, but it is not a directory,
                 # so we try to create one and cry if it fails
                 try:
-                    os.mkdir(quote_local_unicode_path(directory))
+                    umask = config.get("magic_folder", "download.umask").decode('utf8')
+                    os.mkdir(quote_local_unicode_path(directory, 0777 & (~ umask)))
                 except OSError:
                     raise Exception(
                         "The '[magic_folder] local.directory' parameter is {} "

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -627,13 +627,13 @@ class Uploader(QueueMixin):
 
         # TODO: what about IN_MOVE_SELF and IN_UNMOUNT?
         #
-        self.mask = ( self._inotify.IN_CREATE
-                    | self._inotify.IN_CLOSE_WRITE
-                    | self._inotify.IN_MOVED_TO
-                    | self._inotify.IN_MOVED_FROM
-                    | self._inotify.IN_DELETE
-                    | self._inotify.IN_ONLYDIR
-                    | IN_EXCL_UNLINK
+        self.mask = (self._inotify.IN_CREATE
+                     | self._inotify.IN_CLOSE_WRITE
+                     | self._inotify.IN_MOVED_TO
+                     | self._inotify.IN_MOVED_FROM
+                     | self._inotify.IN_DELETE
+                     | self._inotify.IN_ONLYDIR
+                     | IN_EXCL_UNLINK
                     )
         self._notifier.watch(self._local_filepath, mask=self.mask, callbacks=[self._notify],
                              recursive=False)#True)
@@ -752,7 +752,7 @@ class Uploader(QueueMixin):
         # It isn't possible to avoid watching for IN_CREATE at all, because
         # it is the only event notified for a directory creation.
 
-        if ((events_mask & self._inotify.IN_CREATE) != 0 and
+        if ((events_mask & self._inotify.IN_CREATE) != 0 and \
             (events_mask & self._inotify.IN_ISDIR) == 0):
             self._log("ignoring event for %r (creation of non-directory)\n" % (relpath_u,))
             return
@@ -1199,8 +1199,8 @@ class Downloader(QueueMixin, WriteFileMixin):
                 self._log("%r has local dbentry %r, remote version %r, remote uri %r"
                           % (relpath_u, local_dbentry, remote_version, remote_uri))
 
-                if (local_dbentry is None or remote_version is None or
-                    local_dbentry.version < remote_version or
+                if (local_dbentry is None or remote_version is None or \
+                    local_dbentry.version < remote_version or \
                     (local_dbentry.version == remote_version and local_dbentry.last_downloaded_uri != remote_uri)):
                     self._log("%r added to download queue" % (relpath_u,))
                     if scan_batch.has_key(relpath_u):

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -150,13 +150,19 @@ def load_magic_folders(node_directory):
                 interval = 60
             dir_fp = to_filepath(directory)
 
+            # make sure directory for magic folder exists
             if not dir_fp.exists():
-                raise Exception(
-                    "The '[magic_folder] local.directory' parameter is {} "
-                    "but there is no directory at that location.".format(
-                        quote_local_unicode_path(directory),
+                # there is something there, but it is not a directory,
+                # so we try to create one and cry if it fails
+                try:
+                    os.mkdir(quote_local_unicode_path(directory))
+                except OSError:
+                    raise Exception(
+                        "The '[magic_folder] local.directory' parameter is {} "
+                        "but no directory could be created at that location.".format(
+                            quote_local_unicode_path(directory)
+                        )
                     )
-                )
             if not dir_fp.isdir():
                 raise Exception(
                     "The '[magic_folder] local.directory' parameter is {} "

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -207,8 +207,8 @@ class LegacyConfigUtilTests(unittest.TestCase):
 
         with self.assertRaises(Exception) as ctx:
             magic_folder.load_magic_folders(self.basedir)
-        self.assertIn(
-            "there is no directory at that location",
+        self.assertNotIn(
+            "no directory could be created",
             str(ctx.exception)
         )
 


### PR DESCRIPTION
Hi there,

thhis PR adresses [ticket 2879: 'magic-folder create' should also create the target local directory](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2879).
Caveat: the local directory has 0777 permissions (see defaults with [os.mdir()](https://docs.python.org/2/library/os.html#os.mkdir)) and I don't know if that is correct in the Tahoe-LAFS magic folder context.

Cheers,
tpltnt