### PR TITLE
NOT FOR MERGE: travis: turn on pip verbose logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   - echo $PATH; which python; which pip; which tox
   - python misc/build_helpers/show-tool-versions.py
 script:
-  - PIP_VERBOSE=1 tox -e codechecks
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then tox; else tox -e coverage; fi
+  - PIP_VERBOSE=1 tox -vv -e codechecks
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then tox -vv; else tox -vv -e coverage; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then /bin/bash integration/install-tor.sh && tox -e integration; fi
 after_success:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - echo $PATH; which python; which pip; which tox
   - python misc/build_helpers/show-tool-versions.py
 script:
-  - tox -e codechecks
+  - PIP_VERBOSE=1 tox -e codechecks
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then tox; else tox -e coverage; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then /bin/bash integration/install-tor.sh && tox -e integration; fi
 after_success:


### PR DESCRIPTION
the OS-X travis builders are failing, and it might be due to some TLS<1.2
brownouts. More logging might tell us what's happening.

Don't merge this, I just needed a PR to get travis to build it.