### PR TITLE
Separate config.1

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -28,7 +28,6 @@ from allmydata.history import History
 from allmydata.interfaces import IStatsProducer, SDMF_VERSION, MDMF_VERSION
 from allmydata.nodemaker import NodeMaker
 from allmydata.blacklist import Blacklist
-from allmydata import node
 
 
 KiB=1024

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -165,13 +165,23 @@ class Terminator(service.Service):
 
 
 #@defer.inlineCallbacks
-def create_client(basedir=u"."):
+def create_client(basedir=u".", _client_factory=None):
+    """
+    Creates a new client instance (a subclass of Node).
+
+    :param basedir: the node directory
+
+    :param _client_factory: for testing; the class to instantiate
+    """
     # load configuration
     config = read_config(basedir, u"client.port", _valid_config_sections=_valid_config_sections)
     config.write_private_config("README", CLIENT_README)
 
+    if _client_factory is None:
+        _client_factory = _Client
+
     #defer.returnValue(
-    return _Client(
+    return _client_factory(
             config,
         )
     #)

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -30,6 +30,7 @@ from allmydata.nodemaker import NodeMaker
 from allmydata.blacklist import Blacklist
 from allmydata.node import OldConfigOptionError, _common_config_sections
 from allmydata.node import read_config
+from allmydata.node import get_app_versions
 
 
 KiB=1024
@@ -276,7 +277,7 @@ class _Client(node.Node, pollmixin.PollMixin):
                                   self.nickname,
                                   str(allmydata.__full_version__),
                                   str(self.OLDEST_SUPPORTED_VERSION),
-                                  self.config.get_app_versions(), self._sequencer,
+                                  get_app_versions(), self._sequencer,
                                   introducer_cache_filepath)
             self.introducer_clients.append(ic)
             self.introducer_furls.append(introducer['furl'])

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -173,9 +173,10 @@ def create_client(basedir=u".", _client_factory=None):
 
     :param _client_factory: for testing; the class to instantiate
     """
+    node.create_node_dir(basedir, CLIENT_README)
+
     # load configuration
     config = read_config(basedir, u"client.port", _valid_config_sections=_valid_config_sections)
-    config.write_private_config("README", CLIENT_README)
 
     if _client_factory is None:
         _client_factory = _Client

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -95,6 +95,15 @@ def _valid_config_sections():
     })
     return cfg
 
+# this is put into README in new node-directories
+CLIENT_README = """
+This directory contains files which contain private data for the Tahoe node,
+such as private keys.  On Unix-like systems, the permissions on this directory
+are set to disallow users other than its owner from reading the contents of
+the files.   See the 'configuration.rst' documentation file for details.
+"""
+
+
 
 def _make_secret():
     return base32.b2a(os.urandom(hashutil.CRYPTO_VAL_SIZE)) + "\n"
@@ -157,7 +166,10 @@ class Terminator(service.Service):
 
 #@defer.inlineCallbacks
 def create_client(basedir=u"."):
+    # load configuration
     config = read_config(basedir, u"client.port", _valid_config_sections=_valid_config_sections)
+    config.write_private_config("README", CLIENT_README)
+
     #defer.returnValue(
     return _Client(
             config,

--- a/src/allmydata/control.py
+++ b/src/allmydata/control.py
@@ -150,7 +150,7 @@ class SpeedTest:
         self.size = size
         self.mutable_mode = mutable
         self.uris = {}
-        self.basedir = os.path.join(self.parent.basedir, "_speed_test_data")
+        self.basedir = self.parent.config.get_config_path("_speed_test_data")
 
     def run(self):
         self.create_data()

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -11,6 +11,15 @@ from allmydata.introducer.interfaces import \
 from allmydata.introducer.common import unsign_from_foolscap, \
      SubscriberDescriptor, AnnouncementDescriptor
 
+# this is put into README in new node-directories
+INTRODUCER_README = """
+This directory contains files which contain private data for the Tahoe node,
+such as private keys.  On Unix-like systems, the permissions on this directory
+are set to disallow users other than its owner from reading the contents of
+the files.   See the 'configuration.rst' documentation file for details.
+"""
+
+
 def _valid_config_sections():
     return node._common_config_sections()
 
@@ -21,8 +30,13 @@ class FurlFileConflictError(Exception):
 #@defer.inlineCallbacks
 def create_introducer(basedir=u"."):
     from allmydata.node import read_config
-    config = read_config(basedir, u"client.port", generated_files=["introducer.furl"])
-    config.validate(_valid_config_sections())
+
+    config = read_config(
+        basedir, u"client.port",
+        generated_files=["introducer.furl"],
+        _valid_config_secionts=_valid_config_sections,
+    )
+    config.write_private_config("README", INTRODUCER_README)
     #defer.returnValue(
     return _IntroducerNode(
             config,

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -34,7 +34,7 @@ def create_introducer(basedir=u"."):
     config = read_config(
         basedir, u"client.port",
         generated_files=["introducer.furl"],
-        _valid_config_secionts=_valid_config_sections,
+        _valid_config_sections=_valid_config_sections,
     )
     config.write_private_config("README", INTRODUCER_README)
     #defer.returnValue(

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -29,14 +29,15 @@ class FurlFileConflictError(Exception):
 
 #@defer.inlineCallbacks
 def create_introducer(basedir=u"."):
-    from allmydata.node import read_config
+    from allmydata import node
+    if not os.path.exists(basedir):
+        node.create_node_dir(basedir, INTRODUCER_README)
 
-    config = read_config(
+    config = node.read_config(
         basedir, u"client.port",
         generated_files=["introducer.furl"],
         _valid_config_sections=_valid_config_sections,
     )
-    config.write_private_config("README", INTRODUCER_README)
     #defer.returnValue(
     return _IntroducerNode(
             config,

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -311,6 +311,7 @@ class _Config(object):
         config file that resides within the subdirectory named 'private'), and
         return it.
         """
+        fileutil.make_dirs(os.path.join(self._basedir, "private"), 0700)
         privname = os.path.join(self._basedir, "private", name)
         with open(privname, "w") as f:
             f.write(value)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -146,14 +146,17 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config_sections
     except EnvironmentError:
         if os.path.exists(config_fname):
             raise
-        configutil.validate_config(config_fname, parser, _valid_config_sections())
-    return _Config(parser, portnumfile, config_fname)
+
+    # make sure we have a private configuration area
+    fileutil.make_dirs(os.path.join(basedir, "private"), 0o700)
+    return _Config(parser, portnumfile, basedir, config_fname)
 
 
-def config_from_string(config_str, portnumfile):
+def config_from_string(config_str, portnumfile, basedir):
+    # load configuration from in-memory string
     parser = ConfigParser.SafeConfigParser()
     parser.readfp(BytesIO(config_str))
-    return _Config(parser, portnumfile, '<in-memory>')
+    return _Config(parser, portnumfile, basedir, '<in-memory>')
 
 
 def _error_about_old_config_files(basedir, generated_files):
@@ -189,11 +192,11 @@ class _Config(object):
     as a helper instead.
     """
 
-    def __init__(self, configparser, portnum_fname, config_fname):
+    def __init__(self, configparser, portnum_fname, basedir, config_fname):
         # XXX I think this portnumfile thing is just legacy?
         self.portnum_fname = portnum_fname
-        self._config_fname = config_fname
-
+        self._basedir = abspath_expanduser_unicode(unicode(basedir))
+        self._config_fname = config_fname  # the actual fname "configparser" came from
         self.config = configparser
 
         nickname_utf8 = self.get_config("node", "nickname", "<unspecified>")
@@ -210,6 +213,22 @@ class _Config(object):
         except EnvironmentError:
             if os.path.exists(self.config_fname):
                 raise
+
+    def get_app_versions(self):
+        # TODO: merge this with allmydata.get_package_versions
+        return dict(app_versions.versions)
+
+    def write_config_file(self, name, value, mode="w"):
+        """
+        writes the given 'value' into a file called 'name' in the config
+        directory
+        """
+        fn = os.path.join(self._basedir, name)
+        try:
+            fileutil.write(fn, value, mode)
+        except EnvironmentError as e:
+            log.msg("Unable to write config file '{}'".format(fn))
+            log.err(e)
 
     def get_config(self, section, option, default=_None, boolean=False):
         try:
@@ -232,6 +251,87 @@ class _Config(object):
                 )
             return default
 
+    def get_config_from_file(self, name, required=False):
+        """Get the (string) contents of a config file, or None if the file
+        did not exist. If required=True, raise an exception rather than
+        returning None. Any leading or trailing whitespace will be stripped
+        from the data."""
+        fn = os.path.join(self._basedir, name)
+        try:
+            return fileutil.read(fn).strip()
+        except EnvironmentError:
+            if not required:
+                return None
+            raise
+
+    def get_or_create_private_config(self, name, default=_None):
+        """Try to get the (string) contents of a private config file (which
+        is a config file that resides within the subdirectory named
+        'private'), and return it. Any leading or trailing whitespace will be
+        stripped from the data.
+
+        If the file does not exist, and default is not given, report an error.
+        If the file does not exist and a default is specified, try to create
+        it using that default, and then return the value that was written.
+        If 'default' is a string, use it as a default value. If not, treat it
+        as a zero-argument callable that is expected to return a string.
+        """
+        privname = os.path.join(self._basedir, "private", name)
+        try:
+            value = fileutil.read(privname)
+        except EnvironmentError:
+            if os.path.exists(privname):
+                raise
+            if default is _None:
+                raise MissingConfigEntry("The required configuration file %s is missing."
+                                         % (quote_output(privname),))
+            if isinstance(default, basestring):
+                value = default
+            else:
+                value = default()
+            fileutil.write(privname, value)
+        return value.strip()
+
+    def write_private_config(self, name, value):
+        """Write the (string) contents of a private config file (which is a
+        config file that resides within the subdirectory named 'private'), and
+        return it.
+        """
+        privname = os.path.join(self._basedir, "private", name)
+        with open(privname, "w") as f:
+            f.write(value)
+
+    def get_private_config(self, name, default=_None):
+        """Read the (string) contents of a private config file (which is a
+        config file that resides within the subdirectory named 'private'),
+        and return it. Return a default, or raise an error if one was not
+        given.
+        """
+        privname = os.path.join(self._basedir, "private", name)
+        try:
+            return fileutil.read(privname).strip()
+        except EnvironmentError:
+            if os.path.exists(privname):
+                raise
+            if default is _None:
+                raise MissingConfigEntry("The required configuration file %s is missing."
+                                         % (quote_output(privname),))
+            return default
+
+    def get_private_path(self, *args):
+        """
+        returns an absolute path inside the 'private' directory with any
+        extra args join()-ed
+        """
+        return os.path.join(self._basedir, "private", *args)
+
+    def get_config_path(self, *args):
+        """
+        returns an absolute path inside the config directory with any
+        extra args join()-ed
+        """
+        return os.path.join(self._basedir, *args)
+
     @staticmethod
     def _contains_unescaped_hash(item):
         characters = iter(item)
@@ -253,17 +353,15 @@ class Node(service.MultiService):
     CERTFILE = "node.pem"
     GENERATED_FILES = []
 
-    def __init__(self, config, basedir=u"."):
+    def __init__(self, config):
         """
-        Initialize the node with the given configuration. It's base directory
+        Initialize the node with the given configuration. Its base directory
         is the current directory by default.
         """
         service.MultiService.__init__(self)
-        # ideally, this would only be in _Config (or otherwise abstracted)
-        self.basedir = abspath_expanduser_unicode(unicode(basedir))
         # XXX don't write files in ctor!
-        fileutil.make_dirs(os.path.join(self.basedir, "private"), 0700)
-        with open(os.path.join(self.basedir, "private", "README"), "w") as f:
+        fileutil.make_dirs(os.path.join(config._basedir, "private"), 0700)
+        with open(os.path.join(config._basedir, "private", "README"), "w") as f:
             f.write(PRIV_README)
 
         self.config = config
@@ -292,7 +390,9 @@ class Node(service.MultiService):
         Initialize/create a directory for temporary files.
         """
         tempdir_config = self.config.get_config("node", "tempdir", "tmp").decode('utf-8')
-        tempdir = abspath_expanduser_unicode(tempdir_config, base=self.basedir)
+        tempdir = self.config.get_config_path(tempdir_config)
+        tempdir0 = abspath_expanduser_unicode(tempdir_config, base=self.config._basedir)
+        assert tempdir == tempdir0
         if not os.path.exists(tempdir):
             fileutil.make_dirs(tempdir)
         tempfile.tempdir = tempdir
@@ -308,12 +408,12 @@ class Node(service.MultiService):
         self._reveal_ip = self.config.get_config("node", "reveal-IP-address", True,
                                                  boolean=True)
     def create_i2p_provider(self):
-        self._i2p_provider = i2p_provider.Provider(self.basedir, self.config, reactor)
+        self._i2p_provider = i2p_provider.Provider(self.config, reactor)
         self._i2p_provider.check_dest_config()
         self._i2p_provider.setServiceParent(self)
 
     def create_tor_provider(self):
-        self._tor_provider = tor_provider.Provider(self.basedir, self.config, reactor)
+        self._tor_provider = tor_provider.Provider(self.config, reactor)
         self._tor_provider.check_onion_config()
         self._tor_provider.setServiceParent(self)
 
@@ -475,11 +575,11 @@ class Node(service.MultiService):
         return tubport, location
 
     def create_main_tub(self):
-        certfile = os.path.join(self.basedir, "private", self.CERTFILE)
+        certfile = self.config.get_private_path(self.CERTFILE)
         self.tub = self._create_tub(certFile=certfile)
 
         self.nodeid = b32decode(self.tub.tubID.upper()) # binary format
-        self.write_config("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+        self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
         self.short_nodeid = b32encode(self.nodeid).lower()[:8] # for printing
         cfg_tubport = self.config.get_config("node", "tub.port", None)
         cfg_location = self.config.get_config("node", "tub.location", None)
@@ -538,86 +638,6 @@ class Node(service.MultiService):
         self.log("Log Tub location set to %s" % (location,))
         self.log_tub.setServiceParent(self)
 
-    def get_app_versions(self):
-        # TODO: merge this with allmydata.get_package_versions
-        return dict(app_versions.versions)
-
-    def get_config_from_file(self, name, required=False):
-        """Get the (string) contents of a config file, or None if the file
-        did not exist. If required=True, raise an exception rather than
-        returning None. Any leading or trailing whitespace will be stripped
-        from the data."""
-        fn = os.path.join(self.basedir, name)
-        try:
-            return fileutil.read(fn).strip()
-        except EnvironmentError:
-            if not required:
-                return None
-            raise
-
-    def write_private_config(self, name, value):
-        """Write the (string) contents of a private config file (which is a
-        config file that resides within the subdirectory named 'private'), and
-        return it.
-        """
-        privname = os.path.join(self.basedir, "private", name)
-        with open(privname, "w") as f:
-            f.write(value)
-
-    def get_private_config(self, name, default=_None):
-        """Read the (string) contents of a private config file (which is a
-        config file that resides within the subdirectory named 'private'),
-        and return it. Return a default, or raise an error if one was not
-        given.
-        """
-        privname = os.path.join(self.basedir, "private", name)
-        try:
-            return fileutil.read(privname).strip()
-        except EnvironmentError:
-            if os.path.exists(privname):
-                raise
-            if default is _None:
-                raise MissingConfigEntry("The required configuration file %s is missing."
-                                         % (quote_output(privname),))
-            return default
-
-    def get_or_create_private_config(self, name, default=_None):
-        """Try to get the (string) contents of a private config file (which
-        is a config file that resides within the subdirectory named
-        'private'), and return it. Any leading or trailing whitespace will be
-        stripped from the data.
-
-        If the file does not exist, and default is not given, report an error.
-        If the file does not exist and a default is specified, try to create
-        it using that default, and then return the value that was written.
-        If 'default' is a string, use it as a default value. If not, treat it
-        as a zero-argument callable that is expected to return a string.
-        """
-        privname = os.path.join(self.basedir, "private", name)
-        try:
-            value = fileutil.read(privname)
-        except EnvironmentError:
-            if os.path.exists(privname):
-                raise
-            if default is _None:
-                raise MissingConfigEntry("The required configuration file %s is missing."
-                                         % (quote_output(privname),))
-            if isinstance(default, basestring):
-                value = default
-            else:
-                value = default()
-            fileutil.write(privname, value)
-        return value.strip()
-
-    def write_config(self, name, value, mode="w"):
-        """Write a string to a config file."""
-        fn = os.path.join(self.basedir, name)
-        try:
-            fileutil.write(fn, value, mode)
-        except EnvironmentError, e:
-            self.log("Unable to write config file '%s'" % fn)
-            self.log(e)
-
     def startService(self):
         # Note: this class can be started and stopped at most once.
         self.log("Node.startService")
@@ -658,7 +678,7 @@ class Node(service.MultiService):
                     ob.formatTime = newmeth
         # TODO: twisted >2.5.0 offers maxRotatedFiles=50
 
-        lgfurl_file = os.path.join(self.basedir, "private", "logport.furl").encode(get_filesystem_encoding())
+        lgfurl_file = self.config.get_private_path("logport.furl").encode(get_filesystem_encoding())
         if os.path.exists(lgfurl_file):
             os.remove(lgfurl_file)
         self.log_tub.setOption("logport-furlfile", lgfurl_file)
@@ -667,9 +687,9 @@ class Node(service.MultiService):
             # this is in addition to the contents of log-gatherer-furlfile
             self.log_tub.setOption("log-gatherer-furl", lgfurl)
         self.log_tub.setOption("log-gatherer-furlfile",
-                               os.path.join(self.basedir, "log_gatherer.furl"))
+                               self.config.get_config_path("log_gatherer.furl"))
 
-        incident_dir = os.path.join(self.basedir, "logs", "incidents")
+        incident_dir = self.config.get_config_path("logs", "incidents")
         foolscap.logging.log.setLogDir(incident_dir.encode(get_filesystem_encoding()))
         twlog.msg("Foolscap logging initialized")
         twlog.msg("Note to developers: twistd.log does not receive very much.")

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -159,6 +159,11 @@ def config_from_string(config_str, portnumfile, basedir):
     return _Config(parser, portnumfile, basedir, '<in-memory>')
 
 
+def get_app_versions():
+    # TODO: merge this with allmydata.get_package_versions
+    return dict(app_versions.versions)
+
+
 def _error_about_old_config_files(basedir, generated_files):
     """
     If any old configuration files are detected, raise
@@ -213,10 +218,6 @@ class _Config(object):
         except EnvironmentError:
             if os.path.exists(self.config_fname):
                 raise
-
-    def get_app_versions(self):
-        # TODO: merge this with allmydata.get_package_versions
-        return dict(app_versions.versions)
 
     def write_config_file(self, name, value, mode="w"):
         """

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -94,7 +94,7 @@ such as private keys.  On Unix-like systems, the permissions on this directory
 are set to disallow users other than its owner from reading the contents of
 the files.   See the 'configuration.rst' documentation file for details."""
 
-class _None(object):
+class _None(object):  # used as a marker in get_config()
     """
     This class is to be used as a marker in get_config()
     """
@@ -373,8 +373,6 @@ class Node(service.MultiService):
         is the current directory by default.
         """
         service.MultiService.__init__(self)
-        with open(os.path.join(config._basedir, "private", "README"), "w") as f:
-            f.write(PRIV_README)
 
         self.config = config
         self.get_config = config.get_config # XXX stopgap

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -191,17 +191,30 @@ def _error_about_old_config_files(basedir, generated_files):
 
 class _Config(object):
     """
-    FIXME better name
+    Manages configuration of a Tahoe 'node directory'.
 
-    pulling out all the 'config' stuff from Node, so we can pass it in
-    as a helper instead.
+    Note: all this code and functionality was formerly in the Node
+    class; names and funtionality have been kept the same while moving
+    the code. It probably makes sense for several of these APIs to
+    have better names.
     """
 
     def __init__(self, configparser, portnum_fname, basedir, config_fname):
-        # XXX I think this portnumfile thing is just legacy?
+        """
+        :param configparser: a ConfigParser instance
+
+        :param portnum_fname: filename to use for the port-number file
+           (a relative path inside basedir)
+
+        :param basedir: path to our "node directory", inside which all
+           configuration is managed
+
+        :param config_fname: the pathname actually used to create the
+            configparser (might be 'fake' if using in-memory data)
+        """
         self.portnum_fname = portnum_fname
         self._basedir = abspath_expanduser_unicode(unicode(basedir))
-        self._config_fname = config_fname  # the actual fname "configparser" came from
+        self._config_fname = config_fname
         self.config = configparser
 
         nickname_utf8 = self.get_config("node", "nickname", "<unspecified>")

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -344,7 +344,12 @@ class _Config(object):
         returns an absolute path inside the config directory with any
         extra args join()-ed
         """
-        return os.path.join(self._basedir, *args)
+        # note: we re-expand here (_basedir already went through this
+        # expanduser function) in case the path we're being asked for
+        # has embedded ".."'s in it
+        return abspath_expanduser_unicode(
+            os.path.join(self._basedir, *args)
+        )
 
     @staticmethod
     def _contains_unescaped_hash(item):

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -401,8 +401,6 @@ class Node(service.MultiService):
         """
         tempdir_config = self.config.get_config("node", "tempdir", "tmp").decode('utf-8')
         tempdir = self.config.get_config_path(tempdir_config)
-        tempdir0 = abspath_expanduser_unicode(tempdir_config, base=self.config._basedir)
-        assert tempdir == tempdir0
         if not os.path.exists(tempdir):
             fileutil.make_dirs(tempdir)
         tempfile.tempdir = tempdir

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -224,14 +224,6 @@ class _Config(object):
     def validate(self, valid_config_sections):
         configutil.validate_config(self._config_fname, self.config, valid_config_sections)
 
-    def read_config(self):
-
-        try:
-            self.config = configutil.get_config(self.config_fname)
-        except EnvironmentError:
-            if os.path.exists(self.config_fname):
-                raise
-
     def write_config_file(self, name, value, mode="w"):
         """
         writes the given 'value' into a file called 'name' in the config

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -127,6 +127,23 @@ class PrivacyError(Exception):
     that the IP address could be revealed"""
 
 
+def create_node_dir(basedir, readme_text):
+    """
+    Create new new 'node directory' at 'basedir'. This includes a
+    'private' subdirectory. If basedir (and privdir) already exists,
+    nothing is done.
+
+    :param readme_text: text to put in <basedir>/private/README
+    """
+    if not os.path.exists(basedir):
+        fileutil.make_dirs(basedir)
+    privdir = os.path.join(basedir, "private")
+    if not os.path.exists(privdir):
+        fileutil.make_dirs(privdir, 0700)
+        with open(os.path.join(privdir, 'README'), 'w') as f:
+            f.write(readme_text)
+
+
 def read_config(basedir, portnumfile, generated_files=[], _valid_config_sections=None):
     basedir = abspath_expanduser_unicode(unicode(basedir))
     if _valid_config_sections is None:
@@ -147,8 +164,6 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config_sections
         if os.path.exists(config_fname):
             raise
 
-    # make sure we have a private configuration area
-    fileutil.make_dirs(os.path.join(basedir, "private"), 0o700)
     return _Config(parser, portnumfile, basedir, config_fname)
 
 
@@ -303,7 +318,6 @@ class _Config(object):
         config file that resides within the subdirectory named 'private'), and
         return it.
         """
-        fileutil.make_dirs(os.path.join(self._basedir, "private"), 0700)
         privname = os.path.join(self._basedir, "private", name)
         with open(privname, "w") as f:
             f.write(value)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -373,8 +373,6 @@ class Node(service.MultiService):
         is the current directory by default.
         """
         service.MultiService.__init__(self)
-        # XXX don't write files in ctor!
-        fileutil.make_dirs(os.path.join(config._basedir, "private"), 0700)
         with open(os.path.join(config._basedir, "private", "README"), "w") as f:
             f.write(PRIV_README)
 

--- a/src/allmydata/test/cli/test_backup.py
+++ b/src/allmydata/test/cli/test_backup.py
@@ -193,8 +193,7 @@ class Backup(GridTestMixin, CLITestMixin, StallMixin, unittest.TestCase):
         # sneak into the backupdb, crank back the "last checked"
         # timestamp to force a check on all files
         def _reset_last_checked(res):
-            dbfile = os.path.join(self.get_clientdir(),
-                                  "private", "backupdb.sqlite")
+            dbfile = self.get_client_config().get_private_path("backupdb.sqlite")
             self.failUnless(os.path.exists(dbfile), dbfile)
             bdb = backupdb.get_backupdb(dbfile)
             bdb.cursor.execute("UPDATE last_upload SET last_checked=0")

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -400,6 +400,11 @@ class GridTestMixin:
     def get_client_config(self, i=0):
         return self.g.clients[i].config
 
+    def get_clientdir(self, i=0):
+        # ideally, use something get_client_config() only, we
+        # shouldn't need to manipulate raw paths..
+        return self.get_client_config(i).get_config_path()
+
     def get_client(self, i=0):
         return self.g.clients[i]
 

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -27,7 +27,7 @@ from allmydata.util.assertutil import _assert
 
 from allmydata import uri as tahoe_uri
 from allmydata.client import _Client
-from allmydata.client import _valid_config_sections as client_valid_config_sections
+from allmydata.client import create_client
 from allmydata.storage.server import StorageServer, storage_index_to_dir
 from allmydata.util import fileutil, idlib, hashutil
 from allmydata.util.hashutil import permute_server_hash
@@ -185,12 +185,8 @@ class NoNetworkStorageBroker(object):
         return []  # FIXME?
 
 
-def NoNetworkClient(basedir):
-    # XXX FIXME this is just to avoid massive search-replace for now;
-    # should be create_nonetwork_client() or something...
-    from allmydata.node import read_config
-    config = read_config(basedir, u'client.port', _valid_config_sections=client_valid_config_sections)
-    return _NoNetworkClient(config)
+def create_no_network_client(basedir):
+    return create_client(basedir, _client_factory=_NoNetworkClient)
 
 
 class _NoNetworkClient(_Client):
@@ -293,7 +289,7 @@ class NoNetworkGrid(service.MultiService):
             c = self.client_config_hooks[i](clientdir)
 
         if not c:
-            c = NoNetworkClient(clientdir)
+            c = create_no_network_client(clientdir)
             c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
 
         c.nodeid = clientid

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -397,8 +397,8 @@ class GridTestMixin:
         self.client_baseurls = [c.getServiceNamed("webish").getURL()
                                 for c in self.g.clients]
 
-    def get_clientdir(self, i=0):
-        return self.g.clients[i].config._basedir
+    def get_client_config(self, i=0):
+        return self.g.clients[i].config
 
     def get_client(self, i=0):
         return self.g.clients[i]

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -27,6 +27,7 @@ from allmydata.util.assertutil import _assert
 
 from allmydata import uri as tahoe_uri
 from allmydata.client import _Client
+from allmydata.client import _valid_config_sections as client_valid_config_sections
 from allmydata.storage.server import StorageServer, storage_index_to_dir
 from allmydata.util import fileutil, idlib, hashutil
 from allmydata.util.hashutil import permute_server_hash
@@ -188,8 +189,8 @@ def NoNetworkClient(basedir):
     # XXX FIXME this is just to avoid massive search-replace for now;
     # should be create_nonetwork_client() or something...
     from allmydata.node import read_config
-    config = read_config(basedir, u'client.port')
-    return _NoNetworkClient(config, basedir=basedir)
+    config = read_config(basedir, u'client.port', _valid_config_sections=client_valid_config_sections)
+    return _NoNetworkClient(config)
 
 
 class _NoNetworkClient(_Client):
@@ -401,10 +402,7 @@ class GridTestMixin:
                                 for c in self.g.clients]
 
     def get_clientdir(self, i=0):
-        return self.g.clients[i].basedir
-
-    def set_clientdir(self, basedir, i=0):
-        self.g.clients[i].basedir = basedir
+        return self.g.clients[i].config._basedir
 
     def get_client(self, i=0):
         return self.g.clients[i]

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -7,7 +7,7 @@ import allmydata
 import allmydata.frontends.magic_folder
 import allmydata.util.log
 
-from allmydata.node import OldConfigError, OldConfigOptionError, UnescapedHashError, _Config, read_config
+from allmydata.node import OldConfigError, OldConfigOptionError, UnescapedHashError, _Config, read_config, create_node_dir
 from allmydata.frontends.auth import NeedRootcapLookupScheme
 from allmydata import client
 from allmydata.storage_client import StorageFarmBroker
@@ -199,6 +199,20 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
                            "enabled = true\n" + \
                            "reserved_space = bogus\n")
         self.failUnlessRaises(ValueError, client.create_client, basedir)
+
+    def test_web_apiauthtoken(self):
+        basedir = u"client.Basic.test_web_apiauthtoken"
+        create_node_dir(basedir, "testing")
+        config = read_config(basedir, "portnum")
+
+        c = client.create_client(basedir)
+        # this must come after we create the client, as it will create
+        # a new, random authtoken itself
+        with open(os.path.join(basedir, "private", "api_auth_token"), "w") as f:
+            f.write("deadbeef")
+
+        token = c.get_auth_token()
+        self.assertEqual("deadbeef", token)
 
     def test_web_staticdir(self):
         basedir = u"client.Basic.test_web_staticdir"

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -2,6 +2,7 @@ import os, sys
 import twisted
 from twisted.trial import unittest
 from twisted.application import service
+import mock
 
 import allmydata
 import allmydata.frontends.magic_folder
@@ -229,6 +230,21 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         self.failUnlessReallyEqual(w.staticdir, expected)
 
     # TODO: also test config options for SFTP.
+
+    def test_ftp_create(self):
+        basedir = u"client.Basic.test_ftp_create"
+        create_node_dir(basedir, "testing")
+        with open(os.path.join(basedir, "tahoe.cfg"), "w") as f:
+            f.write(
+                '[sftpd]\n'
+                'enabled = true\n'
+                'accounts.file = foo\n'
+                'host_pubkey_file = pubkey\n'
+                'host_privkey_file = privkey\n'
+            )
+        with mock.patch('allmydata.frontends.sftpd.SFTPServer') as p:
+            c = client.create_client(basedir)
+        self.assertTrue(p.called)
 
     def test_ftp_auth_keyfile(self):
         basedir = u"client.Basic.test_ftp_auth_keyfile"

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -204,7 +204,6 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
     def test_web_apiauthtoken(self):
         basedir = u"client.Basic.test_web_apiauthtoken"
         create_node_dir(basedir, "testing")
-        config = read_config(basedir, "portnum")
 
         c = client.create_client(basedir)
         # this must come after we create the client, as it will create
@@ -243,7 +242,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
                 'host_privkey_file = privkey\n'
             )
         with mock.patch('allmydata.frontends.sftpd.SFTPServer') as p:
-            c = client.create_client(basedir)
+            client.create_client(basedir)
         self.assertTrue(p.called)
 
     def test_ftp_auth_keyfile(self):

--- a/src/allmydata/test/test_configutil.py
+++ b/src/allmydata/test/test_configutil.py
@@ -13,10 +13,9 @@ class ConfigUtilTests(GridTestMixin, unittest.TestCase):
     def test_config_utils(self):
         self.basedir = "cli/ConfigUtilTests/test-config-utils"
         self.set_up_grid(oneshare=True)
-        tahoe_cfg = os.path.join(self.get_clientdir(i=0), "tahoe.cfg")
 
         # test that at least one option was read correctly
-        config = configutil.get_config(tahoe_cfg)
+        config = self.get_client_config(i=0)
         self.failUnlessEqual(config.get("node", "nickname"), "client-0")
 
         # test that set_config can mutate an existing option

--- a/src/allmydata/test/test_configutil.py
+++ b/src/allmydata/test/test_configutil.py
@@ -13,9 +13,10 @@ class ConfigUtilTests(GridTestMixin, unittest.TestCase):
     def test_config_utils(self):
         self.basedir = "cli/ConfigUtilTests/test-config-utils"
         self.set_up_grid(oneshare=True)
+        tahoe_cfg = os.path.join(self.get_clientdir(i=0), "tahoe.cfg")
 
         # test that at least one option was read correctly
-        config = self.get_client_config(i=0)
+        config = configutil.get_config(tahoe_cfg)
         self.failUnlessEqual(config.get("node", "nickname"), "client-0")
 
         # test that set_config can mutate an existing option

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -10,8 +10,7 @@ from ..util import connection_status
 class FakeNode(Node):
     def __init__(self, config_str):
         from allmydata.node import config_from_string
-        self.config = config_from_string(config_str, "fake.port")
-        self.basedir = "BASEDIR"
+        self.config = config_from_string(config_str, "fake.port", "no-basedir")
         self._reveal_ip = True
         self.services = []
         self.create_i2p_provider()
@@ -60,7 +59,7 @@ class Tor(unittest.TestCase):
                         return_value=h1) as f:
             n = FakeNode(config)
             h = n._make_tor_handler()
-            private_dir = os.path.join(n.basedir, "private")
+            private_dir = n.config.get_config_path("private")
             exp = mock.call(n._tor_provider._make_control_endpoint,
                             takes_status=True)
             self.assertEqual(f.mock_calls, [exp])
@@ -78,7 +77,8 @@ class Tor(unittest.TestCase):
                 d = tp._make_control_endpoint(reactor,
                                               update_status=lambda status: None)
                 cep = self.successResultOf(d)
-        launch_tor.assert_called_with(reactor, executable, private_dir,
+        launch_tor.assert_called_with(reactor, executable,
+                                      os.path.abspath(private_dir),
                                       tp._txtorcon)
         cfs.assert_called_with(reactor, "ep_desc")
         self.assertIs(cep, tcep)

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -193,16 +193,16 @@ class FakeConfig(dict):
 
 class Provider(unittest.TestCase):
     def test_build(self):
-        i2p_provider.Provider("basedir", FakeConfig(), "reactor")
+        i2p_provider.Provider(FakeConfig(), "reactor")
 
     def test_handler_disabled(self):
-        p = i2p_provider.Provider("basedir", FakeConfig(enabled=False),
+        p = i2p_provider.Provider(FakeConfig(enabled=False),
                                   "reactor")
         self.assertEqual(p.get_i2p_handler(), None)
 
     def test_handler_no_i2p(self):
         with mock_i2p(None):
-            p = i2p_provider.Provider("basedir", FakeConfig(), "reactor")
+            p = i2p_provider.Provider(FakeConfig(), "reactor")
         self.assertEqual(p.get_i2p_handler(), None)
 
     def test_handler_sam_endpoint(self):
@@ -213,8 +213,7 @@ class Provider(unittest.TestCase):
         reactor = object()
 
         with mock_i2p(i2p):
-            p = i2p_provider.Provider("basedir",
-                                      FakeConfig(**{"sam.port": "ep_desc"}),
+            p = i2p_provider.Provider(FakeConfig(**{"sam.port": "ep_desc"}),
                                       reactor)
             with mock.patch("allmydata.util.i2p_provider.clientFromString",
                             return_value=ep) as cfs:
@@ -230,7 +229,7 @@ class Provider(unittest.TestCase):
         reactor = object()
 
         with mock_i2p(i2p):
-            p = i2p_provider.Provider("basedir", FakeConfig(launch=True),
+            p = i2p_provider.Provider(FakeConfig(launch=True),
                                       reactor)
         h = p.get_i2p_handler()
         self.assertIs(h, handler)
@@ -243,8 +242,7 @@ class Provider(unittest.TestCase):
         reactor = object()
 
         with mock_i2p(i2p):
-            p = i2p_provider.Provider("basedir",
-                                      FakeConfig(launch=True,
+            p = i2p_provider.Provider(FakeConfig(launch=True,
                                                  **{"i2p.configdir": "configdir"}),
                                       reactor)
         h = p.get_i2p_handler()
@@ -258,8 +256,7 @@ class Provider(unittest.TestCase):
         reactor = object()
 
         with mock_i2p(i2p):
-            p = i2p_provider.Provider("basedir",
-                                      FakeConfig(launch=True,
+            p = i2p_provider.Provider(FakeConfig(launch=True,
                                                  **{"i2p.configdir": "configdir",
                                                     "i2p.executable": "myi2p",
                                                    }),
@@ -275,8 +272,7 @@ class Provider(unittest.TestCase):
         reactor = object()
 
         with mock_i2p(i2p):
-            p = i2p_provider.Provider("basedir",
-                                      FakeConfig(**{"i2p.configdir": "configdir"}),
+            p = i2p_provider.Provider(FakeConfig(**{"i2p.configdir": "configdir"}),
                                       reactor)
         h = p.get_i2p_handler()
         i2p.local_i2p.assert_called_with("configdir")
@@ -289,7 +285,7 @@ class Provider(unittest.TestCase):
         reactor = object()
 
         with mock_i2p(i2p):
-            p = i2p_provider.Provider("basedir", FakeConfig(), reactor)
+            p = i2p_provider.Provider(FakeConfig(), reactor)
         h = p.get_i2p_handler()
         self.assertIs(h, handler)
         i2p.default.assert_called_with(reactor, keyfile=None)
@@ -308,8 +304,7 @@ class ProviderListener(unittest.TestCase):
 
         privkeyfile = os.path.join("private", "i2p_dest.privkey")
         with mock_i2p(i2p):
-            p = i2p_provider.Provider("basedir",
-                                      FakeConfig(**{
+            p = i2p_provider.Provider(FakeConfig(**{
                                           "i2p.configdir": "configdir",
                                           "sam.port": "good:port",
                                           "dest": "true",
@@ -326,37 +321,36 @@ class Provider_CheckI2PConfig(unittest.TestCase):
         # default config doesn't start an I2P service, so it should be
         # happy both with and without txi2p
 
-        p = i2p_provider.Provider("basedir", FakeConfig(), "reactor")
+        p = i2p_provider.Provider(FakeConfig(), "reactor")
         p.check_dest_config()
 
         with mock_txi2p(None):
-            p = i2p_provider.Provider("basedir", FakeConfig(), "reactor")
+            p = i2p_provider.Provider(FakeConfig(), "reactor")
             p.check_dest_config()
 
     def test_no_txi2p(self):
         with mock_txi2p(None):
-            p = i2p_provider.Provider("basedir", FakeConfig(dest=True),
+            p = i2p_provider.Provider(FakeConfig(dest=True),
                                       "reactor")
             e = self.assertRaises(ValueError, p.check_dest_config)
             self.assertEqual(str(e), "Cannot create I2P Destination without txi2p. "
                              "Please 'pip install tahoe-lafs[i2p]' to fix.")
 
     def test_no_launch_no_control(self):
-        p = i2p_provider.Provider("basedir", FakeConfig(dest=True), "reactor")
+        p = i2p_provider.Provider(FakeConfig(dest=True), "reactor")
         e = self.assertRaises(ValueError, p.check_dest_config)
         self.assertEqual(str(e), "[i2p] dest = true, but we have neither "
                          "sam.port= nor launch=true nor configdir=")
 
     def test_missing_keys(self):
-        p = i2p_provider.Provider("basedir", FakeConfig(dest=True,
+        p = i2p_provider.Provider(FakeConfig(dest=True,
                                              **{"sam.port": "x",
                                                 }), "reactor")
         e = self.assertRaises(ValueError, p.check_dest_config)
         self.assertEqual(str(e), "[i2p] dest = true, "
                          "but dest.port= is missing")
 
-        p = i2p_provider.Provider("basedir",
-                                  FakeConfig(dest=True,
+        p = i2p_provider.Provider(FakeConfig(dest=True,
                                              **{"sam.port": "x",
                                                 "dest.port": "y",
                                                 }), "reactor")
@@ -365,8 +359,7 @@ class Provider_CheckI2PConfig(unittest.TestCase):
                          "but dest.private_key_file= is missing")
 
     def test_launch_not_implemented(self):
-        p = i2p_provider.Provider("basedir",
-                                  FakeConfig(dest=True, launch=True,
+        p = i2p_provider.Provider(FakeConfig(dest=True, launch=True,
                                              **{"dest.port": "x",
                                                 "dest.private_key_file": "y",
                                                 }), "reactor")
@@ -374,8 +367,7 @@ class Provider_CheckI2PConfig(unittest.TestCase):
         self.assertEqual(str(e), "[i2p] launch is under development.")
 
     def test_ok(self):
-        p = i2p_provider.Provider("basedir",
-                                  FakeConfig(dest=True,
+        p = i2p_provider.Provider(FakeConfig(dest=True,
                                              **{"sam.port": "x",
                                                 "dest.port": "y",
                                                 "dest.private_key_file": "z",

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -35,6 +35,11 @@ class Node(testutil.SignalMixin, testutil.ReallyEqualMixin, unittest.TestCase):
         from allmydata.introducer import IntroducerNode
         IntroducerNode  # pyflakes
 
+    def test_create(self):
+        basedir = "introducer.IntroducerNode.test_create"
+        create_introducer(basedir)
+        self.assertTrue(os.path.exists(basedir))
+
     def test_furl(self):
         basedir = "introducer.IntroducerNode.test_furl"
         create_node_dir(basedir, "testing")

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -16,6 +16,7 @@ from allmydata.introducer.server import IntroducerService, FurlFileConflictError
 from allmydata.introducer.common import get_tubid_string_from_ann, \
      get_tubid_string, sign_to_foolscap, unsign_from_foolscap, \
      UnknownKeyError
+from allmydata.node import create_node_dir
 # the "new way" to create introducer node instance
 from allmydata.introducer.server import create_introducer
 from allmydata.web import introweb
@@ -36,7 +37,7 @@ class Node(testutil.SignalMixin, testutil.ReallyEqualMixin, unittest.TestCase):
 
     def test_furl(self):
         basedir = "introducer.IntroducerNode.test_furl"
-        os.mkdir(basedir)
+        create_node_dir(basedir, "testing")
         public_fn = os.path.join(basedir, "introducer.furl")
         private_fn = os.path.join(basedir, "private", "introducer.furl")
 
@@ -69,7 +70,7 @@ class Node(testutil.SignalMixin, testutil.ReallyEqualMixin, unittest.TestCase):
 
     def test_web_static(self):
         basedir = u"introducer.Node.test_web_static"
-        os.mkdir(basedir)
+        create_node_dir(basedir, "testing")
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),
                        "[node]\n" +
                        "web.port = tcp:0:interface=127.0.0.1\n" +

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -262,43 +262,6 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         self.failUnless(ns.called)
 
 
-class EmptyNode(Node):
-    def __init__(self, config=None):
-        if config is None:
-            config = config_from_string("", "no portfile", 'no basedir')
-        Node.__init__(self, config)
-
-
-EXPECTED = {
-    # top-level key is tub.port category
-    "missing": {
-        # 2nd-level key is tub.location category
-        "missing": "alloc/auto",
-        "empty": "ERR2",
-        "disabled": "ERR4",
-        "hintstring": "alloc/file",
-        },
-    "empty": {
-        "missing": "ERR1",
-        "empty": "ERR1",
-        "disabled": "ERR1",
-        "hintstring": "ERR1",
-        },
-    "disabled": {
-        "missing": "ERR3",
-        "empty": "ERR2",
-        "disabled": "no-listen",
-        "hintstring": "ERR3",
-        },
-    "endpoint": {
-        "missing": "auto",
-        "empty": "ERR2",
-        "disabled": "ERR4",
-        "hintstring": "manual",
-        },
-    }
-
-
 class TestMissingPorts(unittest.TestCase):
     """
     Test certain error-cases for ports setup
@@ -512,7 +475,7 @@ class Listeners(unittest.TestCase):
             f.write("tub.location = %s\n" % location)
 
         config = read_config(basedir, "client.port")
-        n = EmptyNode(config)
+        n = Node(config)
 
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
@@ -558,7 +521,7 @@ class Listeners(unittest.TestCase):
 
         tub_mock = mock.patch("allmydata.node.Tub", return_value=FakeTub())
         with i2p_mock, tor_mock, tub_mock:
-            n = EmptyNode(config)
+            n = Node(config)
 
         self.assertEqual(n._i2p_provider.get_listener.mock_calls, [mock.call()])
         self.assertEqual(n._tor_provider.get_listener.mock_calls, [mock.call()])

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -16,8 +16,8 @@ import foolscap.logging.log
 from twisted.application import service
 from allmydata.node import Node, formatTimeTahoeStyle, MissingConfigEntry, read_config, config_from_string, create_node_dir
 from allmydata.introducer.server import create_introducer
-from allmydata.client import create_client
-from allmydata.client import _valid_config_sections as client_valid_config_sections
+from allmydata import client
+
 from allmydata.util import fileutil, iputil
 from allmydata.util import i2p_provider, tor_provider
 from allmydata.util.namespace import Namespace
@@ -424,7 +424,7 @@ class Listeners(unittest.TestCase):
             f.write("tub.location = tcp:example.org:1234\n")
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
-        config = read_config(basedir, "client.port", _valid_config_sections=client_valid_config_sections)
+        config = client.read_config(basedir, "client.port")
 
         i2p_ep = object()
         i2p_prov = i2p_provider.Provider(config, mock.Mock())
@@ -458,7 +458,7 @@ class ClientNotListening(unittest.TestCase):
         f.write(NOLISTEN)
         f.write(DISABLE_STORAGE)
         f.close()
-        n = create_client(basedir)
+        n = client.create_client(basedir)
         self.assertEqual(n.tub.getListeners(), [])
 
     def test_disabled_but_storage(self):
@@ -469,7 +469,7 @@ class ClientNotListening(unittest.TestCase):
         f.write(NOLISTEN)
         f.write(ENABLE_STORAGE)
         f.close()
-        e = self.assertRaises(ValueError, create_client, basedir)
+        e = self.assertRaises(ValueError, client.create_client, basedir)
         self.assertIn("storage is enabled, but tub is not listening", str(e))
 
     def test_disabled_but_helper(self):
@@ -481,7 +481,7 @@ class ClientNotListening(unittest.TestCase):
         f.write(DISABLE_STORAGE)
         f.write(ENABLE_HELPER)
         f.close()
-        e = self.assertRaises(ValueError, create_client, basedir)
+        e = self.assertRaises(ValueError, client.create_client, basedir)
         self.assertIn("helper is enabled, but tub is not listening", str(e))
 
 class IntroducerNotListening(unittest.TestCase):

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -19,6 +19,7 @@ from allmydata.introducer.server import create_introducer
 from allmydata.client import create_client
 from allmydata.client import _valid_config_sections as client_valid_config_sections
 from allmydata.util import fileutil, iputil
+from allmydata.util import i2p_provider, tor_provider
 from allmydata.util.namespace import Namespace
 import allmydata.test.common_util as testutil
 
@@ -163,8 +164,8 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
     def test_write_config_unwritable_file(self):
         """
         Existing behavior merely logs any errors upon writing
-        configuration; this should probably be fixed to do something
-        better (like fail entirely). See #2905
+        configuration files; this bad behavior should probably be
+        fixed to do something better (like fail entirely). See #2905
         """
         basedir = "test_node/configdir"
         fileutil.make_dirs(basedir)
@@ -175,12 +176,8 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
 
         config.write_config_file("bad", "some value")
 
-        errs = self.flushLoggedErrors()
+        errs = self.flushLoggedErrors(IOError)
         self.assertEqual(1, len(errs))
-        self.assertIn(
-            "IOError",
-            str(errs[0])
-        )
 
     def test_timestamp(self):
         # this modified logger doesn't seem to get used during the tests,

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -140,6 +140,11 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
             config.get_config_from_file("it_does_not_exist", required=True)
 
     def test_private_config_unreadable(self):
+        if "win32" in sys.platform.lower() or "cygwin" in sys.platform.lower():
+            # We don't know how to test that unprivileged users can't read this
+            # thing.  (Also we don't know exactly how to set the permissions so
+            # that unprivileged users can't read this thing.)
+            raise unittest.SkipTest("We don't know how to set permissions on Windows.")
         basedir = u"test_node/test_private_config_unreadable"
         create_node_dir(basedir, "testing")
         config = read_config(basedir, "portnum")
@@ -151,6 +156,11 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
             config.get_or_create_private_config("foo")
 
     def test_private_config_unreadable_preexisting(self):
+        if "win32" in sys.platform.lower() or "cygwin" in sys.platform.lower():
+            # We don't know how to test that unprivileged users can't read this
+            # thing.  (Also we don't know exactly how to set the permissions so
+            # that unprivileged users can't read this thing.)
+            raise unittest.SkipTest("We don't know how to set permissions on Windows.")
         basedir = u"test_node/test_private_config_unreadable_preexisting"
         create_node_dir(basedir, "testing")
         config = read_config(basedir, "portnum")

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -162,6 +162,11 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         self.failUnlessEqual(value, "newer")
 
     def test_write_config_unwritable_file(self):
+        """
+        Existing behavior merely logs any errors upon writing
+        configuration; this should probably be fixed to do something
+        better (like fail entirely). See #2905
+        """
         basedir = "test_node/configdir"
         fileutil.make_dirs(basedir)
         config = config_from_string("", "", basedir)

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -14,7 +14,7 @@ from foolscap.api import flushEventualQueue
 import foolscap.logging.log
 
 from twisted.application import service
-from allmydata.node import Node, formatTimeTahoeStyle, MissingConfigEntry, read_config, config_from_string
+from allmydata.node import Node, formatTimeTahoeStyle, MissingConfigEntry, read_config, config_from_string, create_node_dir
 from allmydata.introducer.server import create_introducer
 from allmydata.client import create_client
 from allmydata.client import _valid_config_sections as client_valid_config_sections
@@ -53,14 +53,13 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         return d
 
     def _test_location(self, basedir, expected_addresses, tub_port=None, tub_location=None, local_addresses=None):
-        fileutil.make_dirs(basedir)
-        f = open(os.path.join(basedir, 'tahoe.cfg'), 'wt')
-        f.write("[node]\n")
-        if tub_port:
-            f.write("tub.port = %d\n" % (tub_port,))
-        if tub_location is not None:
-            f.write("tub.location = %s\n" % (tub_location,))
-        f.close()
+        create_node_dir(basedir, "testing")
+        with open(os.path.join(basedir, 'tahoe.cfg'), 'wt') as f:
+            f.write("[node]\n")
+            if tub_port:
+                f.write("tub.port = %d\n" % (tub_port,))
+            if tub_location is not None:
+                f.write("tub.location = %s\n" % (tub_location,))
 
         if local_addresses:
             self.patch(iputil, 'get_local_addresses_sync',
@@ -195,9 +194,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
 
     def test_secrets_dir(self):
         basedir = "test_node/test_secrets_dir"
-        fileutil.make_dirs(basedir)
-        read_config(basedir, "")
-
+        create_node_dir(basedir, "testing")
         self.failUnless(os.path.exists(os.path.join(basedir, "private")))
 
     def test_secrets_dir_protected(self):
@@ -207,9 +204,9 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
             # that unprivileged users can't read this thing.)
             raise unittest.SkipTest("We don't know how to set permissions on Windows.")
         basedir = "test_node/test_secrets_dir_protected"
-        fileutil.make_dirs(basedir)
-        read_config(basedir, "")
+        create_node_dir(basedir, "nothing to see here")
 
+        # make sure private dir was created with correct modes
         privdir = os.path.join(basedir, "private")
         st = os.stat(privdir)
         bits = stat.S_IMODE(st[stat.ST_MODE])
@@ -217,7 +214,6 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
 
     def test_logdir_is_str(self):
         basedir = "test_node/test_logdir_is_str"
-        fileutil.make_dirs(basedir)
 
         ns = Namespace()
         ns.called = False
@@ -226,13 +222,17 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
             self.failUnless(isinstance(logdir, str), logdir)
         self.patch(foolscap.logging.log, 'setLogDir', call_setLogDir)
 
+        create_node_dir(basedir, "nothing to see here")
         TestNode(basedir)
         self.failUnless(ns.called)
 
+
 class EmptyNode(Node):
-    def __init__(self):
-        config = config_from_string("", "no portfile", 'no basedir')
+    def __init__(self, config=None):
+        if config is None:
+            config = config_from_string("", "no portfile", 'no basedir')
         Node.__init__(self, config)
+
 
 EXPECTED = {
     # top-level key is tub.port category
@@ -283,10 +283,10 @@ class PortLocation(unittest.TestCase):
                         "hintstring": "tcp:HOST:888,AUTO",
                         }[tl]
 
-        n = EmptyNode()
         basedir = os.path.join("test_node/portlocation/%s/%s" % (tp, tl))
-        fileutil.make_dirs(basedir)
-        config = n.config = read_config(basedir, "node.port")
+        create_node_dir(basedir, "testing")
+        config = read_config(basedir, "node.port")
+        n = EmptyNode(config)
         n._reveal_ip = True
 
         if exp in ("ERR1", "ERR2", "ERR3", "ERR4"):
@@ -385,23 +385,24 @@ class FakeTub:
 
 class Listeners(unittest.TestCase):
     def test_multiple_ports(self):
-        n = EmptyNode()
-        n.basedir = self.mktemp()
-        n.config_fname = os.path.join(n.basedir, "tahoe.cfg")
-        os.mkdir(n.basedir)
-        os.mkdir(os.path.join(n.basedir, "private"))
+        basedir = self.mktemp()
+        create_node_dir(basedir, "testing")
+
         port1 = iputil.allocate_tcp_port()
         port2 = iputil.allocate_tcp_port()
         port = ("tcp:%d:interface=127.0.0.1,tcp:%d:interface=127.0.0.1" %
                 (port1, port2))
         location = "tcp:localhost:%d,tcp:localhost:%d" % (port1, port2)
-        with open(n.config_fname, "w") as f:
+        with open(os.path.join(basedir, "tahoe.cfg"), "w") as f:
             f.write(BASE_CONFIG)
             f.write("tub.port = %s\n" % port)
             f.write("tub.location = %s\n" % location)
+
+        config = read_config(basedir, "client.port")
+        n = EmptyNode(config)
+
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
-        n.config = read_config(n.basedir, "client.port", _valid_config_sections=client_valid_config_sections)
         n.check_privacy()
         n.services = []
         n.create_i2p_provider()
@@ -416,39 +417,45 @@ class Listeners(unittest.TestCase):
                           "tcp:%d:interface=127.0.0.1" % port2])
 
     def test_tor_i2p_listeners(self):
-        n = EmptyNode()
-        n.basedir = self.mktemp()
-        n.config_fname = os.path.join(n.basedir, "tahoe.cfg")
-        os.mkdir(n.basedir)
-        os.mkdir(os.path.join(n.basedir, "private"))
-        with open(n.config_fname, "w") as f:
+        basedir = self.mktemp()
+        config_fname = os.path.join(basedir, "tahoe.cfg")
+        os.mkdir(basedir)
+        os.mkdir(os.path.join(basedir, "private"))
+        with open(config_fname, "w") as f:
             f.write(BASE_CONFIG)
             f.write("tub.port = listen:i2p,listen:tor\n")
             f.write("tub.location = tcp:example.org:1234\n")
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
-        n.config = read_config(n.basedir, "client.port", _valid_config_sections=client_valid_config_sections)
-        n.check_privacy()
-        n.services = []
+        config = read_config(basedir, "client.port", _valid_config_sections=client_valid_config_sections)
+
         i2p_ep = object()
+        i2p_prov = i2p_provider.Provider(config, mock.Mock())
+        i2p_prov.get_listener = mock.Mock(return_value=i2p_ep)
+        i2p_x = mock.Mock()
+        i2p_x.Provider = lambda c, r: i2p_prov
+        i2p_mock = mock.patch('allmydata.node.i2p_provider', new=i2p_x)
+
         tor_ep = object()
-        n._i2p_provider = mock.Mock()
-        n._i2p_provider.get_listener = mock.Mock(return_value=i2p_ep)
-        n._tor_provider = mock.Mock()
-        n._tor_provider.get_listener = mock.Mock(return_value=tor_ep)
-        n.init_connections()
-        n.set_tub_options()
-        t = FakeTub()
-        with mock.patch("allmydata.node.Tub", return_value=t):
-            n.create_main_tub()
+        tor_prov = tor_provider.Provider(config, mock.Mock())
+        tor_prov.get_listener = mock.Mock(return_value=tor_ep)
+        tor_x = mock.Mock()
+        tor_x.Provider = lambda c, r: tor_prov
+        tor_mock = mock.patch('allmydata.node.tor_provider', new=tor_x)
+
+        tub_mock = mock.patch("allmydata.node.Tub", return_value=FakeTub())
+        with i2p_mock, tor_mock, tub_mock:
+            n = EmptyNode(config)
+
         self.assertEqual(n._i2p_provider.get_listener.mock_calls, [mock.call()])
         self.assertEqual(n._tor_provider.get_listener.mock_calls, [mock.call()])
-        self.assertEqual(t.listening_ports, [i2p_ep, tor_ep])
+        self.assertIn(i2p_ep, n.tub.listening_ports)
+        self.assertIn(tor_ep, n.tub.listening_ports)
 
 class ClientNotListening(unittest.TestCase):
     def test_disabled(self):
         basedir = "test_node/test_disabled"
-        fileutil.make_dirs(basedir)
+        create_node_dir(basedir, "testing")
         f = open(os.path.join(basedir, 'tahoe.cfg'), 'wt')
         f.write(BASE_CONFIG)
         f.write(NOLISTEN)
@@ -459,7 +466,7 @@ class ClientNotListening(unittest.TestCase):
 
     def test_disabled_but_storage(self):
         basedir = "test_node/test_disabled_but_storage"
-        fileutil.make_dirs(basedir)
+        create_node_dir(basedir, "testing")
         f = open(os.path.join(basedir, 'tahoe.cfg'), 'wt')
         f.write(BASE_CONFIG)
         f.write(NOLISTEN)
@@ -470,7 +477,7 @@ class ClientNotListening(unittest.TestCase):
 
     def test_disabled_but_helper(self):
         basedir = "test_node/test_disabled_but_helper"
-        fileutil.make_dirs(basedir)
+        create_node_dir(basedir, "testing")
         f = open(os.path.join(basedir, 'tahoe.cfg'), 'wt')
         f.write(BASE_CONFIG)
         f.write(NOLISTEN)
@@ -483,11 +490,10 @@ class ClientNotListening(unittest.TestCase):
 class IntroducerNotListening(unittest.TestCase):
     def test_port_none_introducer(self):
         basedir = "test_node/test_port_none_introducer"
-        fileutil.make_dirs(basedir)
-        f = open(os.path.join(basedir, 'tahoe.cfg'), 'wt')
-        f.write("[node]\n")
-        f.write("tub.port = disabled\n")
-        f.write("tub.location = disabled\n")
-        f.close()
+        create_node_dir(basedir, "testing")
+        with open(os.path.join(basedir, 'tahoe.cfg'), 'wt') as f:
+            f.write("[node]\n")
+            f.write("tub.port = disabled\n")
+            f.write("tub.location = disabled\n")
         e = self.assertRaises(ValueError, create_introducer, basedir)
         self.assertIn("we are Introducer, but tub is not listening", str(e))

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -136,7 +136,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         basedir = u"test_node/test_config_required"
         config = read_config(basedir, "portnum")
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(Exception):
             config.get_config_from_file("it_does_not_exist", required=True)
 
     def test_private_config_unreadable(self):
@@ -147,7 +147,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         fname = os.path.join(basedir, "private", "foo")
         os.chmod(fname, 0)
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(Exception):
             config.get_or_create_private_config("foo")
 
     def test_private_config_unreadable_preexisting(self):
@@ -159,7 +159,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
             f.write("stuff")
         os.chmod(fname, 0)
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(Exception):
             config.get_private_config("foo")
 
     def test_private_config_missing(self):
@@ -167,7 +167,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         create_node_dir(basedir, "testing")
         config = read_config(basedir, "portnum")
 
-        with self.assertRaises(MissingConfigEntry) as ctx:
+        with self.assertRaises(MissingConfigEntry):
             config.get_or_create_private_config("foo")
 
     def test_private_config(self):

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -132,6 +132,44 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         config = read_config(basedir, "")
         self.failUnless(config.nickname == nickname)
 
+    def test_config_required(self):
+        basedir = u"test_node/test_config_required"
+        config = read_config(basedir, "portnum")
+
+        with self.assertRaises(Exception) as ctx:
+            config.get_config_from_file("it_does_not_exist", required=True)
+
+    def test_private_config_unreadable(self):
+        basedir = u"test_node/test_private_config_unreadable"
+        create_node_dir(basedir, "testing")
+        config = read_config(basedir, "portnum")
+        config.get_or_create_private_config("foo", "contents")
+        fname = os.path.join(basedir, "private", "foo")
+        os.chmod(fname, 0)
+
+        with self.assertRaises(Exception) as ctx:
+            config.get_or_create_private_config("foo")
+
+    def test_private_config_unreadable_preexisting(self):
+        basedir = u"test_node/test_private_config_unreadable_preexisting"
+        create_node_dir(basedir, "testing")
+        config = read_config(basedir, "portnum")
+        fname = os.path.join(basedir, "private", "foo")
+        with open(fname, "w") as f:
+            f.write("stuff")
+        os.chmod(fname, 0)
+
+        with self.assertRaises(Exception) as ctx:
+            config.get_private_config("foo")
+
+    def test_private_config_missing(self):
+        basedir = u"test_node/test_private_config_missing"
+        create_node_dir(basedir, "testing")
+        config = read_config(basedir, "portnum")
+
+        with self.assertRaises(MissingConfigEntry) as ctx:
+            config.get_or_create_private_config("foo")
+
     def test_private_config(self):
         basedir = "test_node/test_private_config"
         privdir = os.path.join(basedir, "private")

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -467,7 +467,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         self.clients = []
         basedirs = []
         for i in range(self.numclients):
-            basedir = self.getdir("client%d" % i)
+            basedir = self.getdir("client{}".format(i))
             basedirs.append(basedir)
             fileutil.make_dirs(os.path.join(basedir, "private"))
             if len(SYSTEM_TEST_CERTS) > (i+1):
@@ -1931,7 +1931,7 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
         # exercise the remote-control-the-client foolscap interfaces in
         # allmydata.control (mostly used for performance tests)
         c0 = self.clients[0]
-        control_furl_file = os.path.join(c0.basedir, "private", "control.furl")
+        control_furl_file = c0.config.get_private_path("control.furl")
         control_furl = open(control_furl_file, "r").read().strip()
         # it doesn't really matter which Tub we use to connect to the client,
         # so let's just use our IntroducerNode's

--- a/src/allmydata/test/web/test_grid.py
+++ b/src/allmydata/test/web/test_grid.py
@@ -1238,8 +1238,7 @@ class Grid(GridTestMixin, WebErrorMixin, ShouldFailMixin, testutil.ReallyEqualMi
         self.basedir = "web/Grid/blacklist"
         self.set_up_grid(oneshare=True)
         c0 = self.g.clients[0]
-        c0_basedir = c0.basedir
-        fn = os.path.join(c0_basedir, "access.blacklist")
+        fn = c0.config.get_config_path("access.blacklist")
         self.uris = {}
         DATA = "off-limits " * 50
 

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -25,7 +25,7 @@ class IntroducerWeb(unittest.TestCase):
         )
         from allmydata.node import config_from_string
         self.node = IntroducerNode(
-            config_from_string(config, portnumfile="introducer.port"),
+            config_from_string(config, "introducer.port", "no-basedir"),
         )
         self.ws = self.node.getServiceNamed("webish")
 

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -2,6 +2,7 @@ from twisted.trial import unittest
 from foolscap.api import fireEventually, flushEventualQueue
 from twisted.internet import defer
 from allmydata.introducer import IntroducerNode
+from allmydata import node
 from .common import FAVICON_MARKUP
 from ..common_web import do_http
 
@@ -23,9 +24,12 @@ class IntroducerWeb(unittest.TestCase):
             "tub.location = 127.0.0.1:1\n"
             "web.port = tcp:0\n"
         )
+        basedir = self.mktemp()
+        node.create_node_dir(basedir, "testing")
+
         from allmydata.node import config_from_string
         self.node = IntroducerNode(
-            config_from_string(config, "introducer.port", "no-basedir"),
+            config_from_string(config, "introducer.port", basedir),
         )
         self.ws = self.node.getServiceNamed("webish")
 

--- a/src/allmydata/util/i2p_provider.py
+++ b/src/allmydata/util/i2p_provider.py
@@ -124,9 +124,8 @@ def create_config(reactor, cli_config):
 # a nice error, and startService will throw an ugly error.
 
 class Provider(service.MultiService):
-    def __init__(self, basedir, config, reactor):
+    def __init__(self, config, reactor):
         service.MultiService.__init__(self)
-        self._basedir = basedir
         self._config = config
         self._i2p = _import_i2p()
         self._txi2p = _import_txi2p()

--- a/src/allmydata/util/tor_provider.py
+++ b/src/allmydata/util/tor_provider.py
@@ -202,10 +202,9 @@ def create_config(reactor, cli_config):
 # nice error, and startService will throw an ugly error.
 
 class Provider(service.MultiService):
-    def __init__(self, basedir, node_for_config, reactor):
+    def __init__(self, config, reactor):
         service.MultiService.__init__(self)
-        self._basedir = basedir
-        self._node_for_config = node_for_config
+        self._config = config
         self._tor_launched = None
         self._onion_ehs = None
         self._onion_tor_control_proto = None
@@ -214,7 +213,7 @@ class Provider(service.MultiService):
         self._reactor = reactor
 
     def _get_tor_config(self, *args, **kwargs):
-        return self._node_for_config.get_config("tor", *args, **kwargs)
+        return self._config.get_config("tor", *args, **kwargs)
 
     def get_listener(self):
         local_port = int(self._get_tor_config("onion.local_port"))
@@ -259,7 +258,7 @@ class Provider(service.MultiService):
         # this fires with a tuple of (control_endpoint, tor_protocol)
         if not self._tor_launched:
             self._tor_launched = OneShotObserverList()
-            private_dir = os.path.join(self._basedir, "private")
+            private_dir = self._config.get_config_path("private")
             tor_binary = self._get_tor_config("tor.executable", None)
             d = _launch_tor(reactor, tor_binary, private_dir, self._txtorcon)
             d.addBoth(self._tor_launched.fire)
@@ -302,7 +301,7 @@ class Provider(service.MultiService):
         external_port = int(self._get_tor_config("onion.external_port"))
 
         fn = self._get_tor_config("onion.private_key_file")
-        privkeyfile = os.path.join(self._basedir, fn)
+        privkeyfile = self._config.get_config_path(fn)
         with open(privkeyfile, "rb") as f:
             privkey = f.read()
         ehs = self._txtorcon.EphemeralHiddenService(


### PR DESCRIPTION
A part of the "async-initializers" branch that (just) pulls out the rest of the "configuration related" methods from `Node` into their own, private, class (`_Config`). This includes the `self.basedir` attribute in `Node`.

Part of https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2870