### PR TITLE
setup.py: unpin pypiwin32, should be fixed by now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -254,9 +254,7 @@ setup(name="tahoe-lafs", # also set in __init__.py
       python_requires="<3.0",
       install_requires=install_requires,
       extras_require={
-          # this pinning is temporary until an upstream issue is fixed:
-          # https://github.com/mhammond/pywin32/issues/1151
-          ':sys_platform=="win32"': ["pypiwin32==219"],
+          ':sys_platform=="win32"': ["pypiwin32"],
           "test": [
               "pyflakes",
               "coverage",


### PR DESCRIPTION
At the time we pinned this to v219, I think the v220 on PyPI was broken for
py2.7, or they'd stopped producing newer wheels for py2 but the most recent
py2-capable one was broken. The upstream bug is fixed, so I'll unpin this and
see if it works.