### PR TITLE
tox: use newer (tox-2.4) settings, pre-install 'incremental'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,22 @@ twisted = 1
 
 [tox]
 envlist = py27
-minversion = 1.7
+minversion = 2.4
 skipsdist = True
 
 [testenv]
+basepython=python2.7
 passenv = TAHOE_LAFS_TRIAL_ARGS USERPROFILE HOMEDRIVE HOMEPATH
-# the default install is non-(--editable), and would displace our -e .[test]
-skip_install = True
-deps = --editable=.[test]
+# Pre-install "incremental" to avoid bug #2913. Basically if Twisted's
+# setup_requires=["incremental"] causes this to be installed (with
+# setuptools), then it'll fail on travis's OS-X 10.12 machines when PyPI
+# disables access with TLS-1.1 or older, so we have to install it ahead of
+# time (with pip).
+deps = incremental
+# We add usedevelop=True for speed, and extras=test to get things like "mock"
+# that are required for our unit tests.
+usedevelop = True
+extras = test
 commands =
          pyflakes src static misc setup.py
          tahoe --version
@@ -28,9 +36,6 @@ commands =
 
 [testenv:coverage]
 # coverage (with --branch) takes about 65% longer to run
-passenv = TAHOE_LAFS_TRIAL_ARGS USERPROFILE HOMEDRIVE HOMEPATH
-skip_install = True
-deps = --editable=.[test]
 commands =
          pyflakes src static misc setup.py
          tahoe --version
@@ -38,9 +43,6 @@ commands =
          coverage xml
 
 [testenv:codechecks]
-passenv = USERPROFILE HOMEDRIVE HOMEPATH
-skip_install = True
-deps = --editable=.[test]
 commands =
          pyflakes src static misc setup.py
          python misc/coding_tools/check-umids.py src
@@ -52,23 +54,15 @@ commands =
          python misc/coding_tools/check-interfaces.py
 
 [testenv:deprecations]
-basepython=python2.7
-passenv = TAHOE_LAFS_TRIAL_ARGS USERPROFILE HOMEDRIVE HOMEPATH
-skip_install = True
-deps = --editable=.[test]
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 commands =
          python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
 
 [testenv:upcoming-deprecations]
-basepython=python2.7
-passenv = TAHOE_LAFS_TRIAL_ARGS USERPROFILE HOMEDRIVE HOMEPATH
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
-skip_install = True
 deps =
-     --editable=.[test]
      git+https://github.com/twisted/twisted
      git+https://github.com/warner/foolscap
 commands =
@@ -108,11 +102,12 @@ commands =
          sphinx-build -b html -d {toxinidir}/docs/_build/doctrees {toxinidir}/docs {toxinidir}/docs/_build/html
 
 [testenv:pyinstaller]
-basepython=python2.7
 # Do not use the '--editable' flag for this testenv as the 'pyinstaller.spec'
 # script called below will need patch the source tree at build-time in order
 # to remove the setuptools requirement from '_auto_deps.py' (and we want to
 # avoid race-conditions when running tests in parallel, e.g., with "detox").
+usedevelop = False
+extras =
 deps =
     .
     pyinstaller


### PR DESCRIPTION
* use 'extras' for our `[test]` additions instead of abusing 'deps'
* use 'deps' to pre-install 'incremental', which we couldn't do when we
  filled it with --editable to get `[test]`
* pre-install 'incremental' to work around a bug that strikes on Travis under
  OS-X-10.12 as PyPI gradually disables TLS<1.2. See ticket 2913 for details
* remove redundant configuration lines
* require tox-2.4 or newer, to get 'extras'

refs ticket:2913
https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2913