### PR TITLE
Configure CircleCI for much of the Linux testing

### DIFF
--- a/.circleci/bootstrap-test-environment.sh
+++ b/.circleci/bootstrap-test-environment.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Avoid the /nonexistent home directory in nobody's /etc/passwd entry.
+usermod --home /tmp/nobody nobody
+
+# Grant read access to nobody, the user which will eventually try to test this
+# checkout.
+mv /root/project /tmp/project
+
+# Python build/install toolchain wants to write to the source checkout, too.
+chown --recursive nobody:nogroup /tmp/project
+
+apt-get --quiet --yes install \
+    sudo \
+    build-essential \
+    python2.7 \
+    python2.7-dev \
+    libffi-dev \
+    libssl-dev \
+    libyaml-dev \
+    virtualenv \
+    ${EXTRA_PACKAGES}

--- a/.circleci/bootstrap-test-environment.sh
+++ b/.circleci/bootstrap-test-environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eo pipefail
+#!/bin/bash -e
 
 PROJECT=$1
 shift

--- a/.circleci/bootstrap-test-environment.sh
+++ b/.circleci/bootstrap-test-environment.sh
@@ -21,5 +21,4 @@ apt-get --quiet --yes install \
     libffi-dev \
     libssl-dev \
     libyaml-dev \
-    virtualenv \
     ${EXTRA_PACKAGES}

--- a/.circleci/bootstrap-test-environment.sh
+++ b/.circleci/bootstrap-test-environment.sh
@@ -3,6 +3,9 @@
 PROJECT=$1
 shift
 
+EXTRA_PACKAGES=$1
+shift
+
 # Avoid the /nonexistent home directory in nobody's /etc/passwd entry.
 usermod --home /tmp/nobody nobody
 

--- a/.circleci/bootstrap-test-environment.sh
+++ b/.circleci/bootstrap-test-environment.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -eo pipefail
 
 # Avoid the /nonexistent home directory in nobody's /etc/passwd entry.
 usermod --home /tmp/nobody nobody

--- a/.circleci/bootstrap-test-environment.sh
+++ b/.circleci/bootstrap-test-environment.sh
@@ -1,11 +1,14 @@
 #!/bin/bash -eo pipefail
 
+PROJECT=$1
+shift
+
 # Avoid the /nonexistent home directory in nobody's /etc/passwd entry.
 usermod --home /tmp/nobody nobody
 
 # Grant read access to nobody, the user which will eventually try to test this
 # checkout.
-mv /root/project /tmp/project
+mv "${PROJECT}" /tmp/project
 
 # Python build/install toolchain wants to write to the source checkout, too.
 chown --recursive nobody:nogroup /tmp/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,5 @@ jobs:
       - run:
           name: "Static-ish code checks"
           command: |
-            tox -e codechecks
+            pip install --user tox
+            ~/.local/bin/tox -e codechecks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,17 @@ jobs:
       - image: "debian:8"
 
     steps:
+      - run:
+          node: "Install Git"
+          command: |
+            apt-get --quiet update
+            apt-get --quiet --yes install git
+
       - "checkout"
 
       - run:
           name: "Bootstrap test environment"
           command: |
-            apt-get --quiet update
             apt-get --quiet --yes install \
                 build-essential \
                 python2.7 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
 
       - run:
           name: "Run test suite"
-          command: |
+          command: &RUN_TESTS |
             # Run the test suite as a non-root user.  This is the expected
             # usage some small areas of the test suite assume non-root
             # privileges (such as unreadable files being unreadable).
@@ -142,12 +142,4 @@ jobs:
 
       - run:
           name: "Run test suite"
-          command: |
-            # Run the test suite as a non-root user.  This is the expected
-            # usage some small areas of the test suite assume non-root
-            # privileges (such as unreadable files being unreadable).
-            #
-            # Also run with /tmp as a workdir because the non-root user won't
-            # be able to create the tox working filesystem state in the source
-            # checkout because it is owned by root.
-            sudo -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27
+          command: *RUN_TESTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,6 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
-            env
-
             # Run the test suite as a non-root user.  This is the expected
             # usage some small areas of the test suite assume non-root
             # privileges (such as unreadable files being unreadable).

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
 
       - run: &SUBMIT_COVERAGE
           name: "Submit coverage results"
+          working_directory: "/tmp/project"
           command: |
             /tmp/tests/bin/codecov
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           # readable.
           working_directory: "/tmp"
           command: |
-            ~/project/.circleci/setup-virtualenv.sh
+            /tmp/project/.circleci/setup-virtualenv.sh
 
       - run: &RUN_TESTS
           name: "Run test suite"
@@ -78,7 +78,7 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
-            ~/project/.circleci/setup-virtualenv.sh
+            /tmp/project/.circleci/setup-virtualenv.sh
 
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial
@@ -229,12 +229,12 @@ jobs:
       - run:
           <<: *SETUP_VIRTUALENV
           command: |
-            sudo ~/project/.circleci/setup-virtualenv.sh
+            sudo /tmp/project/.circleci/setup-virtualenv.sh
 
       - run:
           <<: *RUN_TESTS
           command: |
-            sudo ~/project/.circleci/setup-virtualenv.sh
+            sudo /tmp/project/.circleci/setup-virtualenv.sh
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,17 +227,17 @@ jobs:
       - run:
           <<: *BOOTSTRAP_TEST_ENVIRONMENT
           command: |
-            sudo --preserve-env ~/project/.circleci/bootstrap-test-environment.sh ~/project
+            sudo ~/project/.circleci/bootstrap-test-environment.sh ~/project "${EXTRA_PACKAGES}"
 
       - run:
           <<: *SETUP_VIRTUALENV
           command: |
-            sudo --preserve-env /tmp/project/.circleci/setup-virtualenv.sh
+            sudo /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - run:
           <<: *RUN_TESTS
           command: |
-            sudo --preserve-env /tmp/project/.circleci/run-tests.sh
+            sudo /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ workflows:
       - "fedora-27"
       - "fedora-28"
 
+      - "deprecations"
+
 jobs:
   lint:
     docker:
@@ -99,6 +101,8 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
+            env
+
             # Run the test suite as a non-root user.  This is the expected
             # usage some small areas of the test suite assume non-root
             # privileges (such as unreadable files being unreadable).
@@ -122,6 +126,18 @@ jobs:
   debian-9:
     docker:
       - image: "debian:9"
+
+    <<: *DEBIAN
+
+
+  deprecations:
+    docker:
+      - image: "debian:9"
+
+    environment:
+      <<: *UTF_8_ENVIRONMENT
+      # Select a tox environment to run for this job.
+      TAHOE_LAFS_TOX_ENVIRONMENT: "deprecations,upcoming-deprecations"
 
     <<: *DEBIAN
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,21 +62,23 @@ jobs:
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
           command: |
-            ~/project/.circleci/bootstrap-test-environment.sh
+            ~/project/.circleci/bootstrap-test-environment.sh ~/project
 
       - run: &SETUP_VIRTUALENV
           name: "Setup virtualenv"
           # pip cannot install packages if the working directory is not
           # readable.
           working_directory: "/tmp"
-          command: "~/project/.circleci/setup-virtualenv.sh"
+          command: |
+            ~/project/.circleci/setup-virtualenv.sh
 
       - run: &RUN_TESTS
           name: "Run test suite"
           # Something about when it re-uses an existing environment blows up
           # if the working directory is not readable.
           working_directory: "/tmp"
-          command: "~/project/.circleci/setup-virtualenv.sh"
+          command: |
+            ~/project/.circleci/setup-virtualenv.sh
 
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial
@@ -222,15 +224,17 @@ jobs:
       - run:
           <<: *BOOTSTRAP_TEST_ENVIRONMENT
           command: |
-            sudo ~/project/.circleci/bootstrap-test-environment.sh
+            sudo ~/project/.circleci/bootstrap-test-environment.sh ~/project
 
       - run:
           <<: *SETUP_VIRTUALENV
-          command: "sudo ~/project/.circleci/setup-virtualenv.sh"
+          command: |
+            sudo ~/project/.circleci/setup-virtualenv.sh
 
       - run:
           <<: *RUN_TESTS
-          command: "sudo ~/project/.circleci/setup-virtualenv.sh"
+          command: |
+            sudo ~/project/.circleci/setup-virtualenv.sh
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
       - "debian-8"
       - "debian-9"
       - "centos-7"
+      - "fedora-27"
 
 jobs:
   lint:
@@ -90,7 +91,7 @@ jobs:
     <<: *DEBIAN
 
 
-  centos-7:
+  centos-7: &RHEL_DERIV
     docker:
       - image: "centos:7"
 
@@ -143,3 +144,10 @@ jobs:
       - run:
           name: "Run test suite"
           command: *RUN_TESTS
+
+
+  fedora-27:
+    docker:
+      - image: "fedora:27"
+
+    <<: *RHEL_DERIV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,11 @@ jobs:
             # checkout because it is owned by root.
             sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27
 
+      - store_artifacts: &STORE_ARTIFACTS
+          # Despite passing --workdir /tmp to tox above, it still runs trial
+          # in the project source checkout.
+          path: "/tmp/project/_trial_temp/test.log"
+
 
   debian-9:
     docker:
@@ -169,6 +174,8 @@ jobs:
       - run:
           <<: *RUN_TESTS
 
+
+      - store_artifacts: *STORE_ARTIFACTS
 
   fedora-27:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ jobs:
       # Tell the C runtime things about character encoding (mainly to do with
       # filenames and argv).
       LANG: "en_US.UTF-8"
+      # The package name for this software varies somewhat across distros.
+      EXTRA_PACKAGES: "virtualenv"
       # Select a tox environment to run for this job.
       TAHOE_LAFS_TOX_ENVIRONMENT: "coverage"
       # Additional arguments to pass to tox.
@@ -124,7 +126,7 @@ jobs:
     environment:
       <<: *UTF_8_ENVIRONMENT
       # Necessary for en_US LANG setting.
-      EXTRA_PACKAGES: "language-pack-en"
+      EXTRA_PACKAGES: "virtualenv language-pack-en"
 
 
   ubuntu-18.04:
@@ -135,7 +137,7 @@ jobs:
     environment:
       <<: *UTF_8_ENVIRONMENT
       # Necessary for automatic address detection/assignment.
-      EXTRA_PACKAGES: "iproute2"
+      EXTRA_PACKAGES: "virtualenv iproute2"
 
 
   centos-7: &RHEL_DERIV
@@ -209,6 +211,7 @@ jobs:
 
     environment:
       <<: *UTF_8_ENVIRONMENT
+      EXTRA_PACKAGES: "python-virtualenv"
       TAHOE_LAFS_TOX_ARGS: "-- allmydata.test.test_magic_folder"
 
     # Unfortunately, duplicate all the steps here but run with `sudo`.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,9 @@ jobs:
     steps:
       - run: &INSTALL_GIT
           node: "Install Git"
-          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/install-git.sh"
+          command: |
+            sudo apt-get --quiet update
+            sudo apt-get --quiet --yes install git
 
       - "checkout"
 
@@ -208,9 +210,7 @@ jobs:
 
     # Unfortunately, duplicate all the steps here but run with `sudo`.
     steps:
-      - run:
-          <<: *INSTALL_GIT
-          command: "sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/install-git.sh"
+      - run: *INSTALL_GIT
 
       - "checkout"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,10 @@ jobs:
     docker:
       - image: "debian:8"
 
-    environment:
+    environment: &UTF_8_ENVIRONMENT
+      # Tell Hypothesis which configuration we want it to use.
       - TAHOE_LAFS_HYPOTHESIS_PROFILE: "ci"
+      # Tell the C runtime things about character encoding (mainly to do with
 
     steps:
       - run:
@@ -112,7 +114,7 @@ jobs:
       - image: "centos:7"
 
     environment:
-      - TAHOE_LAFS_HYPOTHESIS_PROFILE: "ci"
+      <<: *UTF_8_ENVIRONMENT
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,8 @@ jobs:
       - run: &INSTALL_GIT
           node: "Install Git"
           command: |
-            sudo apt-get --quiet update
-            sudo apt-get --quiet --yes install git
+            apt-get --quiet update
+            apt-get --quiet --yes install git
 
       - "checkout"
 
@@ -222,8 +222,8 @@ jobs:
           <<: *BOOTSTRAP_TEST_ENVIRONMENT
           command: |
             echo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
-            ls ${CIRCLE_WORKING_DIRECTORY}/.circleci/
             ls ${CIRCLE_WORKING_DIRECTORY}/
+            ls ${CIRCLE_WORKING_DIRECTORY}/.circleci/
             sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,12 @@ jobs:
 
     environment: &UTF_8_ENVIRONMENT
       # Tell Hypothesis which configuration we want it to use.
-      - TAHOE_LAFS_HYPOTHESIS_PROFILE: "ci"
+      TAHOE_LAFS_HYPOTHESIS_PROFILE: "ci"
       # Tell the C runtime things about character encoding (mainly to do with
       # filenames and argv).
-      - LANG: "en_US.UTF-8"
+      LANG: "en_US.UTF-8"
       # Select a tox environment to run for this job.
-      - TAHOE_LAFS_TOX_ENVIRONMENT: "coverage"
+      TAHOE_LAFS_TOX_ENVIRONMENT: "coverage"
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,17 +227,17 @@ jobs:
       - run:
           <<: *BOOTSTRAP_TEST_ENVIRONMENT
           command: |
-            sudo ~/project/.circleci/bootstrap-test-environment.sh ~/project
+            sudo --preserve-env ~/project/.circleci/bootstrap-test-environment.sh ~/project
 
       - run:
           <<: *SETUP_VIRTUALENV
           command: |
-            sudo /tmp/project/.circleci/setup-virtualenv.sh
+            sudo --preserve-env /tmp/project/.circleci/setup-virtualenv.sh
 
       - run:
           <<: *RUN_TESTS
           command: |
-            sudo /tmp/project/.circleci/run-tests.sh
+            sudo --preserve-env /tmp/project/.circleci/run-tests.sh
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,14 @@ jobs:
             # suite as a non-root user.  See below.
             sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
             sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
+            # Get everything installed in it, too.
+            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e ${TAHOE_LAFS_TOX_ENVIRONMENT}
 
       - run: &RUN_TESTS
           name: "Run test suite"
+          # Something about when it re-uses an existing environment blows up
+          # if the working directory is not readable.
+          working_directory: "/tmp"
           command: |
             # Run the test suite as a non-root user.  This is the expected
             # usage some small areas of the test suite assume non-root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+# https://circleci.com/docs/2.0/
+
+version: 2
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - "lint"
+
+jobs:
+  lint:
+    docker:
+      - image: "circleci/python:2"
+
+    steps:
+      - "checkout"
+
+      - run:
+          name: "Static-ish code checks"
+          command: |
+            tox -e codechecks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           # readable.
           working_directory: "/tmp"
           command: |
-            /tmp/project/.circleci/setup-virtualenv.sh
+            /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - run: &RUN_TESTS
           name: "Run test suite"
@@ -80,7 +80,7 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
-            /tmp/project/.circleci/run-tests.sh
+            /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,11 @@ jobs:
 
     # Unfortunately, duplicate all the steps here but run with `sudo`.
     steps:
-      - run: *INSTALL_GIT
+      - run:
+          node: "Install Git"
+          command: |
+            sudo apt-get --quiet update
+            sudo apt-get --quiet --yes install git
 
       - "checkout"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - "lint"
       - "debian-8"
       - "debian-9"
+      - "ubuntu-18.04"
       - "centos-7"
       - "fedora-27"
       - "fedora-28"
@@ -90,6 +91,12 @@ jobs:
       - image: "debian:9"
 
     <<: *DEBIAN
+
+
+  ubuntu-18.04:
+    <<: *DEBIAN
+    docker:
+      - image: "ubuntu:18.04"
 
 
   centos-7: &RHEL_DERIV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
             # checkout because it is owned by root.
             sudo -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27
 
+
   debian-9:
     docker:
       - image: "debian:9"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           working_directory: "/tmp"
           command: |
             env
-            /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
+            /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - run: &RUN_TESTS
           name: "Run test suite"
@@ -82,7 +82,7 @@ jobs:
           working_directory: "/tmp"
           command: |
             env
-            /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
+            /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial
@@ -235,13 +235,13 @@ jobs:
           <<: *SETUP_VIRTUALENV
           command: |
             env
-            sudo /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
+            sudo /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - run:
           <<: *RUN_TESTS
           command: |
             env
-            sudo /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
+            sudo /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,17 +5,17 @@ workflows:
   version: 2
   ci:
     jobs:
-      # - "lint"
+      - "lint"
       - "debian-8"
-      # - "debian-9"
-      # - "ubuntu-16.04"
-      # - "ubuntu-18.04"
-      # - "centos-7"
-      # - "fedora-27"
-      # - "fedora-28"
+      - "debian-9"
+      - "ubuntu-16.04"
+      - "ubuntu-18.04"
+      - "centos-7"
+      - "fedora-27"
+      - "fedora-28"
 
       - "magic-folder-ubuntu-14.04"
-      # - "deprecations"
+      - "deprecations"
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,17 +5,17 @@ workflows:
   version: 2
   ci:
     jobs:
-      - "lint"
-      - "debian-8"
-      - "debian-9"
-      - "ubuntu-16.04"
-      - "ubuntu-18.04"
-      - "centos-7"
-      - "fedora-27"
-      - "fedora-28"
+      # - "lint"
+      # - "debian-8"
+      # - "debian-9"
+      # - "ubuntu-16.04"
+      # - "ubuntu-18.04"
+      # - "centos-7"
+      # - "fedora-27"
+      # - "fedora-28"
 
       - "magic-folder-ubuntu-14.04"
-      - "deprecations"
+      # - "deprecations"
 
 jobs:
   lint:
@@ -51,80 +51,42 @@ jobs:
       TAHOE_LAFS_TOX_ARGS: ""
 
     steps:
-      - run:
+      - run: &INSTALL_GIT
           node: "Install Git"
-          command: |
-            apt-get --quiet update
-            apt-get --quiet --yes install git
+          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/install-git.sh"
 
       - "checkout"
 
-      - run:
+      - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
-          command: |
-            # Avoid the /nonexistent home directory in nobody's /etc/passwd
-            # entry.
-            usermod --home /tmp/nobody nobody
-
-            # Grant read access to nobody, the user which will eventually try
-            # to test this checkout.
-            mv /root/project /tmp/project
-
-            # Python build/install toolchain wants to write to the source
-            # checkout, too.
-            chown --recursive nobody:nogroup /tmp/project
-
-            apt-get --quiet --yes install \
-                sudo \
-                build-essential \
-                python2.7 \
-                python2.7-dev \
-                libffi-dev \
-                libssl-dev \
-                libyaml-dev \
-                virtualenv \
-                ${EXTRA_PACKAGES}
+          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh"
 
       - run: &SETUP_VIRTUALENV
           name: "Setup virtualenv"
           # pip cannot install packages if the working directory is not
           # readable.
           working_directory: "/tmp"
-          command: |
-            # Set up the virtualenv as a non-root user so we can run the test
-            # suite as a non-root user.  See below.
-            sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
-            sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
-            # Get everything installed in it, too.
-            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
+          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
 
       - run: &RUN_TESTS
           name: "Run test suite"
           # Something about when it re-uses an existing environment blows up
           # if the working directory is not readable.
           working_directory: "/tmp"
-          command: |
-            # Run the test suite as a non-root user.  This is the expected
-            # usage some small areas of the test suite assume non-root
-            # privileges (such as unreadable files being unreadable).
-            #
-            # Also run with /tmp as a workdir because the non-root user won't
-            # be able to create the tox working filesystem state in the source
-            # checkout because it is owned by root.
-            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e ${TAHOE_LAFS_TOX_ENVIRONMENT}
+          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
 
-      - store_artifacts: &STORE_ARTIFACTS
+      - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial
           # in the project source checkout.
           path: "/tmp/project/_trial_temp/test.log"
 
-      - store_artifacts:
+      - store_artifacts: &STORE_OTHER_ARTIFACTS
           # Store any other artifacts, too.  This is handy to allow other jobs
           # sharing most of the definition of this one to be able to
           # contribute artifacts easily.
           path: "/tmp/artifacts"
 
-      - run:
+      - run: &SUBMIT_COVERAGE
           name: "Submit coverage results"
           command: |
             /tmp/tests/bin/codecov
@@ -218,7 +180,9 @@ jobs:
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
 
-      - store_artifacts: *STORE_ARTIFACTS
+      - store_artifacts: *STORE_TEST_LOG
+      - store_artifacts: *STORE_OTHER_ARTIFACTS
+      - run: *SUBMIT_COVERAGE
 
 
   fedora-27:
@@ -234,11 +198,6 @@ jobs:
 
 
   magic-folder-ubuntu-14.04:
-    <<: *DEBIAN
-
-    # Turn off the inherited docker executor.
-    docker: null
-
     machine:
       enabled: true
       image: "circleci/classic:201711-01"
@@ -246,3 +205,27 @@ jobs:
     environment:
       <<: *UTF_8_ENVIRONMENT
       TAHOE_LAFS_TOX_ARGS: "-- allmydata.test.test_magic_folder"
+
+    # Unfortunately, duplicate all the steps here but run with `sudo`.
+    steps:
+      - run:
+          <<: *INSTALL_GIT
+          command: "sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/install-git.sh"
+
+      - "checkout"
+
+      - run:
+          <<: *BOOTSTRAP_TEST_ENVIRONMENT
+          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh"
+
+      - run:
+          <<: *SETUP_VIRTUALENV
+          command: "sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
+
+      - run:
+          <<: *RUN_TESTS
+          command: "sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
+
+      - store_artifacts: *STORE_TEST_LOG
+      - store_artifacts: *STORE_OTHER_ARTIFACTS
+      - run: *SUBMIT_COVERAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
           # readable.
           working_directory: "/tmp"
           command: |
+            env
             /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - run: &RUN_TESTS
@@ -80,6 +81,7 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
+            env
             /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - store_artifacts: &STORE_TEST_LOG
@@ -232,11 +234,13 @@ jobs:
       - run:
           <<: *SETUP_VIRTUALENV
           command: |
+            env
             sudo /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - run:
           <<: *RUN_TESTS
           command: |
+            env
             sudo /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - store_artifacts: *STORE_TEST_LOG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ workflows:
       - "fedora-27"
       - "fedora-28"
 
+      - "magic-folder-ubuntu-14.04"
       - "deprecations"
 
 jobs:
@@ -46,6 +47,8 @@ jobs:
       LANG: "en_US.UTF-8"
       # Select a tox environment to run for this job.
       TAHOE_LAFS_TOX_ENVIRONMENT: "coverage"
+      # Additional arguments to pass to tox.
+      TAHOE_LAFS_TOX_ARGS: ""
 
     steps:
       - run:
@@ -93,7 +96,7 @@ jobs:
             sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
             sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
             # Get everything installed in it, too.
-            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e ${TAHOE_LAFS_TOX_ENVIRONMENT}
+            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
 
       - run: &RUN_TESTS
           name: "Run test suite"
@@ -222,4 +225,19 @@ jobs:
   fedora-28:
     <<: *RHEL_DERIV
     docker:
-      - image: "fedora:28"
+      - image: "fedora"
+
+
+  magic-folder-ubuntu-14.04:
+    <<: *DEBIAN
+
+    # Turn off the inherited docker executor.
+    docker: null
+
+    machine:
+      enabled: true
+      image: "circleci/classic:201711-01"
+
+    environment:
+      <<: *UTF_8_ENVIRONMENT
+      TAHOE_LAFS_TOX_ARGS: "-- allmydata.test.test_magic_folder"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
 
       - "magic-folder-ubuntu-14.04"
       - "deprecations"
+      - "c-locale"
 
 jobs:
   lint:
@@ -106,6 +107,17 @@ jobs:
     <<: *DEBIAN
     docker:
       - image: "debian:9"
+
+
+  c-locale:
+    <<: *DEBIAN
+    docker:
+      - image: "debian:9"
+
+    environment:
+      <<: *UTF_8_ENVIRONMENT
+      LANG: "C"
+
 
 
   deprecations:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,24 +62,21 @@ jobs:
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
           command: |
-            echo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
-            ls ${CIRCLE_WORKING_DIRECTORY}/.circleci/
-            ls ${CIRCLE_WORKING_DIRECTORY}/
-            ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
+            ~/project/.circleci/bootstrap-test-environment.sh
 
       - run: &SETUP_VIRTUALENV
           name: "Setup virtualenv"
           # pip cannot install packages if the working directory is not
           # readable.
           working_directory: "/tmp"
-          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
+          command: "~/project/.circleci/setup-virtualenv.sh"
 
       - run: &RUN_TESTS
           name: "Run test suite"
           # Something about when it re-uses an existing environment blows up
           # if the working directory is not readable.
           working_directory: "/tmp"
-          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
+          command: "~/project/.circleci/setup-virtualenv.sh"
 
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial
@@ -225,18 +222,15 @@ jobs:
       - run:
           <<: *BOOTSTRAP_TEST_ENVIRONMENT
           command: |
-            echo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
-            ls ${CIRCLE_WORKING_DIRECTORY}/
-            ls ${CIRCLE_WORKING_DIRECTORY}/.circleci/
-            sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
+            sudo ~/project/.circleci/bootstrap-test-environment.sh
 
       - run:
           <<: *SETUP_VIRTUALENV
-          command: "sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
+          command: "sudo ~/project/.circleci/setup-virtualenv.sh"
 
       - run:
           <<: *RUN_TESTS
-          command: "sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/setup-virtualenv.sh"
+          command: "sudo ~/project/.circleci/setup-virtualenv.sh"
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
-            /tmp/project/.circleci/setup-virtualenv.sh
+            /tmp/project/.circleci/run-tests.sh
 
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial
@@ -234,7 +234,7 @@ jobs:
       - run:
           <<: *RUN_TESTS
           command: |
-            sudo /tmp/project/.circleci/setup-virtualenv.sh
+            sudo /tmp/project/.circleci/run-tests.sh
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,13 @@ jobs:
       - "checkout"
 
       - run:
-          name: "Static-ish code checks"
+          name: "Install tox"
           command: |
             pip install --user tox
+
+      - run:
+          name: "Static-ish code checks"
+          command: |
             ~/.local/bin/tox -e codechecks
 
   debian-8: &DEBIAN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,12 @@ jobs:
           # in the project source checkout.
           path: "/tmp/project/_trial_temp/test.log"
 
+      - store_artifacts:
+          # Store any other artifacts, too.  This is handy to allow other jobs
+          # sharing most of the definition of this one to be able to
+          # contribute artifacts easily.
+          path: "/tmp/artifacts"
+
       - run:
           name: "Submit coverage results"
           command: |
@@ -136,6 +142,8 @@ jobs:
       <<: *UTF_8_ENVIRONMENT
       # Select the deprecations tox environments.
       TAHOE_LAFS_TOX_ENVIRONMENT: "deprecations,upcoming-deprecations"
+      # Put the logs somewhere we can report them.
+      TAHOE_LAFS_WARNINGS_LOG: "/tmp/artifacts/deprecation-warnings.log"
 
 
   ubuntu-16.04:
@@ -201,7 +209,6 @@ jobs:
 
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
-
 
       - store_artifacts: *STORE_ARTIFACTS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,22 @@ jobs:
 
       - run:
           name: "Bootstrap test environment"
+          working_directory: "/tmp"
           command: |
+            # Avoid the /nonexistent home directory in nobody's /etc/passwd
+            # entry.
+            usermod --home /tmp/nobody nobody
+
+            # Grant read access to nobody, the user which will eventually try
+            # to test this checkout.
+            mv /root/project /tmp/project
+
+            # Python build/install toolchain wants to write to the source
+            # checkout, too.
+            chown --recursive nobody:nogroup /tmp/project
+
             apt-get --quiet --yes install \
+                sudo \
                 build-essential \
                 python2.7 \
                 python2.7-dev \
@@ -47,13 +61,23 @@ jobs:
                 libssl-dev \
                 libyaml-dev \
                 virtualenv
-            virtualenv --python python2.7 tests
-            tests/bin/pip install tox
+
+            # Set up the virtualenv as a non-root user so we can run the test
+            # suite as a non-root user.  See below.
+            sudo -u nobody virtualenv --python python2.7 /tmp/tests
+            sudo -u nobody /tmp/tests/bin/pip install tox
 
       - run:
           name: "Run test suite"
           command: |
-            tests/bin/tox -e py27
+            # Run the test suite as a non-root user.  This is the expected
+            # usage some small areas of the test suite assume non-root
+            # privileges (such as unreadable files being unreadable).
+            #
+            # Also run with /tmp as a workdir because the non-root user won't
+            # be able to create the tox working filesystem state in the source
+            # checkout because it is owned by root.
+            sudo -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27
 
   debian-9:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
   ci:
     jobs:
       - "lint"
+      - "tests"
 
 jobs:
   lint:
@@ -20,3 +21,30 @@ jobs:
           command: |
             pip install --user tox
             ~/.local/bin/tox -e codechecks
+
+  tests:
+    docker:
+      - image: "debian:8"
+
+    steps:
+      - "checkout"
+
+      - run:
+          name: "Bootstrap test environment"
+          command: |
+            apt-get --quiet update
+            apt-get --quiet --yes install \
+                build-essential \
+                python2.7 \
+                python2.7-dev \
+                libffi-dev \
+                libssl-dev \
+                libyaml-dev \
+                virtualenv
+            virtualenv --python python2.7 tests
+            tests/bin/pip install tox
+
+      - run:
+          name: "Run test suite"
+          command: |
+            tests/bin/tox -e py27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             pip install --user tox
             ~/.local/bin/tox -e codechecks
 
-  debian-8:
+  debian-8: &DEBIAN
     docker:
       - image: "debian:8"
 
@@ -59,25 +59,4 @@ jobs:
     docker:
       - image: "debian:9"
 
-    steps:
-      - "checkout"
-
-      - run:
-          name: "Bootstrap test environment"
-          command: |
-            apt-get --quiet update
-            apt-get --quiet --yes install \
-                build-essential \
-                python2.7 \
-                python2.7-dev \
-                libffi-dev \
-                libssl-dev \
-                libyaml-dev \
-                virtualenv
-            virtualenv --python python2.7 tests
-            tests/bin/pip install tox
-
-      - run:
-          name: "Run test suite"
-          command: |
-            tests/bin/tox -e py27
+    <<: *DEBIAN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - "lint"
       - "debian-8"
       - "debian-9"
+      - "centos-7"
 
 jobs:
   lint:
@@ -87,3 +88,66 @@ jobs:
       - image: "debian:9"
 
     <<: *DEBIAN
+
+
+  centos-7:
+    docker:
+      - image: "centos:7"
+
+    environment:
+      - TAHOE_LAFS_HYPOTHESIS_PROFILE: "ci"
+
+    steps:
+      - run:
+          node: "Install Git"
+          command: |
+            yum install --assumeyes git
+
+      - "checkout"
+
+      - run:
+          name: "Bootstrap test environment"
+          working_directory: "/tmp"
+          command: |
+            # Avoid the /nonexistent home directory in nobody's /etc/passwd
+            # entry.
+            usermod --home /tmp/nobody nobody
+
+            # Grant read access to nobody, the user which will eventually try
+            # to test this checkout.
+            mv /root/project /tmp/project
+
+            # Python build/install toolchain wants to write to the source
+            # checkout, too.
+            chown --recursive nobody:nobody /tmp/project
+
+            yum install --assumeyes \
+                sudo \
+                make automake gcc gcc-c++ \
+                python \
+                python-devel \
+                libffi-devel \
+                openssl-devel \
+                libyaml-devel \
+                python-virtualenv
+
+            # XXX net-tools is actually a Tahoe-LAFS runtime dependency!
+            yum install --assumeyes \
+                net-tools
+
+            # Set up the virtualenv as a non-root user so we can run the test
+            # suite as a non-root user.  See below.
+            sudo -u nobody virtualenv --python python2.7 /tmp/tests
+            sudo -u nobody /tmp/tests/bin/pip install tox
+
+      - run:
+          name: "Run test suite"
+          command: |
+            # Run the test suite as a non-root user.  This is the expected
+            # usage some small areas of the test suite assume non-root
+            # privileges (such as unreadable files being unreadable).
+            #
+            # Also run with /tmp as a workdir because the non-root user won't
+            # be able to create the tox working filesystem state in the source
+            # checkout because it is owned by root.
+            sudo -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,13 +124,13 @@ jobs:
 
 
   debian-9:
+    <<: *DEBIAN
     docker:
       - image: "debian:9"
 
-    <<: *DEBIAN
-
 
   deprecations:
+    <<: *DEBIAN
     docker:
       - image: "debian:9"
 
@@ -138,8 +138,6 @@ jobs:
       <<: *UTF_8_ENVIRONMENT
       # Select a tox environment to run for this job.
       TAHOE_LAFS_TOX_ENVIRONMENT: "deprecations,upcoming-deprecations"
-
-    <<: *DEBIAN
 
 
   ubuntu-16.04:
@@ -209,14 +207,14 @@ jobs:
 
       - store_artifacts: *STORE_ARTIFACTS
 
+
   fedora-27:
+    <<: *RHEL_DERIV
     docker:
       - image: "fedora:27"
 
-    <<: *RHEL_DERIV
 
   fedora-28:
+    <<: *RHEL_DERIV
     docker:
       - image: "fedora:28"
-
-    <<: *RHEL_DERIV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,8 +171,7 @@ jobs:
             sudo -u nobody virtualenv --python python2.7 /tmp/tests
             sudo -u nobody /tmp/tests/bin/pip install tox
 
-      - run:
-          <<: *RUN_TESTS
+      - run: *RUN_TESTS
 
 
       - store_artifacts: *STORE_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - "lint"
       - "debian-8"
       - "debian-9"
+      - "ubuntu-16.04"
       - "ubuntu-18.04"
       - "centos-7"
       - "fedora-27"
@@ -92,6 +93,12 @@ jobs:
       - image: "debian:9"
 
     <<: *DEBIAN
+
+
+  ubuntu-16.04:
+    <<: *DEBIAN
+    docker:
+      - image: "ubuntu:16.04"
 
 
   ubuntu-18.04:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,11 @@ jobs:
     docker:
       - image: "ubuntu:18.04"
 
+    environment:
+      <<: *UTF_8_ENVIRONMENT
+      # Necessary for automatic address detection/assignment.
+      EXTRA_PACKAGES: "iproute2"
+
 
   centos-7: &RHEL_DERIV
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
 
       - run:
           name: "Bootstrap test environment"
-          working_directory: "/tmp"
           command: |
             # Avoid the /nonexistent home directory in nobody's /etc/passwd
             # entry.
@@ -75,10 +74,16 @@ jobs:
                 virtualenv \
                 ${EXTRA_PACKAGES}
 
+      - run: &SETUP_VIRTUALENV
+          name: "Setup virtualenv"
+          # pip cannot install packages if the working directory is not
+          # readable.
+          working_directory: "/tmp"
+          command: |
             # Set up the virtualenv as a non-root user so we can run the test
             # suite as a non-root user.  See below.
             sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
-            sudo --set-home -u nobody /tmp/tests/bin/pip install tox
+            sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
 
       - run: &RUN_TESTS
           name: "Run test suite"
@@ -90,12 +95,17 @@ jobs:
             # Also run with /tmp as a workdir because the non-root user won't
             # be able to create the tox working filesystem state in the source
             # checkout because it is owned by root.
-            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27
+            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e coverage
 
       - store_artifacts: &STORE_ARTIFACTS
           # Despite passing --workdir /tmp to tox above, it still runs trial
           # in the project source checkout.
           path: "/tmp/project/_trial_temp/test.log"
+
+      - run:
+          name: "Submit coverage results"
+          command: |
+            /tmp/tests/bin/codecov
 
 
   debian-9:
@@ -166,11 +176,7 @@ jobs:
             yum install --assumeyes \
                 net-tools
 
-            # Set up the virtualenv as a non-root user so we can run the test
-            # suite as a non-root user.  See below.
-            sudo -u nobody virtualenv --python python2.7 /tmp/tests
-            sudo -u nobody /tmp/tests/bin/pip install tox
-
+      - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ workflows:
   ci:
     jobs:
       - "lint"
-      - "tests"
+      - "debian-8"
+      - "debian-9"
 
 jobs:
   lint:
@@ -22,9 +23,36 @@ jobs:
             pip install --user tox
             ~/.local/bin/tox -e codechecks
 
-  tests:
+  debian-8:
     docker:
       - image: "debian:8"
+
+    steps:
+      - "checkout"
+
+      - run:
+          name: "Bootstrap test environment"
+          command: |
+            apt-get --quiet update
+            apt-get --quiet --yes install \
+                build-essential \
+                python2.7 \
+                python2.7-dev \
+                libffi-dev \
+                libssl-dev \
+                libyaml-dev \
+                virtualenv
+            virtualenv --python python2.7 tests
+            tests/bin/pip install tox
+
+      - run:
+          name: "Run test suite"
+          command: |
+            tests/bin/tox -e py27
+
+  debian-9:
+    docker:
+      - image: "debian:9"
 
     steps:
       - "checkout"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,8 @@ jobs:
       # Tell Hypothesis which configuration we want it to use.
       - TAHOE_LAFS_HYPOTHESIS_PROFILE: "ci"
       # Tell the C runtime things about character encoding (mainly to do with
+      # filenames and argv).
+      - LANG: "en_US.UTF-8"
 
     steps:
       - run:
@@ -70,12 +72,13 @@ jobs:
                 libffi-dev \
                 libssl-dev \
                 libyaml-dev \
-                virtualenv
+                virtualenv \
+                ${EXTRA_PACKAGES}
 
             # Set up the virtualenv as a non-root user so we can run the test
             # suite as a non-root user.  See below.
-            sudo -u nobody virtualenv --python python2.7 /tmp/tests
-            sudo -u nobody /tmp/tests/bin/pip install tox
+            sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
+            sudo --set-home -u nobody /tmp/tests/bin/pip install tox
 
       - run: &RUN_TESTS
           name: "Run test suite"
@@ -87,7 +90,7 @@ jobs:
             # Also run with /tmp as a workdir because the non-root user won't
             # be able to create the tox working filesystem state in the source
             # checkout because it is owned by root.
-            sudo -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27
+            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e py27
 
 
   debian-9:
@@ -102,6 +105,11 @@ jobs:
     docker:
       - image: "ubuntu:16.04"
 
+    environment:
+      <<: *UTF_8_ENVIRONMENT
+      # Necessary for en_US LANG setting.
+      EXTRA_PACKAGES: "language-pack-en"
+
 
   ubuntu-18.04:
     <<: *DEBIAN
@@ -113,8 +121,7 @@ jobs:
     docker:
       - image: "centos:7"
 
-    environment:
-      <<: *UTF_8_ENVIRONMENT
+    environment: *UTF_8_ENVIRONMENT
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
           command: |
-            ~/project/.circleci/bootstrap-test-environment.sh ~/project
+            ~/project/.circleci/bootstrap-test-environment.sh ~/project "${EXTRA_PACKAGES}"
 
       - run: &SETUP_VIRTUALENV
           name: "Setup virtualenv"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,9 @@ jobs:
             sudo -u nobody virtualenv --python python2.7 /tmp/tests
             sudo -u nobody /tmp/tests/bin/pip install tox
 
-      - run:
+      - run: &RUN_TESTS
           name: "Run test suite"
-          command: &RUN_TESTS |
+          command: |
             # Run the test suite as a non-root user.  This is the expected
             # usage some small areas of the test suite assume non-root
             # privileges (such as unreadable files being unreadable).
@@ -158,8 +158,7 @@ jobs:
             sudo -u nobody /tmp/tests/bin/pip install tox
 
       - run:
-          name: "Run test suite"
-          command: *RUN_TESTS
+          <<: *RUN_TESTS
 
 
   fedora-27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
       - "debian-9"
       - "centos-7"
       - "fedora-27"
+      - "fedora-28"
 
 jobs:
   lint:
@@ -149,5 +150,11 @@ jobs:
   fedora-27:
     docker:
       - image: "fedora:27"
+
+    <<: *RHEL_DERIV
+
+  fedora-28:
+    docker:
+      - image: "fedora:28"
 
     <<: *RHEL_DERIV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
       # Tell the C runtime things about character encoding (mainly to do with
       # filenames and argv).
       - LANG: "en_US.UTF-8"
+      # Select a tox environment to run for this job.
+      - TAHOE_LAFS_TOX_ENVIRONMENT: "coverage"
 
     steps:
       - run:
@@ -95,7 +97,7 @@ jobs:
             # Also run with /tmp as a workdir because the non-root user won't
             # be able to create the tox working filesystem state in the source
             # checkout because it is owned by root.
-            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e coverage
+            sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e ${TAHOE_LAFS_TOX_ENVIRONMENT}
 
       - store_artifacts: &STORE_ARTIFACTS
           # Despite passing --workdir /tmp to tox above, it still runs trial

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
     docker:
       - image: "debian:8"
 
+    environment:
+      - TAHOE_LAFS_HYPOTHESIS_PROFILE: "ci"
+
     steps:
       - run:
           node: "Install Git"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
   ci:
     jobs:
       # - "lint"
-      # - "debian-8"
+      - "debian-8"
       # - "debian-9"
       # - "ubuntu-16.04"
       # - "ubuntu-18.04"
@@ -61,7 +61,11 @@ jobs:
 
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
-          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh"
+          command: |
+            echo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
+            ls ${CIRCLE_WORKING_DIRECTORY}/.circleci/
+            ls ${CIRCLE_WORKING_DIRECTORY}/
+            ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
 
       - run: &SETUP_VIRTUALENV
           name: "Setup virtualenv"
@@ -216,7 +220,11 @@ jobs:
 
       - run:
           <<: *BOOTSTRAP_TEST_ENVIRONMENT
-          command: "${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh"
+          command: |
+            echo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
+            ls ${CIRCLE_WORKING_DIRECTORY}/.circleci/
+            ls ${CIRCLE_WORKING_DIRECTORY}/
+            sudo ${CIRCLE_WORKING_DIRECTORY}/.circleci/bootstrap-test-environment.sh
 
       - run:
           <<: *SETUP_VIRTUALENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
 
     environment:
       <<: *UTF_8_ENVIRONMENT
-      # Select a tox environment to run for this job.
+      # Select the deprecations tox environments.
       TAHOE_LAFS_TOX_ENVIRONMENT: "deprecations,upcoming-deprecations"
 
 

--- a/.circleci/install-git.sh
+++ b/.circleci/install-git.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+apt-get --quiet update
+apt-get --quiet --yes install git

--- a/.circleci/install-git.sh
+++ b/.circleci/install-git.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-apt-get --quiet update
-apt-get --quiet --yes install git

--- a/.circleci/run-build-locally.sh
+++ b/.circleci/run-build-locally.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CIRCLE_TOKEN=efb53124be82dd4b3153bc0e3f60de71da629d59
+
+curl --user ${CIRCLE_TOKEN}: \
+    --request POST \
+    --form revision=$(git rev-parse HEAD) \
+    --form config=@config.yml \
+    --form notify=false \
+    https://circleci.com/api/v1.1/project/github/exarkun/tahoe-lafs/tree/2929.circleci

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -eo pipefail
 
 # Run the test suite as a non-root user.  This is the expected usage some
 # small areas of the test suite assume non-root privileges (such as unreadable

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eo pipefail
+#!/bin/bash -e
 
 # Run the test suite as a non-root user.  This is the expected usage some
 # small areas of the test suite assume non-root privileges (such as unreadable

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -4,7 +4,7 @@ TAHOE_LAFS_TOX_ENVIRONMENT=$1
 shift
 
 TAHOE_LAFS_TOX_ARGS=$1
-shift
+shift || :
 
 # Run the test suite as a non-root user.  This is the expected usage some
 # small areas of the test suite assume non-root privileges (such as unreadable

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+TAHOE_LAFS_TOX_ENVIRONMENT=$1
+shift
+
+TAHOE_LAFS_TOX_ARGS=$1
+shift
+
 # Run the test suite as a non-root user.  This is the expected usage some
 # small areas of the test suite assume non-root privileges (such as unreadable
 # files being unreadable).
@@ -7,4 +13,4 @@
 # Also run with /tmp as a workdir because the non-root user won't be able to
 # create the tox working filesystem state in the source checkout because it is
 # owned by root.
-sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e ${TAHOE_LAFS_TOX_ENVIRONMENT}
+sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Run the test suite as a non-root user.  This is the expected usage some
+# small areas of the test suite assume non-root privileges (such as unreadable
+# files being unreadable).
+#
+# Also run with /tmp as a workdir because the non-root user won't be able to
+# create the tox working filesystem state in the source checkout because it is
+# owned by root.
+sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e ${TAHOE_LAFS_TOX_ENVIRONMENT}

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Set up the virtualenv as a non-root user so we can run the test suite as a
+# non-root user.  See below.
+sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
+sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
+# Get everything installed in it, too.
+sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -eo pipefail
 
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -4,7 +4,7 @@ TAHOE_LAFS_TOX_ENVIRONMENT=$1
 shift
 
 TAHOE_LAFS_TOX_ARGS=$1
-shift
+shift || :
 
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+TAHOE_LAFS_TOX_ENVIRONMENT=$1
+shift
+
+TAHOE_LAFS_TOX_ARGS=$1
+shift
+
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eo pipefail
+#!/bin/bash -e
 
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ function correctly, preserving your privacy and security.
 For full documentation, please see
 http://tahoe-lafs.readthedocs.io/en/latest/ .
 
-|readthedocs|  |travis|  |codecov|
+|readthedocs|  |travis|  |circleci|  |codecov|
 
 INSTALLING
 ==========
@@ -98,6 +98,9 @@ slides.
 .. |travis| image:: https://travis-ci.org/tahoe-lafs/tahoe-lafs.png?branch=master
     :alt: build status
     :target: https://travis-ci.org/tahoe-lafs/tahoe-lafs
+
+.. |circleci| image:: https://circleci.com/gh/tahoe-lafs/tahoe-lafs.svg?style=svg
+    :target: https://circleci.com/gh/tahoe-lafs/tahoe-lafs
 
 .. |codecov| image:: https://codecov.io/github/tahoe-lafs/tahoe-lafs/coverage.svg?branch=master
     :alt: test coverage percentage

--- a/tox.ini
+++ b/tox.ini
@@ -49,9 +49,6 @@ commands =
          python misc/coding_tools/check-debugging.py
          python misc/coding_tools/find-trailing-spaces.py -r src static misc setup.py
          python misc/coding_tools/check-miscaptures.py
-         # note: check-interfaces.py imports everything, so it must be run
-         # from a populated virtualenv
-         python misc/coding_tools/check-interfaces.py
 
 [testenv:deprecations]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ usedevelop = True
 extras = test
 commands =
          tahoe --version
-         trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
+         trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
 
 [testenv:integration]
 commands =
@@ -37,7 +37,7 @@ commands =
 # coverage (with --branch) takes about 65% longer to run
 commands =
          tahoe --version
-         coverage run --branch -m twisted.trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors --reporter=timing} {posargs:allmydata.test.test_version}
+         coverage run --branch -m twisted.trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors --reporter=timing} {posargs:allmydata}
          coverage xml
 
 [testenv:codechecks]
@@ -52,7 +52,7 @@ commands =
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 commands =
-         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
+         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
 
 [testenv:upcoming-deprecations]
 setenv =
@@ -62,7 +62,7 @@ deps =
      git+https://github.com/warner/foolscap
 commands =
          flogtool --version
-         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
+         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
 
 [testenv:checkmemory]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps = incremental
 usedevelop = True
 extras = test
 commands =
-         pyflakes src static misc setup.py
          tahoe --version
          trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
 
@@ -37,7 +36,6 @@ commands =
 [testenv:coverage]
 # coverage (with --branch) takes about 65% longer to run
 commands =
-         pyflakes src static misc setup.py
          tahoe --version
          coverage run --branch -m twisted.trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors --reporter=timing} {posargs:allmydata.test.test_version}
          coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 commands =
-         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
+         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
 
 [testenv:upcoming-deprecations]
 setenv =
@@ -62,7 +62,7 @@ deps =
      git+https://github.com/warner/foolscap
 commands =
          flogtool --version
-         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
+         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
 
 [testenv:checkmemory]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 commands =
-         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_versions}
+         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
 
 [testenv:upcoming-deprecations]
 setenv =
@@ -62,7 +62,7 @@ deps =
      git+https://github.com/warner/foolscap
 commands =
          flogtool --version
-         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_versions}
+         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
 
 [testenv:checkmemory]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ extras = test
 commands =
          pyflakes src static misc setup.py
          tahoe --version
-         trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
+         trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_version}
 
 [testenv:integration]
 commands =
@@ -39,7 +39,7 @@ commands =
 commands =
          pyflakes src static misc setup.py
          tahoe --version
-         coverage run --branch -m twisted.trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors --reporter=timing} {posargs:allmydata}
+         coverage run --branch -m twisted.trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors --reporter=timing} {posargs:allmydata.test.test_version}
          coverage xml
 
 [testenv:codechecks]
@@ -57,7 +57,7 @@ commands =
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 commands =
-         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
+         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_versions}
 
 [testenv:upcoming-deprecations]
 setenv =
@@ -67,7 +67,7 @@ deps =
      git+https://github.com/warner/foolscap
 commands =
          flogtool --version
-         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
+         python misc/build_helpers/run-deprecations.py --warnings=_trial_temp/deprecation-warnings.log trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata.test.test_versions}
 
 [testenv:checkmemory]
 commands =


### PR DESCRIPTION
Closes ticket:2929

Along with the branch, this will need CircleCI integration enabled on the Tahoe-LAFS repo.  Also, I expect that this test coverage will let us de-provision some build slaves.