### PR TITLE
Actually validate configs when loading them

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -72,6 +72,7 @@ def _valid_config_sections():
             "expire.override_lease_duration",
             "readonly",
             "reserved_space",
+            "storage_dir",
         ),
         "sftpd": (
             "accounts.file",

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -146,7 +146,7 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config_sections
     except EnvironmentError:
         if os.path.exists(config_fname):
             raise
-        configutil.validate_config(config_fname, parser, _valid_config_sections())
+    configutil.validate_config(config_fname, parser, _valid_config_sections())
     return _Config(parser, portnumfile, config_fname)
 
 

--- a/src/allmydata/scripts/tahoe_daemonize.py
+++ b/src/allmydata/scripts/tahoe_daemonize.py
@@ -132,9 +132,6 @@ class DaemonizeTheRealService(Service):
             except UnknownConfigError as e:
                 sys.stderr.write("\nConfiguration error:\n{}\n\n".format(e))
                 reactor.stop()
-            except Exception as e:
-                sys.stderr.write("\nError building service:\n{}\n\n".format(e))
-                reactor.stop()
 
         from twisted.internet import reactor
         reactor.callWhenRunning(start)

--- a/src/allmydata/scripts/tahoe_daemonize.py
+++ b/src/allmydata/scripts/tahoe_daemonize.py
@@ -8,6 +8,7 @@ from allmydata.scripts.default_nodedir import _default_nodedir
 from allmydata.util import fileutil
 from allmydata.node import read_config
 from allmydata.util.encodingutil import listdir_unicode, quote_local_unicode_path
+from allmydata.util.configutil import UnknownConfigError
 from twisted.application.service import Service
 
 
@@ -125,8 +126,15 @@ class DaemonizeTheRealService(Service):
             except KeyError:
                 raise ValueError("unknown nodetype %s" % self.nodetype)
 
-            srv = service_factory()
-            srv.setServiceParent(self.parent)
+            try:
+                srv = service_factory()
+                srv.setServiceParent(self.parent)
+            except UnknownConfigError as e:
+                sys.stderr.write("\nConfiguration error:\n{}\n\n".format(e))
+                reactor.stop()
+            except Exception as e:
+                sys.stderr.write("\nError building service:\n{}\n\n".format(e))
+                reactor.stop()
 
         from twisted.internet import reactor
         reactor.callWhenRunning(start)

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -26,7 +26,7 @@ import treq
 from allmydata.util.assertutil import _assert
 
 from allmydata import uri as tahoe_uri
-from allmydata.client import _Client
+from allmydata.client import _Client, _valid_config_sections
 from allmydata.storage.server import StorageServer, storage_index_to_dir
 from allmydata.util import fileutil, idlib, hashutil
 from allmydata.util.hashutil import permute_server_hash
@@ -188,7 +188,7 @@ def NoNetworkClient(basedir):
     # XXX FIXME this is just to avoid massive search-replace for now;
     # should be create_nonetwork_client() or something...
     from allmydata.node import read_config
-    config = read_config(basedir, u'client.port')
+    config = read_config(basedir, u'client.port', _valid_config_sections=_valid_config_sections)
     return _NoNetworkClient(config, basedir=basedir)
 
 

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -71,7 +71,13 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         old_mode = os.stat(fn).st_mode
         os.chmod(fn, 0)
         try:
-            e = self.assertRaises(EnvironmentError, read_config, basedir, "client.port", _valid_config_sections=client._valid_config_sections)
+            e = self.assertRaises(
+                EnvironmentError,
+                read_config,
+                basedir,
+                "client.port",
+                _valid_config_sections=client._valid_config_sections,
+            )
             self.assertIn("Permission denied", str(e))
         finally:
             # don't leave undeleteable junk lying around
@@ -93,7 +99,13 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         logged_messages = []
         self.patch(twisted.python.log, 'msg', logged_messages.append)
 
-        e = self.failUnlessRaises(OldConfigError, read_config, basedir, "client.port", _valid_config_sections=client._valid_config_sections)
+        e = self.failUnlessRaises(
+            OldConfigError,
+            read_config,
+            basedir,
+            "client.port",
+            _valid_config_sections=client._valid_config_sections,
+        )
         abs_basedir = fileutil.abspath_expanduser_unicode(unicode(basedir)).encode(sys.getfilesystemencoding())
         self.failUnlessIn(os.path.join(abs_basedir, "introducer.furl"), e.args[0])
         self.failUnlessIn(os.path.join(abs_basedir, "no_storage"), e.args[0])

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -71,7 +71,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         old_mode = os.stat(fn).st_mode
         os.chmod(fn, 0)
         try:
-            e = self.assertRaises(EnvironmentError, read_config, basedir, "client.port")
+            e = self.assertRaises(EnvironmentError, read_config, basedir, "client.port", _valid_config_sections=client._valid_config_sections)
             self.assertIn("Permission denied", str(e))
         finally:
             # don't leave undeleteable junk lying around
@@ -93,7 +93,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         logged_messages = []
         self.patch(twisted.python.log, 'msg', logged_messages.append)
 
-        e = self.failUnlessRaises(OldConfigError, read_config, basedir, "client.port")
+        e = self.failUnlessRaises(OldConfigError, read_config, basedir, "client.port", _valid_config_sections=client._valid_config_sections)
         abs_basedir = fileutil.abspath_expanduser_unicode(unicode(basedir)).encode(sys.getfilesystemencoding())
         self.failUnlessIn(os.path.join(abs_basedir, "introducer.furl"), e.args[0])
         self.failUnlessIn(os.path.join(abs_basedir, "no_storage"), e.args[0])

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -30,7 +30,11 @@ class TestNode(Node):
     CERTFILE='DEFAULT_CERTFILE_BLANK'
 
     def __init__(self, basedir):
-        config = read_config(basedir, 'DEFAULT_PORTNUMFILE_BLANK', _valid_config_sections=_valid_config_sections)
+        config = read_config(
+            basedir,
+            'DEFAULT_PORTNUMFILE_BLANK',
+            _valid_config_sections=_valid_config_sections,
+        )
         Node.__init__(self, config, basedir)
 
 
@@ -262,7 +266,11 @@ class PortLocation(unittest.TestCase):
         n = EmptyNode()
         basedir = os.path.join("test_node/portlocation/%s/%s" % (tp, tl))
         fileutil.make_dirs(basedir)
-        config = n.config = read_config(basedir, "node.port", _valid_config_sections=_valid_config_sections)
+        config = n.config = read_config(
+            basedir,
+            "node.port",
+            _valid_config_sections=_valid_config_sections,
+        )
         n._reveal_ip = True
 
         if exp in ("ERR1", "ERR2", "ERR3", "ERR4"):
@@ -377,7 +385,11 @@ class Listeners(unittest.TestCase):
             f.write("tub.location = %s\n" % location)
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
-        n.config = read_config(n.basedir, "client.port", _valid_config_sections=_valid_config_sections)
+        n.config = read_config(
+            n.basedir,
+            "client.port",
+            _valid_config_sections=_valid_config_sections,
+        )
         n.check_privacy()
         n.services = []
         n.create_i2p_provider()
@@ -403,7 +415,11 @@ class Listeners(unittest.TestCase):
             f.write("tub.location = tcp:example.org:1234\n")
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
-        n.config = read_config(n.basedir, "client.port", _valid_config_sections=_valid_config_sections)
+        n.config = read_config(
+            n.basedir,
+            "client.port",
+            _valid_config_sections=_valid_config_sections,
+        )
         n.check_privacy()
         n.services = []
         i2p_ep = object()

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -16,7 +16,7 @@ import foolscap.logging.log
 from twisted.application import service
 from allmydata.node import Node, formatTimeTahoeStyle, MissingConfigEntry, read_config, config_from_string
 from allmydata.introducer.server import create_introducer
-from allmydata.client import create_client
+from allmydata.client import create_client, _valid_config_sections
 from allmydata.util import fileutil, iputil
 from allmydata.util.namespace import Namespace
 import allmydata.test.common_util as testutil
@@ -30,7 +30,7 @@ class TestNode(Node):
     CERTFILE='DEFAULT_CERTFILE_BLANK'
 
     def __init__(self, basedir):
-        config = read_config(basedir, 'DEFAULT_PORTNUMFILE_BLANK')
+        config = read_config(basedir, 'DEFAULT_PORTNUMFILE_BLANK', _valid_config_sections=_valid_config_sections)
         Node.__init__(self, config, basedir)
 
 
@@ -262,7 +262,7 @@ class PortLocation(unittest.TestCase):
         n = EmptyNode()
         basedir = os.path.join("test_node/portlocation/%s/%s" % (tp, tl))
         fileutil.make_dirs(basedir)
-        config = n.config = read_config(basedir, "node.port")
+        config = n.config = read_config(basedir, "node.port", _valid_config_sections=_valid_config_sections)
         n._reveal_ip = True
 
         if exp in ("ERR1", "ERR2", "ERR3", "ERR4"):
@@ -377,7 +377,7 @@ class Listeners(unittest.TestCase):
             f.write("tub.location = %s\n" % location)
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
-        n.config = read_config(n.basedir, "client.port")
+        n.config = read_config(n.basedir, "client.port", _valid_config_sections=_valid_config_sections)
         n.check_privacy()
         n.services = []
         n.create_i2p_provider()
@@ -403,7 +403,7 @@ class Listeners(unittest.TestCase):
             f.write("tub.location = tcp:example.org:1234\n")
         # we're doing a lot of calling-into-setup-methods here, it might be
         # better to just create a real Node instance, I'm not sure.
-        n.config = read_config(n.basedir, "client.port")
+        n.config = read_config(n.basedir, "client.port", _valid_config_sections=_valid_config_sections)
         n.check_privacy()
         n.services = []
         i2p_ep = object()


### PR DESCRIPTION
An indenting problem meant the configuration validators were no longer being called, which revealed some follow-on errors. Also adds newly-minted `storage_dir` option.