### PR TITLE
Avoid pending Twisted deprecations

### DIFF
--- a/src/allmydata/webish.py
+++ b/src/allmydata/webish.py
@@ -114,16 +114,20 @@ class MyRequest(appserver.NevowRequest):
         if self._tahoe_request_had_error:
             error = " [ERROR]"
 
-        log.msg(format="web: %(clientip)s %(method)s %(uri)s %(code)s %(length)s%(error)s",
-                clientip=self.getClientIP(),
-                method=self.method,
-                uri=uri,
-                code=self.code,
-                length=(self.sentLength or "-"),
-                error=error,
-                facility="tahoe.webish",
-                level=log.OPERATIONAL,
-                )
+        log.msg(
+            format=(
+                "web: %(clientip)s %(method)s %(uri)s %(code)s "
+                "%(length)s%(error)s"
+            ),
+            clientip=self.getClientIP(),
+            method=self.method,
+            uri=uri,
+            code=self.code,
+            length=(self.sentLength or "-"),
+            error=error,
+            facility="tahoe.webish",
+            level=log.OPERATIONAL,
+        )
 
 
 class WebishServer(service.MultiService):
@@ -218,4 +222,3 @@ class IntroducerWebishServer(WebishServer):
         service.MultiService.__init__(self)
         self.root = introweb.IntroducerRoot(introducer)
         self.buildServer(webport, nodeurl_path, staticdir)
-


### PR DESCRIPTION
Replaces getClientIP with getClientAddress if possible.  Fixes the deprecation builder.

This introduces "uncovered" code because coverage is only measured when running the test suite against the released version of Twisted, not trunk@HEAD, and one of the codepaths is currently only exercised against Twisted trunk@HEAD.  This seems not ideal but not catastrophic to me since we _are_ actually testing both code paths - we just don't measure one of them automatically.

When the next Twisted release happens, the situation will get a bit worse because we will _only_ test the newer codepath - because both the Twisted-release and Twisted-trunk@HEAD builds will both be running the newer codepath.  To keep testing the older codepath, we would need a CI job that uses other than the newest allowed released Twisted.  Not sure what to do about that (apart from the semi-obvious: set up a new CI job).