### PR TITLE
Consolidate magic-folder config code

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -606,7 +606,7 @@ class _Client(node.Node, pollmixin.PollMixin):
                     collective_dircap=mf_config["collective_dircap"],
                     local_path_u=abspath_expanduser_unicode(local_dir_config, base=self.basedir),
                     dbfile=abspath_expanduser_unicode(db_filename),
-                    umask=self.get_config("magic_folder", "download.umask", 0077),
+                    umask=mf_config["umask"],
                     name=name,
                     downloader_delay=poll_interval,
                 )

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -593,23 +593,7 @@ class _Client(node.Node, pollmixin.PollMixin):
 
             for (name, mf_config) in magic_folders.items():
                 self.log("Starting magic_folder '{}'".format(name))
-                db_filename = os.path.join(self.basedir, "private", "magicfolder_{}.sqlite".format(name))
-                local_dir_config = mf_config['directory']
-                try:
-                    poll_interval = int(mf_config["poll_interval"])
-                except ValueError:
-                    raise ValueError("'poll_interval' option must be an int")
-
-                s = magic_folder.MagicFolder(
-                    client=self,
-                    upload_dircap=mf_config["upload_dircap"],
-                    collective_dircap=mf_config["collective_dircap"],
-                    local_path_u=abspath_expanduser_unicode(local_dir_config, base=self.basedir),
-                    dbfile=abspath_expanduser_unicode(db_filename),
-                    umask=mf_config["umask"],
-                    name=name,
-                    downloader_delay=poll_interval,
-                )
+                s = magic_folder.MagicFolder.from_config(self.basedir, mf_config)
                 self._magic_folders[name] = s
                 s.setServiceParent(self)
                 s.startService()

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -593,7 +593,7 @@ class _Client(node.Node, pollmixin.PollMixin):
 
             for (name, mf_config) in magic_folders.items():
                 self.log("Starting magic_folder '{}'".format(name))
-                s = magic_folder.MagicFolder.from_config(self.basedir, name, mf_config)
+                s = magic_folder.MagicFolder.from_config(self, name, mf_config)
                 self._magic_folders[name] = s
                 s.setServiceParent(self)
                 s.startService()

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -593,7 +593,7 @@ class _Client(node.Node, pollmixin.PollMixin):
 
             for (name, mf_config) in magic_folders.items():
                 self.log("Starting magic_folder '{}'".format(name))
-                s = magic_folder.MagicFolder.from_config(self.basedir, mf_config)
+                s = magic_folder.MagicFolder.from_config(self.basedir, name, mf_config)
                 self._magic_folders[name] = s
                 s.setServiceParent(self)
                 s.startService()

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -244,6 +244,43 @@ def save_magic_folders(node_directory, folders):
 
 class MagicFolder(service.MultiService):
 
+    @classmethod
+    def from_config(cls, client_node, config):
+        """
+        Create a ``MagicFolder`` from a client node and magic-folder
+        configuration.
+
+        :param _Client client_node: The client node the magic-folder is
+            attached to.
+
+        :param dict config: Magic-folder configuration like that in the list
+            returned by ``load_magic_folders``.
+        """
+        db_filename = os.path.join(
+            client_node.basedir,
+            "private",
+            "magicfolder_{}.sqlite".format(name),
+        )
+        local_dir_config = config['directory']
+        try:
+            poll_interval = int(config["poll_interval"])
+        except ValueError:
+            raise ValueError("'poll_interval' option must be an int")
+
+        return cls(
+            client=client_node,
+            upload_dircap=config["upload_dircap"],
+            collective_dircap=config["collective_dircap"],
+            local_path_u=abspath_expanduser_unicode(
+                local_dir_config,
+                base=client_node.basedir,
+            ),
+            dbfile=abspath_expanduser_unicode(db_filename),
+            umask=config["umask"],
+            name=name,
+            downloader_delay=poll_interval,
+        )
+
     def __init__(self, client, upload_dircap, collective_dircap, local_path_u, dbfile, umask,
                  name, uploader_delay=1.0, clock=None, downloader_delay=60):
         precondition_abspath(local_path_u)

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -18,7 +18,12 @@ from zope.interface import Interface, Attribute, implementer
 from allmydata.util import fileutil, configutil, yamlutil
 from allmydata.interfaces import IDirectoryNode
 from allmydata.util import log
-from allmydata.util.fileutil import precondition_abspath, get_pathinfo, ConflictError
+from allmydata.util.fileutil import (
+    precondition_abspath,
+    get_pathinfo,
+    ConflictError,
+    abspath_expanduser_unicode,
+)
 from allmydata.util.assertutil import precondition, _assert
 from allmydata.util.deferredutil import HookMixin
 from allmydata.util.progress import PercentProgress
@@ -245,7 +250,7 @@ def save_magic_folders(node_directory, folders):
 class MagicFolder(service.MultiService):
 
     @classmethod
-    def from_config(cls, client_node, config):
+    def from_config(cls, client_node, name, config):
         """
         Create a ``MagicFolder`` from a client node and magic-folder
         configuration.

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -119,6 +119,7 @@ def load_magic_folders(node_directory):
     old-style to new-style config (but WILL read old-style config and
     return in the same way as if it was new-style).
 
+    :param node_directory: path where node data is stored
     :returns: dict mapping magic-folder-name to its config (also a dict)
     """
     yaml_fname = os.path.join(node_directory, u"private", u"magic_folders.yaml")

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -65,6 +65,7 @@ class NewConfigUtilTests(unittest.TestCase):
     def test_load(self):
         folders = magic_folder.load_magic_folders(self.basedir)
         self.assertEqual(['default'], list(folders.keys()))
+        self.assertEqual(folders['default'][u'umask'], 0o077)
 
     def test_both_styles_of_config(self):
         os.unlink(join(self.basedir, u"private", u"magic_folders.yaml"))
@@ -112,6 +113,23 @@ class NewConfigUtilTests(unittest.TestCase):
         )
         self.assertIn(
             "'magic-folders'",
+            str(ctx.exception)
+        )
+
+    def test_wrong_umask_obj(self):
+        """
+        If a umask is given for a magic-folder that is not an integer, an
+        exception is raised.
+        """
+        self.folders[u"default"][u"umask"] = "0077"
+        yaml_fname = join(self.basedir, u"private", u"magic_folders.yaml")
+        with open(yaml_fname, "w") as f:
+            f.write(yamlutil.safe_dump({u"magic-folders": self.folders}))
+
+        with self.assertRaises(Exception) as ctx:
+            magic_folder.load_magic_folders(self.basedir)
+        self.assertIn(
+            "umask must be an integer",
             str(ctx.exception)
         )
 


### PR DESCRIPTION
This changes the magic-folder config loading code so that it is not longer spread across `client.py` and `magic_folder.py`.  Instead, the config is read and sanitized in `magic_folder.py` only and the resulting config dict is _used_ in `client.py`.
