### PR TITLE
Fix "Address already in use" errors from test_introducer on POSIX

### DIFF
--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -329,6 +329,8 @@ def foolscapEndpointForPortNumber(portnum):
         Foolscap-compatible endpoint object.
     """
     if portnum is None:
+        # Bury this reactor import here to minimize the chances of it having
+        # the effect of installing the default reactor.
         from twisted.internet import reactor
         if IReactorSocket.providedBy(reactor):
             # On POSIX we can take this very safe approach of binding the

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -2,11 +2,13 @@
 import os, re, itertools
 from base64 import b32decode
 import json
+from socket import socket, AF_INET
 
 from twisted.trial import unittest
 from twisted.internet import defer, address
 from twisted.python import log
 from twisted.python.filepath import FilePath
+from twisted.internet.endpoints import AdoptedStreamServerEndpoint
 
 from foolscap.api import Tub, Referenceable, fireEventually, flushEventualQueue
 from twisted.application import service
@@ -333,8 +335,6 @@ def foolscapEndpointForPortNumber(portnum):
             # actual socket to an address.  Once the bind succeeds here, we're
             # no longer subject to any future EADDRINUSE problems.
             import fcntl
-            from socket import socket, AF_INET
-            from twisted.internet.endpoints import AdoptedStreamServerEndpoint
             s = socket()
             try:
                 s.bind(('', 0))

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -8,6 +8,7 @@ from twisted.trial import unittest
 from twisted.internet import defer, address
 from twisted.python import log
 from twisted.python.filepath import FilePath
+from twisted.python.reflect import requireModule
 from twisted.internet.endpoints import AdoptedStreamServerEndpoint
 from twisted.internet.interfaces import IReactorSocket
 
@@ -25,6 +26,8 @@ from allmydata.web import introweb
 from allmydata.client import create_client
 from allmydata.util import pollmixin, keyutil, idlib, fileutil, iputil, yamlutil
 import allmydata.test.common_util as testutil
+
+fcntl = requireModule("fcntl")
 
 class LoggingMultiService(service.MultiService):
     def log(self, msg, **kw):
@@ -332,11 +335,10 @@ def foolscapEndpointForPortNumber(portnum):
         # Bury this reactor import here to minimize the chances of it having
         # the effect of installing the default reactor.
         from twisted.internet import reactor
-        if IReactorSocket.providedBy(reactor):
+        if fcntl is not None and IReactorSocket.providedBy(reactor):
             # On POSIX we can take this very safe approach of binding the
             # actual socket to an address.  Once the bind succeeds here, we're
             # no longer subject to any future EADDRINUSE problems.
-            import fcntl
             s = socket()
             try:
                 s.bind(('', 0))

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -432,8 +432,8 @@ class SystemTest(SystemTestMixin, unittest.TestCase):
             #tub.setOption("logRemoteFailures", True)
             tub.setOption("expose-remote-exception-types", False)
             tub.setServiceParent(self.parent)
-            portnum = iputil.allocate_tcp_port()
-            tub.listenOn("tcp:%d" % portnum)
+            portnum, endpoint = foolscapEndpointForPortNumber(None)
+            tub.listenOn(endpoint)
             tub.setLocation("localhost:%d" % portnum)
 
             log.msg("creating client %d: %s" % (i, tub.getShortTubID()))

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -913,8 +913,8 @@ class NonV1Server(SystemTestMixin, unittest.TestCase):
         tub = Tub()
         tub.setOption("expose-remote-exception-types", False)
         tub.setServiceParent(self.parent)
-        portnum = iputil.allocate_tcp_port()
-        tub.listenOn("tcp:%d" % portnum)
+        portnum, endpoint = foolscapEndpointForPortNumber(None)
+        tub.listenOn(endpoint)
         tub.setLocation("localhost:%d" % portnum)
 
         c = IntroducerClient(tub, self.introducer_furl,

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -9,6 +9,7 @@ from twisted.internet import defer, address
 from twisted.python import log
 from twisted.python.filepath import FilePath
 from twisted.internet.endpoints import AdoptedStreamServerEndpoint
+from twisted.internet.interfaces import IReactorSocket
 
 from foolscap.api import Tub, Referenceable, fireEventually, flushEventualQueue
 from twisted.application import service
@@ -329,7 +330,6 @@ def foolscapEndpointForPortNumber(portnum):
     """
     if portnum is None:
         from twisted.internet import reactor
-        from twisted.internet.interfaces import IReactorSocket
         if IReactorSocket.providedBy(reactor):
             # On POSIX we can take this very safe approach of binding the
             # actual socket to an address.  Once the bind succeeds here, we're

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -322,11 +322,17 @@ def foolscapEndpointForPortNumber(portnum):
             from socket import socket, AF_INET
             from twisted.internet.endpoints import AdoptedStreamServerEndpoint
             s = socket()
-            s.setblocking(False)
-            s.bind(('', 0))
-            portnum = s.getsockname()[1]
-            s.listen(3)
-            return (portnum, AdoptedStreamServerEndpoint(reactor, s.fileno(), AF_INET))
+            try:
+                s.setblocking(False)
+                s.bind(('', 0))
+                portnum = s.getsockname()[1]
+                s.listen(3)
+                return (
+                    portnum,
+                    AdoptedStreamServerEndpoint(reactor, os.dup(s.fileno()), AF_INET),
+                )
+            finally:
+                s.close()
         else:
             # Get a random port number and fall through.
             portnum = iputil.allocate_tcp_port()


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1595 except on Windows (which lacks IReactorSocket support on Python 2).  I'll open a new ticket for tracking the Windows fix.

