### PR TITLE
tell travis + tox about pytest.twisted in a different way

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -22,8 +22,6 @@ from util import _create_node
 from util import _run_node
 
 
-pytest_plugins = 'pytest_twisted'
-
 # pytest customization hooks
 
 def pytest_addoption(parser):

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+[pytest]
+twisted = 1
+
 [tox]
 envlist = py27
 minversion = 1.7


### PR DESCRIPTION
"Something" changed on Travis; this is a different way to tell py.test about what plugins to use that doesn't cause Travis to explode (and still works locally).