### PR TITLE
appveyor.yml: try different artifact syntax

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,7 @@ artifacts:
   # bdist_wheel puts your built wheel in the dist directory
   # "pip wheel -w dist ." puts all the dependency wheels there too
   # this gives us a zipfile with everything
-  - path: dist
+  - path: 'dist/*'
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,7 @@ artifacts:
   # bdist_wheel puts your built wheel in the dist directory
   # "pip wheel -w dist ." puts all the dependency wheels there too
   # this gives us a zipfile with everything
-  - path: 'dist/*'
+  - path: 'dist\*'
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.


### PR DESCRIPTION
With luck this will upload each binary .whl file as a separate "artifact"
file, rather than merging them all together into a single `dist.zip` bundle.