### PR TITLE
Update NEWS for release 1 13 0

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -192,3 +192,12 @@ D: fix the Download! button on the Welcome page
 N: Jean-Paul Calderone
 E: exarkun@twistedmatrix.com
 D: support SFTP public key authentication.
+
+N: David Stainton
+E: dstainton415@gmail.com
+D: various bug-fixes and features
+
+N: meejah
+E: meejah@meejah.ca
+P: 0xC2602803128069A7, 9D5A 2BD5 688E CB88 9DEB  CD3F C260 2803 1280 69A7
+D: various bug-fixes and features

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,74 +4,234 @@
 User-Visible Changes in Tahoe-LAFS
 ==================================
 
-Release ?? (??)
-'''''''''''''''
+Release 1.13.0 (18-May-2018)
+''''''''''''''''''''''''''''
 
-unedited list of changes since last release, needs cleanup, explanation,
-credit authors, limit to user-visible things
+New Features
+------------
 
-* add "tahoe list-aliases --readonly-uri" PR400
-* add "tahoe status" command
-* add "tahoe list-aliases --json" PR452
-* immutable upload now uses happiness-metric algorithm #1382 PR416
-* add magic-wormhole -based "tahoe invite" and "tahoe create-client --join="
-  #126 PR418
-* tahoe-backup: report progress #1587 PR474
-* web: return "Referrer-Policy: no-referrer" on all requests
-* web: add JSON welcome page #2476 PR430
-* web: handle OPTIONS request #1307 PR447
-* add PyInstaller build #2729 PR421
-* update debian packaging notes after 'stretch' release PR444
-* add Dockerfile PR445
-* add tub.port=listen:i2p / listen:tor, refs #2889 PR437
-* magic-folder: allow for multiple magic-folders in one client
-* magic-folder: only create .backup files on deletes #2880 PR448
-* magic-folder: don't set +x in default umask #2881 PR458
-* magic-folder: preserve user mtime #2882 PR457
-* magic-folder: something about status #2885
-* tahoe.cfg: allow storage path to be configured #2045 PR472
-* tahoe.cfg: tell user path to tahoe.cfg file PR412
-* fix crash when starting with invalid pidfile PR440
-* delete invalid pidfile #1680 PR450
+The ``tahoe list-aliases`` command gained the ``--readonly-uri``
+option in `PR400`_, which lists read-only capabilities (the default
+shows read/write capabilities if available). This command also gained
+a ``--json`` option in `PR452`_, providing machine-readable output.
+
+A new command ``tahoe status`` is added, showing some statistics and
+currently active operations (similar to the ``/status`` page in the
+Web UI).
+
+Immutable uploads now use the "servers of happiness" algorithm for
+uploading shares. This means better placement of shares on available
+servers. See `PR416`_.
+
+To join a new client to a grid, the command ``tahoe invite`` was
+added. This uses `magic wormhole`_ to connect two computers and
+exchange the required information to start the client. The "client
+side" of this command is the also new option ``tahoe
+create-client --join=``. Together, this provides a way to provision a
+new client without having to securely transmit the fURL and other
+details. `PR418`_
+
+``tahoe backup`` now reports progress. `PR474`_
+
+The ``tub.port=`` option can now accept ``listen:i2p`` or
+``listen:tor`` options to use popular anonymity networks with storage
+servers. See `PR437`_
+
+The place where storage servers put shares (the "storage path") is now
+configurable (`PR472`_).
+
+A PyInstaller-based build is now availalbe (`PR421`_). A "Docker
+compose" setup for development purposes is now available (`PR445`_).
+
+
+Bug Fixes in Core
+-----------------
+
+Some bugs with pidfile handling were fixed (`PR440`_ and `PR450`_)
+meaning invalid pidfiles are now deleted. Error-messages related to
+``tahoe.cfg`` now include the full path to the file.
+
+
+Web UI Changes
+--------------
+
+We set the "Referrer-Policy: no-referrer" header on all requests. The
+Welcome page now understands the JSON option (`PR430`_) and OPTIONS
+requests are handled (`PR447`_).
+
+
+Magic Folder Changes
+--------------------
+
+Multiple magic-folders in a single Tahoe client are now
+supported. Bugs with ``.backup`` files have been fixed, meaning
+spurious ``.backup`` files will no longer be produced
+(`PR448`_). Handling of default umask on new magic-folder files is
+fixed in `PR458`_. The user mtime value is now correctly preserved
+(`PR457`_).
+
+A bug in ``tahoe magic-folder status`` causing active operations to
+sometimes not show up is fixed (`PR461`_).
+
+
+Raw Pull Requests
+-----------------
+
+In total, 44 Pull Requests were merged for this release, including
+contributions of code or review from 15 different GitHub users. Thanks
+everyone! A complete list of these PRs and contributions:
+
+`PR380`_: `daira`_
+`PR400`_: `meejah`_ (with `warner`_)
+`PR403`_: `meejah`_
+`PR405`_: `meejah`_ (with `warner`_)
+`PR406`_: `meejah`_ (with `warner`_)
+`PR407`_: `david415`_ (with `meejah`_, `warner`_)
+`PR409`_: `str4d`_ (with `warner`_)
+`PR410`_: `tpltnt`_ (with `warner`_)
+`PR412`_: `tpltnt`_ (with `warner`_)
+`PR414`_: `tpltnt`_ (with `meejah`_, `warner`_)
+`PR416`_: `david415`_, `meejah`_, `markberger`_, `warner`_
+`PR417`_: `meejah`_ (with `pataquets`_, `warner`_)
+`PR418`_: `meejah`_ (with `crwood`_, `exarkun`_, `warner`_)
+`PR419`_: `tpltnt`_ (with `warner`_)
+`PR420`_: `ValdikSS`_ (with `warner`_)
+`PR421`_: `crwood`_ (with `meejah`_, `warner`_)
+`PR423`_: `warner`_
+`PR428`_: `warner`_
+`PR429`_: `exarkun`_ (with `warner`_)
+`PR430`_: `david415`_, `exarkun`_ (with `warner`_)
+`PR432`_: `exarkun`_ (with `meejah`_)
+`PR433`_: `exarkun`_ (with `warner`_)
+`PR434`_: `exarkun`_ (with `warner`_)
+`PR437`_: `warner`_
+`PR438`_: `warner`_ (with `meejah`_)
+`PR440`_: `exarkun`_, `lpirl`_ (with `meejah`_)
+`PR444`_: `AnBuKu`_ (with `warner`_)
+`PR445`_: `bookchin`_ (with `warner`_)
+`PR447`_: `meejah`_ (with `tpltnt`_, `meejah`_)
+`PR448`_: `meejah`_ (with `warner`_)
+`PR450`_: `exarkun`_, `meejah`_, `lpirl`_
+`PR452`_: `meejah`_ (with `tpltnt`_)
+`PR453`_: `meejah`_
+`PR454`_: `meejah`_ (with `tpltnt`_, `meejah`_, `warner`_)
+`PR456`_: `meejah`_ (with `meejah`_)
+`PR457`_: `meejah`_ (with `crwood`_, `tpltnt`_)
+`PR458`_: `meejah`_ (with `tpltnt`_)
+`PR460`_: `tpltnt`_ (with `exarkun`_, `meejah`_)
+`PR462`_: `meejah`_ (with `crwood`_)
+`PR464`_: `meejah`_
+`PR470`_: `meejah`_ (with `exarkun`_, `tpltnt`_, `warner`_)
+`PR472`_: `exarkun`_, `meskio`_
+`PR474`_: `exarkun`_
+`PR482`_: `crwood`_ (with `warner`_)
+
+
+Developer and Internal Changes
+------------------------------
 
 People hacking on Tahoe-LAFS code will be interested in some internal
 improvements which shouldn't have any user-visible effects:
 
 * internal: skip some unicode tests on non-unicode platforms #2912
 * internal: tox: pre-install Incremental to workaround setuptools bug #2913
-* internal: fix PyInstaller builds PR482
-* internal: use @implementer instead of implements PR406
-* internal: improve happiness integration test #2895 PR432
-* web internal: refactor response-format (?t=) logic #2893 PR429
-* internal: fix pyflakes issues #2898 PR434
-* internal: setup.py use find_packages #2897 PR433
+* internal: fix PyInstaller builds `PR482`_
+* internal: use @implementer instead of implements `PR406`_
+* internal: improve happiness integration test #2895 `PR432`_
+* web internal: refactor response-format (?t=) logic #2893 `PR429`_
+* internal: fix pyflakes issues #2898 `PR434`_
+* internal: setup.py use find_packages #2897 `PR433`_
 * internal: ValueOrderedDict fixes #2891
-* internal: remove unnused NumDict #2891 PR438
+* internal: remove unnused NumDict #2891 `PR438`_
 * internal: setup.py use python_requires= so tox3 works #2876
-* internal: rewrite tahoe stop/start/daemonize refs #1148 #275 #1121 #1377 #2149 #719 PR417
-* internal: add docs links to RFCs/etc PR456
-* internal: magic-folder test improvement PR453
-* internal: pytest changes PR462
+* internal: rewrite tahoe stop/start/daemonize refs #1148 #275 #1121 #1377 #2149 #719 `PR417`_
+* internal: add docs links to RFCs/etc `PR456`_
+* internal: magic-folder test improvement `PR453`_
+* internal: pytest changes `PR462`_
 * internal: upload appveyor generated wheels as artifacts #2903
 * internal: fix tox-vs-setuptools-upgrade #2910
-* deps: require txi2p>=0.3.2 to work around TLS who-is-client issue #2861 PR409
-* deps: now need libyaml-dev from system before build PR420
-* deps: twisted>=16.4.0 for "python -m twisted.trial" PR454
-* deps: pin pypiwin32 to 219 until upstream bug resolved PR464
-* deps: setuptools >=28.8.0 for something PR470
-* deps: use stdlib "json" instead of external "simplejson" #2766 PR405
-* complain more loudly in setup.py under py3 PR414
-* rename "filesystem" to "file store" #2345 PR380
-* replace deprecated twisted.web.client with treq #2857 PR428
+* deps: require txi2p>=0.3.2 to work around TLS who-is-client issue #2861 `PR409`_
+* deps: now need libyaml-dev from system before build `PR420`_
+* deps: twisted>=16.4.0 for "python -m twisted.trial" `PR454`_
+* deps: pin pypiwin32 to 219 until upstream bug resolved `PR464`_
+* deps: setuptools >=28.8.0 for something `PR470`_
+* deps: use stdlib "json" instead of external "simplejson" #2766 `PR405`_
+* complain more loudly in setup.py under py3 `PR414`_
+* rename "filesystem" to "file store" #2345 `PR380`_
+* replace deprecated twisted.web.client with treq #2857 `PR428`_
 * improve/stablize some test coverage #2891
 * TODO: can we remove this now? pypiwin32 is now at 223
-* use secure mkstemp() PR460
-* test "tahoe list-aliases --readonly-uri" #2863 PR403
+* use secure mkstemp() `PR460`_
+* test "tahoe list-aliases --readonly-uri" #2863 `PR403`_
 * #455: remove outdated comment
-* PR407 fix stopService calls
-* PR410 explicit python2.7 virtualenv
-* PR419 fix list of supported OSes
-* PR423 switch travis to a supported Ubuntu
+* `PR407`_ fix stopService calls
+* `PR410`_ explicit python2.7 virtualenv
+* `PR419`_ fix list of supported OSes
+* `PR423`_ switch travis to a supported Ubuntu
+
+
+
+.. _PR380: https://github.com/tahoe-lafs/tahoe-lafs/pull/380
+.. _PR400: https://github.com/tahoe-lafs/tahoe-lafs/pull/400
+.. _PR403: https://github.com/tahoe-lafs/tahoe-lafs/pull/403
+.. _PR405: https://github.com/tahoe-lafs/tahoe-lafs/pull/405
+.. _PR406: https://github.com/tahoe-lafs/tahoe-lafs/pull/406
+.. _PR407: https://github.com/tahoe-lafs/tahoe-lafs/pull/407
+.. _PR409: https://github.com/tahoe-lafs/tahoe-lafs/pull/409
+.. _PR410: https://github.com/tahoe-lafs/tahoe-lafs/pull/410
+.. _PR412: https://github.com/tahoe-lafs/tahoe-lafs/pull/412
+.. _PR414: https://github.com/tahoe-lafs/tahoe-lafs/pull/414
+.. _PR416: https://github.com/tahoe-lafs/tahoe-lafs/pull/416
+.. _PR417: https://github.com/tahoe-lafs/tahoe-lafs/pull/417
+.. _PR418: https://github.com/tahoe-lafs/tahoe-lafs/pull/418
+.. _PR419: https://github.com/tahoe-lafs/tahoe-lafs/pull/419
+.. _PR420: https://github.com/tahoe-lafs/tahoe-lafs/pull/420
+.. _PR421: https://github.com/tahoe-lafs/tahoe-lafs/pull/421
+.. _PR423: https://github.com/tahoe-lafs/tahoe-lafs/pull/423
+.. _PR428: https://github.com/tahoe-lafs/tahoe-lafs/pull/428
+.. _PR429: https://github.com/tahoe-lafs/tahoe-lafs/pull/429
+.. _PR430: https://github.com/tahoe-lafs/tahoe-lafs/pull/430
+.. _PR432: https://github.com/tahoe-lafs/tahoe-lafs/pull/432
+.. _PR433: https://github.com/tahoe-lafs/tahoe-lafs/pull/433
+.. _PR434: https://github.com/tahoe-lafs/tahoe-lafs/pull/434
+.. _PR437: https://github.com/tahoe-lafs/tahoe-lafs/pull/437
+.. _PR438: https://github.com/tahoe-lafs/tahoe-lafs/pull/438
+.. _PR440: https://github.com/tahoe-lafs/tahoe-lafs/pull/440
+.. _PR444: https://github.com/tahoe-lafs/tahoe-lafs/pull/444
+.. _PR445: https://github.com/tahoe-lafs/tahoe-lafs/pull/445
+.. _PR447: https://github.com/tahoe-lafs/tahoe-lafs/pull/447
+.. _PR448: https://github.com/tahoe-lafs/tahoe-lafs/pull/448
+.. _PR450: https://github.com/tahoe-lafs/tahoe-lafs/pull/450
+.. _PR452: https://github.com/tahoe-lafs/tahoe-lafs/pull/452
+.. _PR453: https://github.com/tahoe-lafs/tahoe-lafs/pull/453
+.. _PR454: https://github.com/tahoe-lafs/tahoe-lafs/pull/454
+.. _PR456: https://github.com/tahoe-lafs/tahoe-lafs/pull/456
+.. _PR457: https://github.com/tahoe-lafs/tahoe-lafs/pull/457
+.. _PR458: https://github.com/tahoe-lafs/tahoe-lafs/pull/458
+.. _PR460: https://github.com/tahoe-lafs/tahoe-lafs/pull/460
+.. _PR462: https://github.com/tahoe-lafs/tahoe-lafs/pull/462
+.. _PR464: https://github.com/tahoe-lafs/tahoe-lafs/pull/464
+.. _PR470: https://github.com/tahoe-lafs/tahoe-lafs/pull/470
+.. _PR472: https://github.com/tahoe-lafs/tahoe-lafs/pull/472
+.. _PR474: https://github.com/tahoe-lafs/tahoe-lafs/pull/474
+.. _PR482: https://github.com/tahoe-lafs/tahoe-lafs/pull/482
+.. _AnBuKu: https://github.com/AnBuKu
+.. _ValdikSS: https://github.com/ValdikSS
+.. _bookchin: https://github.com/bookchin
+.. _crwood: https://github.com/crwood
+.. _daira: https://github.com/daira
+.. _david415: https://github.com/david415
+.. _exarkun: https://github.com/exarkun
+.. _lpirl: https://github.com/lpirl
+.. _markberger: https://github.com/markberger
+.. _meejah: https://github.com/meejah
+.. _meskio: https://github.com/meskio
+.. _pataquets: https://github.com/pataquets
+.. _str4d: https://github.com/str4d
+.. _tpltnt: https://github.com/tpltnt
+.. _warner: https://github.com/warner
+
+
 
 
 Release 1.12.1 (18-Jan-2017)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,8 +7,6 @@ User-Visible Changes in Tahoe-LAFS
 Release ?? (??)
 '''''''''''''''
 
-TOP
-
 unedited list of changes since last release, needs cleanup, explanation,
 credit authors, limit to user-visible things
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,64 +7,73 @@ User-Visible Changes in Tahoe-LAFS
 Release ?? (??)
 '''''''''''''''
 
+TOP
+
 unedited list of changes since last release, needs cleanup, explanation,
 credit authors, limit to user-visible things
 
 * add "tahoe list-aliases --readonly-uri" PR400
-* web: return "Referrer-Policy: no-referrer" on all requests
-* deps: use stdlib "json" instead of external "simplejson" #2766 PR405
-* internal: use @implementer instead of implements PR406
 * add "tahoe status" command
-* other PRs: 407 412 410 419 423
-* deps: require txi2p>=0.3.2 to work around TLS who-is-client issue #2861 PR409
-* complain more loudly in setup.py under py3 PR414
+* add "tahoe list-aliases --json" PR452
 * immutable upload now uses happiness-metric algorithm #1382 PR416
-* deps: now need libyaml-dev from system before build PR420
-* rename "filesystem" to "file store" #2345 PR380
-* test "tahoe list-aliases --readonly-uri" #2863 PR403
-* replace deprecated twisted.web.client with treq #2857 PR428
-* internal: improve happiness integration test #2895 PR432
-* web internal: refactor response-format (?t=) logic #2893 PR429
-* web: add JSON welcome page #2476 PR430
-* improve/stablize some test coverage #2891
-* internal: fix pyflakes issues #2898 PR434
-* internal: setup.py use find_packages #2897 PR433
 * add magic-wormhole -based "tahoe invite" and "tahoe create-client --join="
   #126 PR418
-* internal: ValueOrderedDict fixes #2891
+* tahoe-backup: report progress #1587 PR474
+* web: return "Referrer-Policy: no-referrer" on all requests
+* web: add JSON welcome page #2476 PR430
+* web: handle OPTIONS request #1307 PR447
 * add PyInstaller build #2729 PR421
-* internal: remove unnused NumDict #2891 PR438
-* internal: setup.py use python_requires= so tox3 works #2876
-* fix crash when starting with invalid pidfile PR440
-* delete invalid pidfile #1680 PR450
 * update debian packaging notes after 'stretch' release PR444
 * add Dockerfile PR445
-* internal: rewrite tahoe stop/start/daemonize refs #1148 #275 #1121 #1377 #2149 #719 PR417
 * add tub.port=listen:i2p / listen:tor, refs #2889 PR437
-* handle multiple magic-folders
-* #2880 (something involving magic-folders) PR448
-* internal magic-folder test improvement PR453
-* deps: twisted>=16.4.0 for "python -m twisted.trial" PR454
-* web: handle OPTIONS request #1307 PR447
-* internal: add docs links to RFCs/etc PR456
-* docs: #455
+* magic-folder: allow for multiple magic-folders in one client
+* magic-folder: only create .backup files on deletes #2880 PR448
 * magic-folder: don't set +x in default umask #2881 PR458
-* internal: pytest changes PR462
-* deps: pin pypiwin32 to 219 until upstream bug resolved PR464
-  TODO: can we remove this now? pypiwin32 is now at 223
 * magic-folder: preserve user mtime #2882 PR457
-* internal: upload appveyor generated wheels as artifacts #2903
-* use secure mkstemp() PR460
-* add "tahoe list-aliases --json" PR452
-* tahoe.cfg: allow storage path to be configured #2045 PR472
 * magic-folder: something about status #2885
-* deps: setuptools >=28.8.0 for something PR470
-* tahoe-backup: report progress #1587 PR474
-* internal: fix tox-vs-setuptools-upgrade #2910
+* tahoe.cfg: allow storage path to be configured #2045 PR472
+* tahoe.cfg: tell user path to tahoe.cfg file PR412
+* fix crash when starting with invalid pidfile PR440
+* delete invalid pidfile #1680 PR450
+
+People hacking on Tahoe-LAFS code will be interested in some internal
+improvements which shouldn't have any user-visible effects:
+
 * internal: skip some unicode tests on non-unicode platforms #2912
 * internal: tox: pre-install Incremental to workaround setuptools bug #2913
 * internal: fix PyInstaller builds PR482
-
+* internal: use @implementer instead of implements PR406
+* internal: improve happiness integration test #2895 PR432
+* web internal: refactor response-format (?t=) logic #2893 PR429
+* internal: fix pyflakes issues #2898 PR434
+* internal: setup.py use find_packages #2897 PR433
+* internal: ValueOrderedDict fixes #2891
+* internal: remove unnused NumDict #2891 PR438
+* internal: setup.py use python_requires= so tox3 works #2876
+* internal: rewrite tahoe stop/start/daemonize refs #1148 #275 #1121 #1377 #2149 #719 PR417
+* internal: add docs links to RFCs/etc PR456
+* internal: magic-folder test improvement PR453
+* internal: pytest changes PR462
+* internal: upload appveyor generated wheels as artifacts #2903
+* internal: fix tox-vs-setuptools-upgrade #2910
+* deps: require txi2p>=0.3.2 to work around TLS who-is-client issue #2861 PR409
+* deps: now need libyaml-dev from system before build PR420
+* deps: twisted>=16.4.0 for "python -m twisted.trial" PR454
+* deps: pin pypiwin32 to 219 until upstream bug resolved PR464
+* deps: setuptools >=28.8.0 for something PR470
+* deps: use stdlib "json" instead of external "simplejson" #2766 PR405
+* complain more loudly in setup.py under py3 PR414
+* rename "filesystem" to "file store" #2345 PR380
+* replace deprecated twisted.web.client with treq #2857 PR428
+* improve/stablize some test coverage #2891
+* TODO: can we remove this now? pypiwin32 is now at 223
+* use secure mkstemp() PR460
+* test "tahoe list-aliases --readonly-uri" #2863 PR403
+* #455: remove outdated comment
+* PR407 fix stopService calls
+* PR410 explicit python2.7 virtualenv
+* PR419 fix list of supported OSes
+* PR423 switch travis to a supported Ubuntu
 
 
 Release 1.12.1 (18-Jan-2017)

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -92,7 +92,7 @@ Many Python installations already include ``pip``, but in case yours does
 not, get it with the `pip install instructions`_::
 
     % pip --version
-    pip 8.1.1 from ... (python 2.7)
+    pip 10.0.1 from ... (python 2.7)
 
 .. _pip install instructions: https://pip.pypa.io/en/stable/installing/
 
@@ -104,7 +104,7 @@ instructions from the `virtualenv documentation`_::
 
 
     % virtualenv --version
-    15.0.1
+    15.1.0
 
 .. _virtualenv documentation: https://virtualenv.pypa.io/en/latest/installation.html
 
@@ -158,7 +158,7 @@ from PyPI with ``venv/bin/pip install tahoe-lafs``. After installation, run
  Successfully installed ...
  
  % venv/bin/tahoe --version
- tahoe-lafs: 1.12.1
+ tahoe-lafs: 1.13.0
  foolscap: ...
  
  %
@@ -178,14 +178,14 @@ You can also install directly from the source tarball URL::
  New python executable in ~/venv/bin/python2.7
  Installing setuptools, pip, wheel...done.
  
- % venv/bin/pip install https://tahoe-lafs.org/downloads/tahoe-lafs-1.12.1.tar.bz2
- Collecting https://tahoe-lafs.org/downloads/tahoe-lafs-1.12.1.tar.bz2
+ % venv/bin/pip install https://tahoe-lafs.org/downloads/tahoe-lafs-1.13.0.tar.bz2
+ Collecting https://tahoe-lafs.org/downloads/tahoe-lafs-1.13.0.tar.bz2
  ...
  Installing collected packages: ...
  Successfully installed ...
  
  % venv/bin/tahoe --version
- tahoe-lafs: 1.12.1
+ tahoe-lafs: 1.13.0
  ...
 
 
@@ -208,7 +208,7 @@ the additional libraries needed to run the unit tests::
  Successfully installed ...
  
  % venv/bin/tahoe --version
- tahoe-lafs: 1.12.1.post34.dev0
+ tahoe-lafs: 1.13.0.post34.dev0
  ...
 
 This way, you won't have to re-run the ``pip install`` step each time you
@@ -257,7 +257,7 @@ result in a "all tests passed" mesage::
  % tox
  GLOB sdist-make: ~/tahoe-lafs/setup.py
  py27 recreate: ~/tahoe-lafs/.tox/py27
- py27 inst: ~/tahoe-lafs/.tox/dist/tahoe-lafs-1.12.1.post8.dev0.zip
+ py27 inst: ~/tahoe-lafs/.tox/dist/tahoe-lafs-1.13.0.post8.dev0.zip
  py27 runtests: commands[0] | tahoe --version
  py27 runtests: commands[1] | trial --rterrors allmydata
  allmydata.test.test_auth

--- a/docs/how_to_make_a_tahoe-lafs_release.org
+++ b/docs/how_to_make_a_tahoe-lafs_release.org
@@ -1,80 +1,94 @@
-﻿* Tahoe Release Checklist [0/19]
-  - [ ] make sure buildbot, travis, appveyor are green
+﻿* select features/PRs for new release [0/]
+  - [ ] made sure they are tagged/labeled
+  - [ ] merged all release PRs
+
+* basic quality checks [0/]
+  - [ ] all travis CI checks pass
+  - [ ] all appveyor checks pass
+  - [ ] all buildbot workers pass their checks
+
+* freeze master branch [0/]
+  - [ ] announced the freeze of the master branch on IRC (i.e. non-release PRs won't be merged until after release)
+
+* sync documentation [0/]
   - [ ] NEWS.rst: summarize user-visible changes, aim for one page of text
-  - [ ] update doc files
-    - NEWS.rst: Add final release name and date to top-most item in NEWS.
-    - relnotes.txt
-    - CREDITS
-    - docs/known_issues.rst
-  - [ ] change docs/INSTALL.rst to point to just the current
-    tahoe-lafs-X.Y.Z.tar.gz source code file
-  - [ ] announce the tree is locked on IRC
-  - [ ] git pull, should be empty
+  - [ ] added final release name and date to top-most item in NEWS.rst
+  - [ ] updated relnotes.txt
+  - [ ] updated CREDITS
+  - [ ] updated docs/known_issues.rst
+  - [ ] docs/INSTALL.rst only points to current tahoe-lafs-X.Y.Z.tar.gz source code file
+  - [ ] updated https://tahoe-lafs.org/hacktahoelafs/
+
+* sign the tag [0/]
+
+  - [ ] code passes all checks / tests (i.e. all CI is green)
+  - [ ] documentation is ready (see above)
+  - [ ] build code locally:
+     tox -e py27,codechecks,coverage,deprecations,docs,integration,tarballs,upcoming-deprecations
+  - [ ] release version is reporting itself as intended version
+  - [ ] created tarballs (for later comparision)
+  - [ ] 'git pull' doesn't pull anything
   - [ ] git tag -s -u 68666A7A -m "release Tahoe-LAFS-X.Y.Z" tahoe-lafs-X.Y.Z
-    - produces a "signed tag"
-  - [ ] build locally to make sure the release is reporting itself as the
-    intended version, make tarballs too (for comparison only)
-  - [ ] push tag to trigger buildslaves. Making a code change is no longer
-    necessary (TODO: pushing just 1.12.0b2 was insufficient: travis fired,
-    but not buildbot)
-    - git push official master TAGNAME
-    - that will build tarballs
-  - [ ] make sure buildbot is green
-  - [ ] download tarballs+wheels
-  - [ ] announce tree is unlocked
-  - [ ] compare tarballs+wheels against local copies (but sign upstreams)
-  - [ ] sign each with "gpg -ba -u 68666a7a FILE"
-  - [ ] twine upload dist/*
-  - [ ] test "pip install tahoe-lafs" (from PyPI)
-  - [ ] upload *.asc to org ~source/downloads/
-  - [ ] copy the release tarball,sigs to tahoe-lafs.org: ~source/downloads/
-  - [ ] move old release out of ~source/downloads (to downloads/old/?)
-  - [ ] send out relnotes.txt:
-    - add prefix with SHA256 of tarballs, release pubkey, git revhash
-    - GPG-sign the email with release key
-    - send to tahoe-announce@tahoe-lafs.org and tahoe-dev@tahoe-lafs.org
-  - [ ] update Wiki front page: version on download link, News column
-  - [ ] update Wiki "Doc": parade of release notes (with rev of NEWS.rst)
-  - [ ] close the Milestone on the trac Roadmap
-  - [ ] tweet to @tahoelafs
-  - other stuff:
-  - [ ] update https://tahoe-lafs.org/hacktahoelafs/
-  - [ ] make an "announcement of new release" on freshmeat
+     XXX should use full key-id above
+  - [ ] pushed tag to trigger buildslaves: git push official master TAGNAME
+
+* sign the release artifacts [0/8]
+
+  - [ ] pushed signed tag (should trigger Buildbot builders)
+  - [ ] Buildbot workers built all artifacts successfully
+  - [ ] downloaded upstream tarballs+wheels
+  - [ ] announce on IRC that master is unlocked
+  - [ ] compared upstream tarballs+wheels against local copies
+  - [ ] signed each upstream artifacts with "gpg -ba -u 68666a7a FILE"
+     XXX should use full key-id above
+  - [ ] added to relnotes.txt: [0/3]
+    - [ ] prefix with SHA256 of tarballs
+    - [ ] release pubkey
+    - [ ] git revision hash
+  - [ ] GPG-signed the release email with release key (write to relnotes.txt.asc)
+
+* publish release artifacts [0/9]
+
+  - [ ] uploaded to PyPI via: twine upload dist/*
+  - [ ] uploaded *.asc to org ~source/downloads/
+  - [ ] test install works properly: pip install tahoe-lafs
+  - [ ] copied the release tarballs and signatures to tahoe-lafs.org: ~source/downloads/
+  - [ ] moved old release out of ~source/downloads (to downloads/old/?)
+  - [ ] ensured readthedocs.org updated
+  - [ ] uploaded wheels to https://tahoe-lafs.org/deps/
+  - [ ] uploaded release to https://github.com/tahoe-lafs/tahoe-lafs/releases
+
+* check release downloads [0/]
+
+  - [ ] test PyPI via: pip install tahoe-lafs
+  - [ ] https://github.com/tahoe-lafs/tahoe-lafs/releases
+  - [ ] https://tahoe-lafs.org/downloads/
+  - [ ] https://tahoe-lafs.org/deps/
+
+* document release in trac [0/]
+
+  - [ ] closed the Milestone on the trac Roadmap
+
+* unfreeze master branch [0/]
+
+  - [ ] announced on IRC that new PRs will be looked at/merged
+
+* announce new release [0/]
+
+  - [ ] sent release email and relnotes.txt.asc to tahoe-announce@tahoe-lafs.org
+  - [ ] sent release email and relnotes.txt.asc to tahoe-dev@tahoe-lafs.org
+  - [ ] updated Wiki front page: version on download link, News column
+  - [ ] updated Wiki "Doc": parade of release notes (with rev of NEWS.rst)
+  - [ ] make an "announcement of new release" on freshmeat (XXX still a thing?)
   - [ ] make an "announcement of new release" on launchpad
-  - [ ] send out relnotes.txt to:
-    - p2p-hackers@lists.zooko.com
-    - lwn@lwn.net
-    - a Google+ page
-    - cap-talk@mail.eros-os.org
-    - cryptography@metzdown.com
-    - cryptography@randombit.net
-    - twisted-python@twistedmatrix.com
-    - owncloud@kde.org
-    - liberationtech@lists.stanford.edu
-    - the "decentralization" group on groups.yahoo.com
-    - pycrypto mailing list
-    - fuse-devel@lists.sourceforge.net
-    - fuse-sshfs@lists.sourceforge.net
-    - duplicity-talk@nongnu.org
-    - news@phoronix.com
-    - python-list@python.org
-    - cygwin@cygwin.com
-    - The Boulder Linux Users' Group
-    - The Boulder Hackerspace mailing list
-    - cryptopp-users@googlegroups.com
-    - tiddlywiki
-    - hdfs-dev@hadoop.apache.org
-    - bzr
-    - mercurial
-    - http://listcultures.org/pipermail/p2presearch_listcultures.org/
-    - deltacloud
-    - libcloud
-    - swift@lists.launchpad.net
-    - stephen@fosketts.net
-    - Chris Mellor of The Register
-    - nosql@mypopescu.com
-    - The H Open
-    - fans/customers of cleversafe
-    - fans/customers of bitcasa
-    - fans/customers of wuala
-    - fans/customers of spideroak
+  - [ ] tweeted as @tahoelafs
+  - [ ] emailed signed relnotes.txt to below listed mailing-lists/organizations
+  - [ ] also announce release to (trimmed from previous version of this doc):
+      - twisted-python@twistedmatrix.com
+      - liberationtech@lists.stanford.edu
+      - lwn@lwn.net
+      - p2p-hackers@lists.zooko.com
+      - python-list@python.org
+      - http://listcultures.org/pipermail/p2presearch_listcultures.org/
+      - cryptopp-users@googlegroups.com
+      - (others?)

--- a/docs/how_to_make_a_tahoe-lafs_release.org
+++ b/docs/how_to_make_a_tahoe-lafs_release.org
@@ -23,8 +23,7 @@
 
   - [ ] code passes all checks / tests (i.e. all CI is green)
   - [ ] documentation is ready (see above)
-  - [ ] git tag -s -u 68666A7A -m "release Tahoe-LAFS-X.Y.Z" tahoe-lafs-X.Y.Z
-     XXX should use full key-id above
+  - [ ] git tag -s -u 0xBDE0D31D68666A7A -m "release Tahoe-LAFS-X.Y.Z" tahoe-lafs-X.Y.Z
   - [ ] build code locally:
      tox -e py27,codechecks,coverage,deprecations,docs,integration,upcoming-deprecations
   - [ ] release version is reporting itself as intended version
@@ -40,8 +39,7 @@
   - [ ] downloaded upstream tarballs+wheels
   - [ ] announce on IRC that master is unlocked
   - [ ] compared upstream tarballs+wheels against local copies
-  - [ ] signed each upstream artifacts with "gpg -ba -u 68666a7a FILE"
-     XXX should use full key-id above
+  - [ ] signed each upstream artifacts with "gpg -ba -u 0xBDE0D31D68666A7A FILE"
   - [ ] added to relnotes.txt: [0/3]
     - [ ] prefix with SHA256 of tarballs
     - [ ] release pubkey

--- a/docs/how_to_make_a_tahoe-lafs_release.org
+++ b/docs/how_to_make_a_tahoe-lafs_release.org
@@ -1,8 +1,8 @@
-﻿* select features/PRs for new release [0/]
+﻿* select features/PRs for new release [0/2]
   - [ ] made sure they are tagged/labeled
   - [ ] merged all release PRs
 
-* basic quality checks [0/]
+* basic quality checks [0/3]
   - [ ] all travis CI checks pass
   - [ ] all appveyor checks pass
   - [ ] all buildbot workers pass their checks
@@ -10,7 +10,7 @@
 * freeze master branch [0/]
   - [ ] announced the freeze of the master branch on IRC (i.e. non-release PRs won't be merged until after release)
 
-* sync documentation [0/]
+* sync documentation [0/7]
   - [ ] NEWS.rst: summarize user-visible changes, aim for one page of text
   - [ ] added final release name and date to top-most item in NEWS.rst
   - [ ] updated relnotes.txt
@@ -19,17 +19,18 @@
   - [ ] docs/INSTALL.rst only points to current tahoe-lafs-X.Y.Z.tar.gz source code file
   - [ ] updated https://tahoe-lafs.org/hacktahoelafs/
 
-* sign the tag [0/]
+* sign the tag [0/8]
 
   - [ ] code passes all checks / tests (i.e. all CI is green)
   - [ ] documentation is ready (see above)
-  - [ ] build code locally:
-     tox -e py27,codechecks,coverage,deprecations,docs,integration,tarballs,upcoming-deprecations
-  - [ ] release version is reporting itself as intended version
-  - [ ] created tarballs (for later comparision)
-  - [ ] 'git pull' doesn't pull anything
   - [ ] git tag -s -u 68666A7A -m "release Tahoe-LAFS-X.Y.Z" tahoe-lafs-X.Y.Z
      XXX should use full key-id above
+  - [ ] build code locally:
+     tox -e py27,codechecks,coverage,deprecations,docs,integration,upcoming-deprecations
+  - [ ] release version is reporting itself as intended version
+  - [ ] created tarballs (they'll be in dist/ for later comparison)
+     tox -e tarballs
+  - [ ] 'git pull' doesn't pull anything
   - [ ] pushed tag to trigger buildslaves: git push official master TAGNAME
 
 * sign the release artifacts [0/8]
@@ -82,7 +83,7 @@
   - [ ] make an "announcement of new release" on freshmeat (XXX still a thing?)
   - [ ] make an "announcement of new release" on launchpad
   - [ ] tweeted as @tahoelafs
-  - [ ] emailed signed relnotes.txt to below listed mailing-lists/organizations
+  - [ ] emailed relnotes.txt.asc to below listed mailing-lists/organizations
   - [ ] also announce release to (trimmed from previous version of this doc):
       - twisted-python@twistedmatrix.com
       - liberationtech@lists.stanford.edu

--- a/fetch-pr.py
+++ b/fetch-pr.py
@@ -1,0 +1,104 @@
+# given a PR number, get all contributers and the summary from
+# GitHub's API
+
+import sys
+import json
+import base64
+
+from twisted.internet.task import react
+from twisted.internet.defer import inlineCallbacks, returnValue
+
+import treq
+
+base_pr_url = "https://api.github.com/repos/tahoe-lafs/tahoe-lafs/pulls/{}"
+token = open('token', 'r').read().strip()
+
+#async def main(reactor):
+@inlineCallbacks
+def main(reactor):
+    """
+    """
+    if len(sys.argv) < 2:
+        data = sys.stdin.read()
+        if not len(data):
+            print("put some PR numbers on the command-line")
+            returnValue(1)
+        else:
+            all_prs = set()
+            for word in data.split():
+                word = word.strip()
+                if word.startswith('PR'):
+                    all_prs.add(word[2:])
+            all_prs = list(all_prs)
+            print("Found {} PRs in stdin text".format(len(all_prs)))
+    else:
+        all_prs = sys.argv[1:]
+
+    headers = {
+        "User-Agent": "treq",
+        "Authorization": "Basic {}".format(base64.b64encode("meejah:{}".format(token))),
+    }
+
+    pr_info = {}
+
+    for pr in all_prs:
+        print("Fetching PR{}".format(pr))
+        resp = yield treq.get(
+            base_pr_url.format(pr),
+            headers=headers,
+        )
+        raw_data = yield resp.text()
+        data = json.loads(raw_data)
+
+        code_handles = set()
+        help_handles = set()
+        ignore = ('codecov-io', )
+
+        print("Commits:")
+        commits_resp = yield treq.get(data['commits_url'], headers=headers)
+        commits_data = yield commits_resp.text()
+        commits = json.loads(commits_data)
+        for commit in commits:
+            if commit['author'] is None:
+                print("  {}: no author!".format(commit['sha']))
+            else:
+                author = commit['author']['login']
+                print("  {}: {}".format(commit['sha'], author))
+                if author not in ignore:
+                      code_handles.add(author)
+
+        print("Comments:")
+        comments_resp = yield treq.get(data['comments_url'], headers=headers)
+        comments_data = yield comments_resp.text()
+        comments = json.loads(comments_data)
+        for comment in comments:
+            author = comment['user']['login']
+            if author not in ignore:
+                help_handles.add(author)
+            print("  {}: {}".format(author, comment['body'].replace('\n', ' ')[:60]))
+
+        pr_info[pr] = (
+            code_handles,
+            help_handles - help_handles.intersection(code_handles),
+        )
+
+    unique_handles = set()
+    for pr, (code_handles, help_handles) in sorted(pr_info.items()):
+        coders = ', '.join('`{}`_'.format(c) for c in code_handles)
+        helpers = ', '.join('`{}`_'.format(c) for c in help_handles)
+        if helpers:
+            print("`PR{}`_: {} (with {})".format(pr, coders, helpers))
+        else:
+            print("`PR{}`_: {}".format(pr, coders))
+        for h in code_handles.union(help_handles):
+            unique_handles.add(h)
+
+    for pr in sorted(pr_info.keys()):
+        print(".. _PR{}: https://github.com/tahoe-lafs/tahoe-lafs/pull/{}".format(pr, pr))
+    for h in sorted(unique_handles):
+        print(".. _{}: https://github.com/{}".format(h, h))
+
+
+if __name__ == "__main__":
+    #react(lambda r: ensureDeferred(main(r)))
+    react(main)

--- a/relnotes.txt
+++ b/relnotes.txt
@@ -1,6 +1,6 @@
-﻿ANNOUNCING Tahoe, the Least-Authority File Store, v1.12.1
+﻿ANNOUNCING Tahoe, the Least-Authority File Store, v1.13.0
 
-The Tahoe-LAFS team is pleased to announce version 1.12.1 of
+The Tahoe-LAFS team is pleased to announce version 1.13.0 of
 Tahoe-LAFS, an extremely reliable decentralized storage
 system. Get it with "pip install tahoe-lafs", or download a
 tarball here:
@@ -15,13 +15,27 @@ unique security and fault-tolerance properties:
 
   http://tahoe-lafs.readthedocs.org/en/latest/about.html
 
-The previous stable release of Tahoe-LAFS was v1.12.0,
-released on December 17, 2016.
+The previous stable release of Tahoe-LAFS was v1.13.1,
+released on January 18, 2017.
 
-v1.12.1 fixes a few small problems discovered just after the
-v1.12.0 release in the new "multiple-introducers" feature and
-the new "--hide-ip" feature (on systems with I2P support but
-not Tor).
+v1.13.1 fixes several problems with the magic-folder frontend, adds
+--json to more commands, adds the "tahoe status" and "tahoe
+magic-folder status" commands and some internal refactoring. It is
+also now possible to have multiple magic folders in a single Tahoe
+client.
+
+A long-standing feature to improve the share-placement algorithm
+("servers of happiness") has been updated and merged. "tahoe backup"
+now reports progress.
+
+New clients can now be added to a grid using "magic wormhole" [14], a
+SPAKE2-based method of securely connecting two computers. This adds
+the "tahoe invite" command for a current grid-participant to invite a
+new client and a corresponding option "tahoe create-client --join" for
+the other side. These use a server at ``wormhole.tahoe-lafs.org``
+currently operated by Least Authority.
+
+Please see ``NEWS.rst`` for a more complete list of changes.
 
 
 WHAT IS IT GOOD FOR?
@@ -133,7 +147,7 @@ Of Fame" [13].
 
 ACKNOWLEDGEMENTS
 
-This is the seventeenth release of Tahoe-LAFS to be created
+This is the eighteenth release of Tahoe-LAFS to be created
 solely as a labor of love by volunteers. Thank you very much
 to the team of "hackers in the public interest" who make
 Tahoe-LAFS possible.
@@ -141,19 +155,20 @@ Tahoe-LAFS possible.
 Brian Warner
 on behalf of the Tahoe-LAFS team
 
-January 18, 2017
+May 17, 2018
 San Francisco, California, USA
 
 
-[1] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.12.1/NEWS.rst
+[1] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.13.0/NEWS.rst
 [2] https://github.com/tahoe-lafs/tahoe-lafs/blob/master/docs/known_issues.rst
 [3] https://tahoe-lafs.org/trac/tahoe-lafs/wiki/RelatedProjects
-[4] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.12.1/COPYING.GPL
-[5] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.12.1/COPYING.TGPPL.rst
-[6] http://tahoe-lafs.readthedocs.org/en/tahoe-lafs-1.12.1/INSTALL.html
+[4] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.13.0/COPYING.GPL
+[5] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.13.0/COPYING.TGPPL.rst
+[6] http://tahoe-lafs.readthedocs.org/en/tahoe-lafs-1.13.0/INSTALL.html
 [7] https://tahoe-lafs.org/cgi-bin/mailman/listinfo/tahoe-dev
 [8] https://tahoe-lafs.org/trac/tahoe-lafs/roadmap
 [9] https://github.com/tahoe-lafs/tahoe-lafs/blob/master/CREDITS
 [10] https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Dev
 [12] https://leastauthority.com/
 [13] https://tahoe-lafs.org/hacktahoelafs/
+[14] http://magic-wormhole.io


### PR DESCRIPTION
First cut at updating the NEWS file for 1.13.0 which also includes a script to scrape all the "PRxxx" stuff out some text and download information about those from GitHub.