### PR TITLE
Configure a Slackware job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
                 gcc-c++-5.5.0 \
                 python-2.7.15 \
                 libffi-3.2.1 \
-                openssl-solibs \
+                openssl-1.0.2k \
                 libyaml-0.1.6 </dev/null
 
             # neither virtualenv nor pip is packaged.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ jobs:
                 libyaml-0.1.6 </dev/null
 
             slackpkg upgrade \
-                openssl-1.0.2k </dev/null
+                openssl-1.0 </dev/null
 
             # neither virtualenv nor pip is packaged.
             # do it the hard way.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,8 @@ jobs:
                 python-2.7.15 \
                 libffi-3.2.1 \
                 libyaml-0.1.6 \
+                sqlite-3.13.0 \
+                icu4c-56.1 \
                 libmpc-1.0.3 </dev/null
 
             slackpkg upgrade \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,7 @@ jobs:
                 sudo-1.8.20p2 \
                 make-4.1 \
                 automake-1.15 \
+                kernel-headers \
                 glibc-2.23 \
                 binutils-2.26 \
                 gcc-5.5.0 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,8 @@ jobs:
                 gcc-c++-5.5.0 \
                 python-2.7.15 \
                 libffi-3.2.1 \
-                libyaml-0.1.6 </dev/null
+                libyaml-0.1.6 \
+                libmpc-1.0.3 </dev/null
 
             slackpkg upgrade \
                 openssl-1.0 </dev/null

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
                 glibc-2.23 \
                 binutils-2.26 \
                 gcc-5.5.0 \
-                gcc-c++-5.5.0 \
+                gcc-g++-5.5.0 \
                 python-2.7.15 \
                 libffi-3.2.1 \
                 libyaml-0.1.6 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,9 +262,12 @@ jobs:
                 openssl-solibs \
                 libyaml-0.1.6 </dev/null
 
-            # neither virtualenv nor pip is packaged
-            # do it the hard way
-            slackpkg install curl-7.60 </dev/null
+            # neither virtualenv nor pip is packaged.
+            # do it the hard way.
+            # and it is extra hard since it is slackware.
+            slackpkg install \
+                cyrus-sasl-2.1.26 \
+                curl-7.60 </dev/null
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python get-pip.py
             pip install virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
           node: "Install Git"
           command: |
             slackpkg update
-            slackpkg install git </dev/null
+            slackpkg install openssh git </dev/null
 
       - "checkout"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,7 @@ jobs:
                 sudo-1.8.20p2 \
                 make-4.1 \
                 automake-1.15 \
+                glibc-2.23 \
                 gcc-5.5.0 \
                 gcc-c++-5.5.0 \
                 python-2.7.15 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
       - "centos-7"
       - "fedora-27"
       - "fedora-28"
+      - "slackware-14.2"
 
       - "magic-folder-ubuntu-14.04"
       - "deprecations"
@@ -217,6 +218,55 @@ jobs:
     <<: *RHEL_DERIV
     docker:
       - image: "fedora"
+
+
+  slackware-14.2:
+    docker:
+      - image: "vbatts/slackware:14.2"
+
+    environment: *UTF_8_ENVIRONMENT
+
+    steps:
+      - run:
+          node: "Install Git"
+          command: |
+            slackpkg update
+            slackpkg install git
+
+      - "checkout"
+
+      - run:
+          name: "Bootstrap test environment"
+          working_directory: "/tmp"
+          command: |
+            # Avoid the /nonexistent home directory in nobody's /etc/passwd
+            # entry.
+            usermod --home /tmp/nobody nobody
+
+            # Grant read access to nobody, the user which will eventually try
+            # to test this checkout.
+            mv /root/project /tmp/project
+
+            # Python build/install toolchain wants to write to the source
+            # checkout, too.
+            chown --recursive nobody:nobody /tmp/project
+
+            slackpkg install \
+                sudo \
+                make automake gcc gcc-c++ \
+                python \
+                python-devel \
+                libffi-devel \
+                openssl-devel \
+                libyaml-devel \
+                python-virtualenv
+
+      - run: *SETUP_VIRTUALENV
+      - run: *RUN_TESTS
+
+      - store_artifacts: *STORE_TEST_LOG
+      - store_artifacts: *STORE_OTHER_ARTIFACTS
+      - run: *SUBMIT_COVERAGE
 
 
   magic-folder-ubuntu-14.04:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
           node: "Install Git"
           command: |
             slackpkg update
-            slackpkg install openssh git </dev/null
+            slackpkg install openssh-7.4p1 git-2.14.4 </dev/null
 
       - "checkout"
 
@@ -252,14 +252,22 @@ jobs:
             chown --recursive nobody:nobody /tmp/project
 
             slackpkg install \
-                sudo \
-                make automake gcc gcc-c++ \
-                python \
-                python-devel \
-                libffi-devel \
-                openssl-devel \
-                libyaml-devel \
-                python-virtualenv </dev/null
+                sudo-1.8.20p2 \
+                make-4.1 \
+                automake-1.15 \
+                gcc-5.5.0 \
+                gcc-c++-5.5.0 \
+                python-2.7.15 \
+                libffi-3.2.1 \
+                openssl-solibs \
+                libyaml-0.1.6 </dev/null
+
+            # neither virtualenv nor pip is packaged
+            # do it the hard way
+            slackpkg install curl-7.60 </dev/null
+            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+            python get-pip.py
+            pip install virtualenv
 
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ jobs:
       LANG: "C"
 
 
-
   deprecations:
     <<: *DEBIAN
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,8 +259,10 @@ jobs:
                 gcc-c++-5.5.0 \
                 python-2.7.15 \
                 libffi-3.2.1 \
-                openssl-1.0.2k \
                 libyaml-0.1.6 </dev/null
+
+            slackpkg upgrade \
+                openssl-1.0.2k </dev/null
 
             # neither virtualenv nor pip is packaged.
             # do it the hard way.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,7 @@ jobs:
                 make-4.1 \
                 automake-1.15 \
                 glibc-2.23 \
+                binutils-2.26 \
                 gcc-5.5.0 \
                 gcc-c++-5.5.0 \
                 python-2.7.15 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
           node: "Install Git"
           command: |
             slackpkg update
-            slackpkg install git
+            slackpkg install git </dev/null
 
       - "checkout"
 
@@ -259,7 +259,7 @@ jobs:
                 libffi-devel \
                 openssl-devel \
                 libyaml-devel \
-                python-virtualenv
+                python-virtualenv </dev/null
 
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ workflows:
       - "fedora-28"
       - "slackware-14.2"
 
-      - "magic-folder-ubuntu-14.04"
       - "deprecations"
       - "c-locale"
 
@@ -282,48 +281,6 @@ jobs:
 
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
-
-      - store_artifacts: *STORE_TEST_LOG
-      - store_artifacts: *STORE_OTHER_ARTIFACTS
-      - run: *SUBMIT_COVERAGE
-
-
-  magic-folder-ubuntu-14.04:
-    machine:
-      enabled: true
-      image: "circleci/classic:201711-01"
-
-    environment:
-      <<: *UTF_8_ENVIRONMENT
-      EXTRA_PACKAGES: "python-virtualenv"
-      TAHOE_LAFS_TOX_ARGS: "-- allmydata.test.test_magic_folder"
-
-    # Unfortunately, duplicate all the steps here but run with `sudo`.
-    steps:
-      - run:
-          node: "Install Git"
-          command: |
-            sudo apt-get --quiet update
-            sudo apt-get --quiet --yes install git
-
-      - "checkout"
-
-      - run:
-          <<: *BOOTSTRAP_TEST_ENVIRONMENT
-          command: |
-            sudo ~/project/.circleci/bootstrap-test-environment.sh ~/project "${EXTRA_PACKAGES}"
-
-      - run:
-          <<: *SETUP_VIRTUALENV
-          command: |
-            env
-            sudo /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
-
-      - run:
-          <<: *RUN_TESTS
-          command: |
-            env
-            sudo /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,28 @@ workflows:
   version: 2
   ci:
     jobs:
-      - "lint"
-      - "debian-8"
+      # Platforms
       - "debian-9"
-      - "ubuntu-16.04"
+      - "debian-8":
+          requires:
+            - "debian-9"
+
       - "ubuntu-18.04"
-      - "centos-7"
-      - "fedora-27"
+      - "ubuntu-16.04":
+          requires:
+            - "ubuntu-18.04"
+
       - "fedora-28"
+      - "fedora-27":
+          requires:
+            - "fedora-28"
+
+      - "centos-7"
+
       - "slackware-14.2"
 
+      # Other assorted tasks and configurations
+      - "lint"
       - "deprecations"
       - "c-locale"
 

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -9,6 +9,12 @@ shift || :
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
-sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
-# Get everything installed in it, too.
+
+# Slackware has non-working SSL support in setuptools until certifi is
+# installed.  SSL support in setuptools is needed in case packages use
+# `setup_requires` which gets satisfied by setuptools instead of by pip.
+# txi2p (vcversioner) is one such package.  Twisted (incremental) is another.
+sudo --set-home -u nobody /tmp/tests/bin/pip install certifi tox codecov
+
+# Get everything else installed in it, too.
 sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -14,7 +14,7 @@ sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 # installed.  SSL support in setuptools is needed in case packages use
 # `setup_requires` which gets satisfied by setuptools instead of by pip.
 # txi2p (vcversioner) is one such package.  Twisted (incremental) is another.
-sudo --set-home -u nobody /tmp/tests/bin/pip install certifi tox codecov
+sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
 
 # Get everything else installed in it, too.
 sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,13 @@ skipsdist = True
 [testenv]
 basepython=python2.7
 passenv = TAHOE_LAFS_* USERPROFILE HOMEDRIVE HOMEPATH
-# Pre-install "incremental" to avoid bug #2913. Basically if Twisted's
-# setup_requires=["incremental"] causes this to be installed (with
-# setuptools), then it'll fail on travis's OS-X 10.12 machines when PyPI
-# disables access with TLS-1.1 or older, so we have to install it ahead of
-# time (with pip).
-deps = incremental
+# Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
+# a package to be installed (with setuptools) then it'll fail on certain
+# platforms (travis's OX-X 10.12, Slackware 14.2) because PyPI's TLS
+# requirements (TLS >= 1.2) are incompatible with the old TLS clients
+# available to those systems.  Installing it ahead of time (with pip) avoids
+# this problem.
+deps = certifi
 # We add usedevelop=True for speed, and extras=test to get things like "mock"
 # that are required for our unit tests.
 usedevelop = True


### PR DESCRIPTION
This adds a Slackware job.  Because of the challenge of getting a configuration that works across Slackware, the other platforms, and in particular Ubuntu 14.04, drop the Ubuntu 14.04 magic-folder job as well.  Instead, I'll make sure buildbot keeps running magic-folder tests across a variety of platforms.  We may want to revisit this if CircleCI ever offers a broader range of "machine" images (currently only Ubuntu 14.04 is available, limiting the value of having magic-folder tests on CircleCI).