### PR TITLE
Provide detailed test results to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
             /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - store_test_results: &STORE_TEST_RESULTS
-          path: "/tmp/junit"
+          path: "/tmp/artifacts/junit"
 
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,9 @@ jobs:
           # readable.
           working_directory: "/tmp"
           command: |
-            /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
+            /tmp/project/.circleci/setup-virtualenv.sh \
+                "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
+                "${TAHOE_LAFS_TOX_ARGS}"
 
       - run: &RUN_TESTS
           name: "Run test suite"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ jobs:
           # readable.
           working_directory: "/tmp"
           command: |
-            env
             /tmp/project/.circleci/setup-virtualenv.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - run: &RUN_TESTS
@@ -94,7 +93,6 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
-            env
             /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
       - store_artifacts: &STORE_TEST_LOG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,10 @@ jobs:
           # if the working directory is not readable.
           working_directory: "/tmp"
           command: |
-            /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
+            /tmp/project/.circleci/run-tests.sh \
+                /tmp/artifacts \
+                "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
+                "${TAHOE_LAFS_TOX_ARGS}"
 
       - store_test_results: &STORE_TEST_RESULTS
           path: "/tmp/artifacts/junit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,9 @@ jobs:
           command: |
             /tmp/project/.circleci/run-tests.sh "${TAHOE_LAFS_TOX_ENVIRONMENT}" "${TAHOE_LAFS_TOX_ARGS}"
 
+      - store_test_results: &STORE_TEST_RESULTS
+          path: "/tmp/junit"
+
       - store_artifacts: &STORE_TEST_LOG
           # Despite passing --workdir /tmp to tox above, it still runs trial
           # in the project source checkout.
@@ -211,6 +214,7 @@ jobs:
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
 
+      - store_test_results: *STORE_TEST_RESULTS
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS
       - run: *SUBMIT_COVERAGE
@@ -291,6 +295,7 @@ jobs:
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
 
+      - store_test_results: *STORE_TEST_RESULTS
       - store_artifacts: *STORE_TEST_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS
       - run: *SUBMIT_COVERAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,9 @@ jobs:
                 /tmp/artifacts \
                 "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
                 "${TAHOE_LAFS_TOX_ARGS}"
+          # trial output gets directed straight to a log.  avoid the circleci
+          # timeout while the test suite runs.
+          no_output_timeout: "20m"
 
       - store_test_results: &STORE_TEST_RESULTS
           path: "/tmp/artifacts/junit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,7 @@ jobs:
             chown --recursive nobody:nobody /tmp/project
 
             slackpkg install \
+                ca-certificates \
                 sudo-1.8.20p2 \
                 make-4.1 \
                 automake-1.15 \

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -9,6 +9,9 @@ shift
 TAHOE_LAFS_TOX_ARGS=$1
 shift || :
 
+# Make sure we can actually write things to this directory.
+mkdir -p "${ARTIFACTS}"
+
 # Run the test suite as a non-root user.  This is the expected usage some
 # small areas of the test suite assume non-root privileges (such as unreadable
 # files being unreadable).

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -39,5 +39,5 @@ for environ in argv[1].split(","):
 # Create a junitxml results area.  Put these results in a subdirectory of the
 # ultimate location because CircleCI extracts some label information from the
 # subdirectory name.
-mkdir -p /tmp/junit/unittests
-/tmp/tests/bin/subunit2junitxml < /tmp/results.subunit2 > /tmp/junit/unittests/results.xml
+mkdir -p /tmp/artifacts/junit/unittests
+/tmp/tests/bin/subunit2junitxml < /tmp/results.subunit2 > /tmp/artifacts/junit/unittests/results.xml

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -12,6 +12,14 @@ shift || :
 # Make sure we can actually write things to this directory.
 sudo --user nobody mkdir -p "${ARTIFACTS}"
 
+TOX_JSON="${ARTIFACTS}"/tox-result.json
+SUBUNIT1="${ARTIFACTS}"/results.subunit1
+SUBUNIT2="${ARTIFACTS}"/results.subunit2
+
+# Use an intermediate directory here because CircleCI extracts some label
+# information from its name.
+JUNITXML="${ARTIFACTS}"/junit/unittests/results.xml
+
 # Run the test suite as a non-root user.  This is the expected usage some
 # small areas of the test suite assume non-root privileges (such as unreadable
 # files being unreadable).
@@ -28,14 +36,6 @@ sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
      --workdir /tmp/tahoe-lafs.tox \
      -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
      ${TAHOE_LAFS_TOX_ARGS}
-
-TOX_JSON="${ARTIFACTS}"/tox-result.json
-SUBUNIT1="${ARTIFACTS}"/results.subunit1
-SUBUNIT2="${ARTIFACTS}"/results.subunit2
-
-# Use an intermediate directory here because CircleCI extracts some label
-# information from its name.
-JUNITXML="${ARTIFACTS}"/junit/unittests/results.xml
 
 # Extract the test process output which should be subunit1-format.
 /tmp/tests/bin/python -c '

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -28,8 +28,9 @@ sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
 from json import load
 from sys import stdin, stdout, argv
 result = load(stdin)
-messy_output = result["testenvs"][argv[1]]["test"][-1]["output"]
-stdout.write(messy_output.split("\n", 3)[3].strip() + "\n")
+for environ in argv[1].split(","):
+    messy_output = result["testenvs"][environ]["test"][-1]["output"]
+    stdout.write(messy_output.split("\n", 3)[3].strip() + "\n")
 ' "${TAHOE_LAFS_TOX_ENVIRONMENT}" < /tmp/tox-result.json > /tmp/results.subunit1
 
 # Upgrade subunit version because subunit2junitxml only works on subunit2

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -19,7 +19,7 @@ sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
      /tmp/tests/bin/tox \
      -c /tmp/project/tox.ini \
      --result-json /tmp/tox-result.json \
-     --workdir /tmp \
+     --workdir /tmp/tahoe-lafs.tox \
      -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
      ${TAHOE_LAFS_TOX_ARGS}
 

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -13,4 +13,22 @@ shift || :
 # Also run with /tmp as a workdir because the non-root user won't be able to
 # create the tox working filesystem state in the source checkout because it is
 # owned by root.
-sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
+sudo --set-home -u nobody /tmp/tests/bin/tox \
+     -c /tmp/project/tox.ini \
+     --result-json /tmp/tox-result.json \
+     --workdir /tmp \
+     -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
+     --reporter=subunit ${TAHOE_LAFS_TOX_ARGS}
+
+# Extract the test process output which should be subunit1-format.
+cat /tmp/tox-result.json | /tmp/tests/bin/python -c '
+from json import load
+from sys import stdin
+result = load(sys.stdin)
+messy_output = result["testenvs"]["py27"]["test"][-1]["output"]
+sys.stdout.write(messy_output.split("\n", 3)[3].strip())
+' > /tmp/test-result.subunit1
+
+# Convert the subunit1 data to junitxml which CircleCI can ingest.
+mkdir -p /tmp/junit
+subunit-1to2 < /tmp/test-result.subunit1 | subunit2junitxml > /tmp/junit/results.junitxml

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -13,7 +13,6 @@ shift || :
 sudo --user nobody mkdir -p "${ARTIFACTS}"
 
 TOX_JSON="${ARTIFACTS}"/tox-result.json
-SUBUNIT1="${ARTIFACTS}"/results.subunit1
 SUBUNIT2="${ARTIFACTS}"/results.subunit2
 
 # Use an intermediate directory here because CircleCI extracts some label
@@ -27,7 +26,7 @@ JUNITXML="${ARTIFACTS}"/junit/unittests/results.xml
 # Also run with /tmp as a workdir because the non-root user won't be able to
 # create the tox working filesystem state in the source checkout because it is
 # owned by root.
-sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
+sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunitv2" \
      --set-home \
      --user nobody \
      /tmp/tests/bin/tox \
@@ -37,7 +36,7 @@ sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
      -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
      ${TAHOE_LAFS_TOX_ARGS}
 
-# Extract the test process output which should be subunit1-format.
+# Extract the test process output which should be subunit2-format.
 /tmp/tests/bin/python -c '
 from json import load
 from sys import stdin, stdout, argv
@@ -52,10 +51,7 @@ for environ in argv[1].split(","):
     )
     messy_output = test_result["output"]
     stdout.write(messy_output.split("\n", 3)[3].strip() + "\n")
-' "${TAHOE_LAFS_TOX_ENVIRONMENT}" < "${TOX_JSON}" > "${SUBUNIT1}"
-
-# Upgrade subunit version because subunit2junitxml only works on subunit2
-/tmp/tests/bin/subunit-1to2 < "${SUBUNIT1}" > "${SUBUNIT2}"
+' "${TAHOE_LAFS_TOX_ENVIRONMENT}" < "${TOX_JSON}" > "${SUBUNIT2}"
 
 # Create a junitxml results area.
 mkdir -p "$(dirname "${JUNITXML}")"

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -24,13 +24,19 @@ sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
      ${TAHOE_LAFS_TOX_ARGS}
 
 # Extract the test process output which should be subunit1-format.
-mkdir /tmp/junit
-cat /tmp/tox-result.json | /tmp/tests/bin/python -c '
+/tmp/tests/bin/python -c '
 from json import load
 from sys import stdin, stdout, argv
 result = load(stdin)
 messy_output = result["testenvs"][argv[1]]["test"][-1]["output"]
-stdout.write(messy_output.split("\n", 3)[3].strip())
-' "${TAHOE_LAFS_TOX_ENVIRONMENT}" |
-    /tmp/tests/bin/subunit-1to2 |
-    /tmp/tests/bin/subunit2junitxml > /tmp/junit/results.xml
+stdout.write(messy_output.split("\n", 3)[3].strip() + "\n")
+' "${TAHOE_LAFS_TOX_ENVIRONMENT}" < /tmp/tox-result.json > /tmp/results.subunit1
+
+# Upgrade subunit version because subunit2junitxml only works on subunit2
+/tmp/tests/bin/subunit-1to2 < /tmp/results.subunit1 > /tmp/results.subunit2
+
+# Create a junitxml results area.  Put these results in a subdirectory of the
+# ultimate location because CircleCI extracts some label information from the
+# subdirectory name.
+mkdir -p /tmp/junit/unittests
+/tmp/tests/bin/subunit2junitxml < /tmp/results.subunit2 > /tmp/junit/unittests/results.xml

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -32,7 +32,7 @@ sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
      --user nobody \
      /tmp/tests/bin/tox \
      -c /tmp/project/tox.ini \
-     --result-json "${ARTIFACTS}"/tox-result.json \
+     --result-json "${TOX_JSON}" \
      --workdir /tmp/tahoe-lafs.tox \
      -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
      ${TAHOE_LAFS_TOX_ARGS}

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -13,22 +13,24 @@ shift || :
 # Also run with /tmp as a workdir because the non-root user won't be able to
 # create the tox working filesystem state in the source checkout because it is
 # owned by root.
-sudo --set-home -u nobody /tmp/tests/bin/tox \
+sudo TAHOE_LAFS_TRIAL_ARGS="--reporter=subunit" \
+     --set-home \
+     --user nobody \
+     /tmp/tests/bin/tox \
      -c /tmp/project/tox.ini \
      --result-json /tmp/tox-result.json \
      --workdir /tmp \
      -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
-     --reporter=subunit ${TAHOE_LAFS_TOX_ARGS}
+     ${TAHOE_LAFS_TOX_ARGS}
 
 # Extract the test process output which should be subunit1-format.
+mkdir /tmp/junit
 cat /tmp/tox-result.json | /tmp/tests/bin/python -c '
 from json import load
-from sys import stdin
-result = load(sys.stdin)
-messy_output = result["testenvs"]["py27"]["test"][-1]["output"]
-sys.stdout.write(messy_output.split("\n", 3)[3].strip())
-' > /tmp/test-result.subunit1
-
-# Convert the subunit1 data to junitxml which CircleCI can ingest.
-mkdir -p /tmp/junit
-subunit-1to2 < /tmp/test-result.subunit1 | subunit2junitxml > /tmp/junit/results.junitxml
+from sys import stdin, stdout, argv
+result = load(stdin)
+messy_output = result["testenvs"][argv[1]]["test"][-1]["output"]
+stdout.write(messy_output.split("\n", 3)[3].strip())
+' "${TAHOE_LAFS_TOX_ENVIRONMENT}" |
+    /tmp/tests/bin/subunit-1to2 |
+    /tmp/tests/bin/subunit2junitxml > /tmp/junit/results.junitxml

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -10,7 +10,7 @@ TAHOE_LAFS_TOX_ARGS=$1
 shift || :
 
 # Make sure we can actually write things to this directory.
-mkdir -p "${ARTIFACTS}"
+sudo --user nobody mkdir -p "${ARTIFACTS}"
 
 # Run the test suite as a non-root user.  This is the expected usage some
 # small areas of the test suite assume non-root privileges (such as unreadable

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -33,4 +33,4 @@ messy_output = result["testenvs"][argv[1]]["test"][-1]["output"]
 stdout.write(messy_output.split("\n", 3)[3].strip())
 ' "${TAHOE_LAFS_TOX_ENVIRONMENT}" |
     /tmp/tests/bin/subunit-1to2 |
-    /tmp/tests/bin/subunit2junitxml > /tmp/junit/results.junitxml
+    /tmp/tests/bin/subunit2junitxml > /tmp/junit/results.xml

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -43,7 +43,14 @@ from json import load
 from sys import stdin, stdout, argv
 result = load(stdin)
 for environ in argv[1].split(","):
-    messy_output = result["testenvs"][environ]["test"][-1]["output"]
+    # Heuristically discover which blob is probably the test output!
+    test_result = next(
+        result
+        for result
+        in result["testenvs"][environ]["test"]
+        if "test: allmydata." in result["output"]
+    )
+    messy_output = test_result["output"]
     stdout.write(messy_output.split("\n", 3)[3].strip() + "\n")
 ' "${TAHOE_LAFS_TOX_ENVIRONMENT}" < "${TOX_JSON}" > "${SUBUNIT1}"
 

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -10,7 +10,15 @@ shift || :
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 
-sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
+# Python packages we need to support the test infrastructure.  *Not* packages
+# Tahoe-LAFS itself (implementation or test suite) need.
+TEST_DEPS="tox codecov"
+
+# Python packages we need to generate test reports for CI infrastructure.
+# *Not* packages Tahoe-LAFS itself (implement or test suite) need.
+REPORTING_DEPS="python-subunit junitxml"
+
+sudo --set-home -u nobody /tmp/tests/bin/pip install ${TEST_DEPS} ${REPORTING_DEPS}
 
 # Get everything else installed in it, too.
 sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -16,7 +16,7 @@ sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 # requirements (TLS >= 1.2) are incompatible with the old TLS clients
 # available to those systems.  Installing it ahead of time (with pip) avoids
 # this problem.
-sudo --set-home -u nobody PIP_FIND_LINKS=/tmp/packages /tmp/tests/bin/pip install certifi
+sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
 
 # Python packages we need to support the test infrastructure.  *Not* packages
 # Tahoe-LAFS itself (implementation or test suite) need.

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -16,7 +16,7 @@ TEST_DEPS="tox codecov"
 
 # Python packages we need to generate test reports for CI infrastructure.
 # *Not* packages Tahoe-LAFS itself (implement or test suite) need.
-REPORTING_DEPS="python-subunit junitxml"
+REPORTING_DEPS="python-subunit junitxml subunitreporter"
 
 sudo --set-home -u nobody /tmp/tests/bin/pip install ${TEST_DEPS} ${REPORTING_DEPS}
 

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -21,4 +21,9 @@ REPORTING_DEPS="python-subunit junitxml"
 sudo --set-home -u nobody /tmp/tests/bin/pip install ${TEST_DEPS} ${REPORTING_DEPS}
 
 # Get everything else installed in it, too.
-sudo --set-home -u nobody /tmp/tests/bin/tox -c /tmp/project/tox.ini --workdir /tmp --notest -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" ${TAHOE_LAFS_TOX_ARGS}
+sudo --set-home -u nobody /tmp/tests/bin/tox \
+     -c /tmp/project/tox.ini \
+     --workdir /tmp/tahoe-lafs.tox \
+     --notest \
+     -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
+     ${TAHOE_LAFS_TOX_ARGS}

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -10,6 +10,14 @@ shift || :
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 
+# Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
+# a package to be installed (with setuptools) then it'll fail on certain
+# platforms (travis's OX-X 10.12, Slackware 14.2) because PyPI's TLS
+# requirements (TLS >= 1.2) are incompatible with the old TLS clients
+# available to those systems.  Installing it ahead of time (with pip) avoids
+# this problem.
+sudo --set-home -u nobody PIP_FIND_LINKS=/tmp/packages /tmp/tests/bin/pip install certifi
+
 # Python packages we need to support the test infrastructure.  *Not* packages
 # Tahoe-LAFS itself (implementation or test suite) need.
 TEST_DEPS="tox codecov"

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -10,10 +10,6 @@ shift || :
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 
-# Slackware has non-working SSL support in setuptools until certifi is
-# installed.  SSL support in setuptools is needed in case packages use
-# `setup_requires` which gets satisfied by setuptools instead of by pip.
-# txi2p (vcversioner) is one such package.  Twisted (incremental) is another.
 sudo --set-home -u nobody /tmp/tests/bin/pip install tox codecov
 
 # Get everything else installed in it, too.

--- a/src/allmydata/test/cli/test_daemonize.py
+++ b/src/allmydata/test/cli/test_daemonize.py
@@ -112,6 +112,7 @@ class RunDaemonizeTests(unittest.TestCase):
         # or raise RuntimeError) it is apparently just ignored and the
         # test passes anyway...
         if self._working != os.path.abspath('.'):
+            print("WARNING: a test just changed the working dir; putting it back")
             os.chdir(self._working)
         return d
 

--- a/src/allmydata/test/cli/test_daemonize.py
+++ b/src/allmydata/test/cli/test_daemonize.py
@@ -112,7 +112,6 @@ class RunDaemonizeTests(unittest.TestCase):
         # or raise RuntimeError) it is apparently just ignored and the
         # test passes anyway...
         if self._working != os.path.abspath('.'):
-            print("WARNING: a test just changed the working dir; putting it back")
             os.chdir(self._working)
         return d
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ passenv = TAHOE_LAFS_* USERPROFILE HOMEDRIVE HOMEPATH
 # requirements (TLS >= 1.2) are incompatible with the old TLS clients
 # available to those systems.  Installing it ahead of time (with pip) avoids
 # this problem.
-deps = certifi
+deps =
+     certifi
+     python-subunit
 # We add usedevelop=True for speed, and extras=test to get things like "mock"
 # that are required for our unit tests.
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ skipsdist = True
 
 [testenv]
 basepython=python2.7
-passenv = TAHOE_LAFS_* USERPROFILE HOMEDRIVE HOMEPATH
+passenv = TAHOE_LAFS_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
 # Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
 # a package to be installed (with setuptools) then it'll fail on certain
 # platforms (travis's OX-X 10.12, Slackware 14.2) because PyPI's TLS

--- a/tox.ini
+++ b/tox.ini
@@ -61,9 +61,8 @@ commands =
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 deps =
-     # Duplicated from [testenv]
-     certifi
-     python-subunit
+     # Take the base deps as well!
+     {[testenv]deps}
      git+https://github.com/twisted/twisted
      git+https://github.com/warner/foolscap
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,9 @@ commands =
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 deps =
+     # Duplicated from [testenv]
+     certifi
+     python-subunit
      git+https://github.com/twisted/twisted
      git+https://github.com/warner/foolscap
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ passenv = TAHOE_LAFS_* USERPROFILE HOMEDRIVE HOMEPATH
 deps =
      certifi
      python-subunit
+     subunitreporter
 # We add usedevelop=True for speed, and extras=test to get things like "mock"
 # that are required for our unit tests.
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ passenv = TAHOE_LAFS_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
 # this problem.
 deps =
      certifi
-     python-subunit
      subunitreporter
 # We add usedevelop=True for speed, and extras=test to get things like "mock"
 # that are required for our unit tests.


### PR DESCRIPTION
This information allows CircleCI to do several things.  Among them:

  * report the slowest test in a successful test run
  * report the names and details of failing tests in an unsuccessful test run
  * generate statistics about the failing-est tests in the suite over multiple runs
