### PR TITLE
Fix frozen builds

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -15,17 +15,6 @@ if not hasattr(sys, 'real_prefix'):
     sys.exit("Please run inside a virtualenv with Tahoe-LAFS installed.")
 
 
-# Ugly hack to disable the setuptools requirement asserted in '_auto_deps.py'.
-# Without patching out this requirement, frozen binaries will fail at runtime.
-autodeps_path = os.path.join(get_python_lib(), 'allmydata', '_auto_deps.py')
-print("Patching '{}' to remove setuptools check...".format(autodeps_path))
-autodeps_path_backup = autodeps_path + '.backup'
-shutil.copy2(autodeps_path, autodeps_path_backup)
-with open(autodeps_path_backup) as src, open(autodeps_path, 'w+') as dest:
-    dest.write(src.read().replace('"setuptools >=', '#"setuptools >='))
-print("Done!")
-
-
 options = [('u', None, 'OPTION')]  # Unbuffered stdio
 
 added_files = [
@@ -85,10 +74,6 @@ coll = COLLECT(
     strip=False,
     upx=False,
     name='Tahoe-LAFS')
-
-
-# Revert the '_auto_deps.py' patch above
-shutil.move(autodeps_path_backup, autodeps_path)
 
 
 print("Creating archive...")

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -37,12 +37,23 @@ added_files = [
     ('src/allmydata/web/static/css/*', 'allmydata/web/static/css'),
     ('src/allmydata/web/static/img/*.png', 'allmydata/web/static/img')]
 
+hidden_imports = [
+    'allmydata.client',
+    'allmydata.introducer',
+    'allmydata.stats',
+    'cffi',
+    'characteristic',
+    'Crypto',
+    'yaml',
+    'zfec'
+]
+
 a = Analysis(
     ['static/tahoe.py'],
     pathex=[],
     binaries=None,
     datas=added_files,
-    hiddenimports=['characteristic', 'cffi'],
+    hiddenimports=hidden_imports,
     hookspath=[],
     runtime_hooks=[],
     excludes=[],

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -123,7 +123,8 @@ package_imports = [
     ('enum34',           'enum'),
     ('pycparser',        'pycparser'),
     ('PyYAML',           'yaml'),
-    ('magic-wormhole',   'wormhole')
+    ('magic-wormhole',   'wormhole'),
+    ('setuptools',       'setuptools')
 ]
 
 # Dependencies for which we don't know how to get a version number at run-time.
@@ -142,14 +143,6 @@ ignorable = [
     'twisted-conch',
 ]
 
-import sys
-
-# Don't try to get the version number of setuptools in frozen builds, because
-# that triggers 'site' processing that causes failures. Note that frozen
-# builds still (unfortunately) import pkg_resources in .tac files, so the
-# entry for setuptools in install_requires above isn't conditional.
-if not hasattr(sys, 'frozen'):
-    package_imports.append(('setuptools', 'setuptools'))
 
 setup_requires = []
 

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -123,6 +123,7 @@ package_imports = [
     ('enum34',           'enum'),
     ('pycparser',        'pycparser'),
     ('PyYAML',           'yaml'),
+    ('magic-wormhole',   'wormhole')
 ]
 
 # Dependencies for which we don't know how to get a version number at run-time.

--- a/src/allmydata/scripts/tahoe_start.py
+++ b/src/allmydata/scripts/tahoe_start.py
@@ -104,7 +104,7 @@ def start(config):
     # "pretty fast" and with a zero return-code, or else something
     # Very Bad has happened.
     try:
-        args = [sys.executable]
+	args = [sys.executable] if not getattr(sys, 'frozen', False) else []
         for i, arg in enumerate(sys.argv):
             if arg in ['start', 'restart']:
                 args.append('daemonize')


### PR DESCRIPTION
This PR contains a few small changes to fix PyInstaller frozen builds (which were recently broken in a few ways by changes introduced with `tahoe invite` and `tahoe daemonize`) and removes a couple of hacks that are longer necessary to create working frozen tahoe executables with PyInstaller. Please see the expanded commit messages for each individual commit explaining, in detail, the rationale behind each change.