### PR TITLE
CircleCI improved caching faster builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,11 @@ jobs:
 
       - "checkout"
 
+      - run: &BOOTSTRAP_TEST_ENVIRONMENT
+          name: "Bootstrap test environment"
+          command: |
+            ~/project/.circleci/bootstrap-test-environment.sh ~/project "${EXTRA_PACKAGES}"
+
       - restore_cache: &RESTORE_HTTP_CACHE
           keys:
             # An exact match on the http cache key is great.  It should have
@@ -105,11 +110,6 @@ jobs:
             # we won't be able to use them (and they'll break the build rather
             # than being ignored).
             - v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}
-
-      - run: &BOOTSTRAP_TEST_ENVIRONMENT
-          name: "Bootstrap test environment"
-          command: |
-            ~/project/.circleci/bootstrap-test-environment.sh ~/project "${EXTRA_PACKAGES}"
 
       - run: &SETUP_VIRTUALENV
           name: "Setup virtualenv"
@@ -234,9 +234,6 @@ jobs:
 
       - "checkout"
 
-      - restore_cache: *RESTORE_HTTP_CACHE
-      - restore_cache: *RESTORE_WHEELHOUSE
-
       - run:
           name: "Bootstrap test environment"
           working_directory: "/tmp"
@@ -266,6 +263,9 @@ jobs:
             # XXX net-tools is actually a Tahoe-LAFS runtime dependency!
             yum install --assumeyes \
                 net-tools
+
+      - restore_cache: *RESTORE_HTTP_CACHE
+      - restore_cache: *RESTORE_WHEELHOUSE
 
       - run: *SETUP_VIRTUALENV
 
@@ -306,9 +306,6 @@ jobs:
             slackpkg install openssh-7.4p1 git-2.14.4 </dev/null
 
       - "checkout"
-
-      - restore_cache: *RESTORE_HTTP_CACHE
-      - restore_cache: *RESTORE_WHEELHOUSE
 
       - run:
           name: "Bootstrap test environment"
@@ -355,6 +352,9 @@ jobs:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python get-pip.py
             pip install virtualenv
+
+      - restore_cache: *RESTORE_HTTP_CACHE
+      - restore_cache: *RESTORE_WHEELHOUSE
 
       - run: *SETUP_VIRTUALENV
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           keys:
             # An exact match on the http cache key is great.  It should have
             # exactly the packages (tgz, whl, whatever) we need.
-            - v4-pip-http-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v4-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
             # A prefix match is okay too.  It might have a
             # partially-overlapping set of packages.  That's a head-start, at
             # least.  We might have to download a few more things but at least
@@ -103,7 +103,7 @@ jobs:
             # There are binary wheels in this wheelhouse and we're not taking
             # care to make manylinux1 wheels.  The binary wheels in this cache
             # will only work on some Linux distros.
-            - v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
             # A partial match is okay too.  It'll get us at least some of the
             # wheels.  We do need to keep the job name as part of the key or
             # we might get binary wheels build against an incompatible ABI and

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
             ~/project/.circleci/bootstrap-test-environment.sh ~/project "${EXTRA_PACKAGES}"
 
       - restore_cache: &RESTORE_HTTP_CACHE
+          name: "Restoring pip HTTP cache"
           keys:
             # An exact match on the http cache key is great.  It should have
             # exactly the packages (tgz, whl, whatever) we need.
@@ -97,6 +98,7 @@ jobs:
             - v5-pip-http-
 
       - restore_cache: &RESTORE_WHEELHOUSE
+          name: "Restoring wheelhouse"
           keys:
             # As above, an exact match is great.  Here, we also need to
             # include the job name to make sure the platform ABI matches.
@@ -122,6 +124,7 @@ jobs:
                 "${TAHOE_LAFS_TOX_ARGS}"
 
       - save_cache: &SAVE_HTTP_CACHE
+          name: "Saving pip HTTP cache"
           key: v5-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             # Perfectly valid for Linux.  Note we exclude the wheel cache
@@ -130,6 +133,7 @@ jobs:
             - "/tmp/nobody/.cache/pip/http"
 
       - save_cache: &SAVE_WHEELHOUSE
+          name: "Caching wheelhouse"
           key: v4-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             - *WHEELHOUSE_PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,14 @@ jobs:
           keys:
             # An exact match on the http cache key is great.  It should have
             # exactly the packages (tgz, whl, whatever) we need.
-            - v4-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+            - v5-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
             # A prefix match is okay too.  It might have a
             # partially-overlapping set of packages.  That's a head-start, at
             # least.  We might have to download a few more things but at least
             # we saved a little time.  After we download some more stuff we'll
             # create a new cache entry with the full key above and the next
             # build will get a better cache hit.
-            - v4-pip-http-
+            - v5-pip-http-
 
       - restore_cache: &RESTORE_WHEELHOUSE
           keys:
@@ -103,13 +103,13 @@ jobs:
             # There are binary wheels in this wheelhouse and we're not taking
             # care to make manylinux1 wheels.  The binary wheels in this cache
             # will only work on some Linux distros.
-            - v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+            - v4-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
             # A partial match is okay too.  It'll get us at least some of the
             # wheels.  We do need to keep the job name as part of the key or
             # we might get binary wheels build against an incompatible ABI and
             # we won't be able to use them (and they'll break the build rather
             # than being ignored).
-            - v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}
+            - v4-wheelhouse-{{ .Environment.CIRCLE_JOB }}
 
       - run: &SETUP_VIRTUALENV
           name: "Setup virtualenv"
@@ -124,7 +124,7 @@ jobs:
                 "${TAHOE_LAFS_TOX_ARGS}"
 
       - save_cache: &SAVE_HTTP_CACHE
-          key: v4-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v5-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             # Perfectly valid for Linux.  Note we exclude the wheel cache
             # because we want this cache to be valid across all platforms and
@@ -132,7 +132,7 @@ jobs:
             - "/tmp/nobody/.cache/pip/http"
 
       - save_cache: &SAVE_WHEELHOUSE
-          key: v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v4-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             - *WHEELHOUSE_PATH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,6 @@ jobs:
           # readable.
           working_directory: "/tmp"
           command: |
-            # XXX DEBUGGING
-            ls -la /tmp/nobody
             /tmp/project/.circleci/setup-virtualenv.sh \
                 "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
                 "${TAHOE_LAFS_TOX_ARGS}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,9 @@ jobs:
 
       - "checkout"
 
+      - restore_cache: *RESTORE_HTTP_CACHE
+      - restore_cache: *RESTORE_WHEEHLHOUSE
+
       - run:
           name: "Bootstrap test environment"
           working_directory: "/tmp"
@@ -248,6 +251,10 @@ jobs:
                 net-tools
 
       - run: *SETUP_VIRTUALENV
+
+      - save_cache: *SAVE_HTTP_CACHE
+      - save_cache: *SAVE_WHEELHOUSE
+
       - run: *RUN_TESTS
 
       - store_test_results: *STORE_TEST_RESULTS
@@ -282,6 +289,9 @@ jobs:
             slackpkg install openssh-7.4p1 git-2.14.4 </dev/null
 
       - "checkout"
+
+      - restore_cache: *RESTORE_HTTP_CACHE
+      - restore_cache: *RESTORE_WHEEHLHOUSE
 
       - run:
           name: "Bootstrap test environment"
@@ -330,6 +340,10 @@ jobs:
             pip install virtualenv
 
       - run: *SETUP_VIRTUALENV
+
+      - save_cache: *SAVE_HTTP_CACHE
+      - save_cache: *SAVE_WHEELHOUSE
+
       - run: *RUN_TESTS
 
       - store_test_results: *STORE_TEST_RESULTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,16 +80,14 @@ jobs:
 
       - restore_cache: &RESTORE_HTTP_CACHE
           keys:
-            - v1-pip-http-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
-            - v1-pip-http-{{ .Branch }}
-            - v1-pip-http-
+            - v2-pip-http-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v2-pip-http-
 
       - restore_cache: &RESTORE_WHEELHOUSE
           keys:
-            - v1-wheelhouse-{{ arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
-            - v1-wheelhouse-{{ arch }}-{{ .Branch }}
-            - v1-wheelhouse-{{ arch }}
-            - v1-wheelhouse-
+            - v2-wheelhouse-{{ arch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v2-wheelhouse-{{ arch }}
+            - v2-wheelhouse-
 
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
@@ -107,13 +105,13 @@ jobs:
                 "${TAHOE_LAFS_TOX_ARGS}"
 
       - save_cache: &SAVE_HTTP_CACHE
-          key: v1-pip-http-{{ .Branch }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v2-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             # Perfectly valid for Linux.
             - "/tmp/nobody/.cache/pip"
 
       - save_cache: &SAVE_WHEELHOUSE
-          key: v1-wheelhouse-{{ arch }}-{{ .Branch }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v2-wheelhouse-{{ arch }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             - *WHEELHOUSE_PATH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
       - "checkout"
 
       - restore_cache: *RESTORE_HTTP_CACHE
-      - restore_cache: *RESTORE_WHEEHLHOUSE
+      - restore_cache: *RESTORE_WHEELHOUSE
 
       - run:
           name: "Bootstrap test environment"
@@ -291,7 +291,7 @@ jobs:
       - "checkout"
 
       - restore_cache: *RESTORE_HTTP_CACHE
-      - restore_cache: *RESTORE_WHEEHLHOUSE
+      - restore_cache: *RESTORE_WHEELHOUSE
 
       - run:
           name: "Bootstrap test environment"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - run: &INSTALL_GIT
-          node: "Install Git"
+          name: "Install Git"
           command: |
             apt-get --quiet update
             apt-get --quiet --yes install git
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - run:
-          node: "Install Git"
+          name: "Install Git"
           command: |
             yum install --assumeyes git
 
@@ -248,7 +248,7 @@ jobs:
 
     steps:
       - run:
-          node: "Install Git"
+          name: "Install Git"
           command: |
             slackpkg update
             slackpkg install openssh-7.4p1 git-2.14.4 </dev/null

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,14 +82,14 @@ jobs:
           keys:
             # An exact match on the http cache key is great.  It should have
             # exactly the packages (tgz, whl, whatever) we need.
-            - v3-pip-http-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v4-pip-http-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
             # A prefix match is okay too.  It might have a
             # partially-overlapping set of packages.  That's a head-start, at
             # least.  We might have to download a few more things but at least
             # we saved a little time.  After we download some more stuff we'll
             # create a new cache entry with the full key above and the next
             # build will get a better cache hit.
-            - v3-pip-http-
+            - v4-pip-http-
 
       - restore_cache: &RESTORE_WHEELHOUSE
           keys:
@@ -122,10 +122,12 @@ jobs:
                 "${TAHOE_LAFS_TOX_ARGS}"
 
       - save_cache: &SAVE_HTTP_CACHE
-          key: v3-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v4-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
-            # Perfectly valid for Linux.
-            - "/tmp/nobody/.cache/pip"
+            # Perfectly valid for Linux.  Note we exclude the wheel cache
+            # because we want this cache to be valid across all platforms and
+            # the wheels in the pip wheel cache are not necessarily so.
+            - "/tmp/nobody/.cache/pip/http"
 
       - save_cache: &SAVE_WHEELHOUSE
           key: v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,8 @@ jobs:
 
       - restore_cache: &RESTORE_WHEELHOUSE
           keys:
-            - v2-wheelhouse-{{ arch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
-            - v2-wheelhouse-{{ arch }}
+            - v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}
             - v2-wheelhouse-
 
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
@@ -111,7 +111,7 @@ jobs:
             - "/tmp/nobody/.cache/pip"
 
       - save_cache: &SAVE_WHEELHOUSE
-          key: v2-wheelhouse-{{ arch }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             - *WHEELHOUSE_PATH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,8 @@ jobs:
           # readable.
           working_directory: "/tmp"
           command: |
+            # XXX DEBUGGING
+            ls -la /tmp/nobody
             /tmp/project/.circleci/setup-virtualenv.sh \
                 "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
                 "${TAHOE_LAFS_TOX_ARGS}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,9 @@ jobs:
 
       - restore_cache: &RESTORE_WHEELHOUSE
           keys:
-            - v1-wheelhouse-{{ .arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
-            - v1-wheelhouse-{{ .arch }}-{{ .Branch }}
-            - v1-wheelhouse-{{ .arch }}
+            - v1-wheelhouse-{{ arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v1-wheelhouse-{{ arch }}-{{ .Branch }}
+            - v1-wheelhouse-{{ arch }}
             - v1-wheelhouse-
 
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
@@ -113,7 +113,7 @@ jobs:
             - "/tmp/nobody/.cache/pip"
 
       - save_cache: &SAVE_WHEELHOUSE
-          key: v1-wheelhouse-{{ .arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+          key: v1-wheelhouse-{{ arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
           paths:
             - *WHEELHOUSE_PATH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,14 +82,14 @@ jobs:
           keys:
             # An exact match on the http cache key is great.  It should have
             # exactly the packages (tgz, whl, whatever) we need.
-            - v2-pip-http-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v3-pip-http-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
             # A prefix match is okay too.  It might have a
             # partially-overlapping set of packages.  That's a head-start, at
             # least.  We might have to download a few more things but at least
             # we saved a little time.  After we download some more stuff we'll
             # create a new cache entry with the full key above and the next
             # build will get a better cache hit.
-            - v2-pip-http-
+            - v3-pip-http-
 
       - restore_cache: &RESTORE_WHEELHOUSE
           keys:
@@ -98,13 +98,13 @@ jobs:
             # There are binary wheels in this wheelhouse and we're not taking
             # care to make manylinux1 wheels.  The binary wheels in this cache
             # will only work on some Linux distros.
-            - v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
             # A partial match is okay too.  It'll get us at least some of the
             # wheels.  We do need to keep the job name as part of the key or
             # we might get binary wheels build against an incompatible ABI and
             # we won't be able to use them (and they'll break the build rather
             # than being ignored).
-            - v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}
+            - v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}
 
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
@@ -122,13 +122,13 @@ jobs:
                 "${TAHOE_LAFS_TOX_ARGS}"
 
       - save_cache: &SAVE_HTTP_CACHE
-          key: v2-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v3-pip-http-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             # Perfectly valid for Linux.
             - "/tmp/nobody/.cache/pip"
 
       - save_cache: &SAVE_WHEELHOUSE
-          key: v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
+          key: v3-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             - *WHEELHOUSE_PATH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,14 +80,31 @@ jobs:
 
       - restore_cache: &RESTORE_HTTP_CACHE
           keys:
+            # An exact match on the http cache key is great.  It should have
+            # exactly the packages (tgz, whl, whatever) we need.
             - v2-pip-http-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            # A prefix match is okay too.  It might have a
+            # partially-overlapping set of packages.  That's a head-start, at
+            # least.  We might have to download a few more things but at least
+            # we saved a little time.  After we download some more stuff we'll
+            # create a new cache entry with the full key above and the next
+            # build will get a better cache hit.
             - v2-pip-http-
 
       - restore_cache: &RESTORE_WHEELHOUSE
           keys:
+            # As above, an exact match is great.  Here, we also need to
+            # include the job name to make sure the platform ABI matches.
+            # There are binary wheels in this wheelhouse and we're not taking
+            # care to make manylinux1 wheels.  The binary wheels in this cache
+            # will only work on some Linux distros.
             - v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            # A partial match is okay too.  It'll get us at least some of the
+            # wheels.  We do need to keep the job name as part of the key or
+            # we might get binary wheels build against an incompatible ABI and
+            # we won't be able to use them (and they'll break the build rather
+            # than being ignored).
             - v2-wheelhouse-{{ .Environment.CIRCLE_JOB }}
-            - v2-wheelhouse-
 
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       # Select a tox environment to run for this job.
       TAHOE_LAFS_TOX_ENVIRONMENT: "coverage"
       # Additional arguments to pass to tox.
-      TAHOE_LAFS_TOX_ARGS: "allmydata.test.cli.test_daemonize"
+      TAHOE_LAFS_TOX_ARGS: ""
       # Convince all of our pip invocations to look at the cached wheelhouse
       # we maintain.
       WHEELHOUSE_PATH: &WHEELHOUSE_PATH "/tmp/wheelhouse"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,13 +107,13 @@ jobs:
                 "${TAHOE_LAFS_TOX_ARGS}"
 
       - save_cache: &SAVE_HTTP_CACHE
-          key: v1-pip-http-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+          key: v1-pip-http-{{ .Branch }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             # Perfectly valid for Linux.
             - "/tmp/nobody/.cache/pip"
 
       - save_cache: &SAVE_WHEELHOUSE
-          key: v1-wheelhouse-{{ arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+          key: v1-wheelhouse-{{ arch }}-{{ .Branch }}-{{ checksum "/tmp/project/setup.py" }}-{{ checksum "/tmp/project/src/allmydata/_auto_deps.py" }}
           paths:
             - *WHEELHOUSE_PATH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,11 @@ jobs:
       # Select a tox environment to run for this job.
       TAHOE_LAFS_TOX_ENVIRONMENT: "coverage"
       # Additional arguments to pass to tox.
-      TAHOE_LAFS_TOX_ARGS: ""
+      TAHOE_LAFS_TOX_ARGS: "allmydata.test.cli.test_daemonize"
+      # Convince all of our pip invocations to look at the cached wheelhouse
+      # we maintain.
+      WHEELHOUSE_PATH: &WHEELHOUSE_PATH "/tmp/wheelhouse"
+      PIP_FIND_LINKS: "file:///tmp/wheelhouse"
 
     steps:
       - run: &INSTALL_GIT
@@ -73,6 +77,19 @@ jobs:
             apt-get --quiet --yes install git
 
       - "checkout"
+
+      - restore_cache: &RESTORE_HTTP_CACHE
+          keys:
+            - v1-pip-http-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v1-pip-http-{{ .Branch }}
+            - v1-pip-http-
+
+      - restore_cache: &RESTORE_WHEELHOUSE
+          keys:
+            - v1-wheelhouse-{{ .arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+            - v1-wheelhouse-{{ .arch }}-{{ .Branch }}
+            - v1-wheelhouse-{{ .arch }}
+            - v1-wheelhouse-
 
       - run: &BOOTSTRAP_TEST_ENVIRONMENT
           name: "Bootstrap test environment"
@@ -88,6 +105,17 @@ jobs:
             /tmp/project/.circleci/setup-virtualenv.sh \
                 "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
                 "${TAHOE_LAFS_TOX_ARGS}"
+
+      - save_cache: &SAVE_HTTP_CACHE
+          key: v1-pip-http-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+          paths:
+            # Perfectly valid for Linux.
+            - "/tmp/nobody/.cache/pip"
+
+      - save_cache: &SAVE_WHEELHOUSE
+          key: v1-wheelhouse-{{ .arch }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "src/allmydata/_auto_deps.py" }}
+          paths:
+            - *WHEELHOUSE_PATH
 
       - run: &RUN_TESTS
           name: "Run test suite"

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -31,7 +31,8 @@ JUNITXML="${ARTIFACTS}"/junit/unittests/results.xml
 sudo \
     SUBUNITREPORTER_OUTPUT_PATH="${SUBUNIT2}" \
     TAHOE_LAFS_TRIAL_ARGS="--reporter=subunitv2-file" \
-     --set-home \
+    PIP_NO_INDEX="1" \
+    --set-home \
      --user nobody \
      /tmp/tests/bin/tox \
      -c /tmp/project/tox.ini \

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -33,12 +33,12 @@ sudo \
     TAHOE_LAFS_TRIAL_ARGS="--reporter=subunitv2-file" \
     PIP_NO_INDEX="1" \
     --set-home \
-     --user nobody \
-     /tmp/tests/bin/tox \
-     -c /tmp/project/tox.ini \
-     --workdir /tmp/tahoe-lafs.tox \
-     -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
-     ${TAHOE_LAFS_TOX_ARGS}
+    --user nobody \
+    /tmp/tests/bin/tox \
+    -c /tmp/project/tox.ini \
+    --workdir /tmp/tahoe-lafs.tox \
+    -e "${TAHOE_LAFS_TOX_ENVIRONMENT}" \
+    ${TAHOE_LAFS_TOX_ARGS}
 
 # Create a junitxml results area.
 mkdir -p "$(dirname "${JUNITXML}")"

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -9,7 +9,7 @@ shift || :
 # Make sure the ownership of the pip cache directory is correct.  The CircleCI
 # cache management operations seem to mess it up.  The cache directory might
 # not exist if there was no matching cache to restore.
-[ -e /tmp/nobody/.cache ] && sudo chown --recursive nobody /tmp/nobody/.cache
+[ -e /tmp/nobody/.cache ] && chown --recursive nobody /tmp/nobody/.cache
 
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -30,23 +30,32 @@ sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 # available to those systems.  Installing it ahead of time (with pip) avoids
 # this problem.  Make sure this step comes before any other attempts to
 # install things using pip!
-sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
+sudo --set-home -u nobody \
+     PIP_FIND_LINKS="${PIP_FIND_LINKS}" \
+     /tmp/tests/bin/pip install certifi
 
 # Get a new, awesome version of pip and setuptools.  For example, the
 # distro-packaged virtualenv's pip may not know about wheels.
-sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip setuptools wheel
+sudo --set-home -u nobody \
+     PIP_FIND_LINKS="${PIP_FIND_LINKS}" \
+     /tmp/tests/bin/pip install --upgrade pip setuptools wheel
 
 # Populate the wheelhouse, if necessary.
-sudo --set-home -u nobody /tmp/tests/bin/pip \
+sudo --set-home -u nobody \
+     PIP_FIND_LINKS="${PIP_FIND_LINKS}" \
+     /tmp/tests/bin/pip \
      wheel \
-     --find-links "${PIP_FIND_LINKS}" \
      --wheel-dir "${WHEELHOUSE_PATH}" \
      /tmp/project ${TEST_DEPS} ${REPORTING_DEPS}
 
-sudo --set-home -u nobody /tmp/tests/bin/pip install ${TEST_DEPS} ${REPORTING_DEPS}
+sudo --set-home -u nobody \
+     PIP_FIND_LINKS="${PIP_FIND_LINKS}" \
+     /tmp/tests/bin/pip install ${TEST_DEPS} ${REPORTING_DEPS}
 
 # Get everything else installed in it, too.
-sudo --set-home -u nobody /tmp/tests/bin/tox \
+sudo --set-home -u nobody \
+     PIP_FIND_LINKS="${PIP_FIND_LINKS}" \
+     /tmp/tests/bin/tox \
      -c /tmp/project/tox.ini \
      --workdir /tmp/tahoe-lafs.tox \
      --notest \

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -19,6 +19,10 @@ sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 # install things using pip!
 sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
 
+# Get a new, awesome version of pip.  For example, the distro-packaged
+# virtualenv's pip may not know about wheels.
+sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip
+
 # Populate the wheelhouse, if necessary.
 sudo --set-home -u nobody /tmp/tests/bin/pip \
      wheel \

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -6,6 +6,14 @@ shift
 TAHOE_LAFS_TOX_ARGS=$1
 shift || :
 
+# Python packages we need to support the test infrastructure.  *Not* packages
+# Tahoe-LAFS itself (implementation or test suite) need.
+TEST_DEPS="tox codecov"
+
+# Python packages we need to generate test reports for CI infrastructure.
+# *Not* packages Tahoe-LAFS itself (implement or test suite) need.
+REPORTING_DEPS="python-subunit junitxml subunitreporter"
+
 # Make sure the ownership of the pip cache directory is correct.  The CircleCI
 # cache management operations seem to mess it up.  The cache directory might
 # not exist if there was no matching cache to restore.
@@ -33,16 +41,7 @@ sudo --set-home -u nobody /tmp/tests/bin/pip \
      wheel \
      --find-links "${PIP_FIND_LINKS}" \
      --wheel-dir "${WHEELHOUSE_PATH}" \
-     /tmp/project
-
-
-# Python packages we need to support the test infrastructure.  *Not* packages
-# Tahoe-LAFS itself (implementation or test suite) need.
-TEST_DEPS="tox codecov"
-
-# Python packages we need to generate test reports for CI infrastructure.
-# *Not* packages Tahoe-LAFS itself (implement or test suite) need.
-REPORTING_DEPS="python-subunit junitxml subunitreporter"
+     /tmp/project ${TEST_DEPS} ${REPORTING_DEPS}
 
 sudo --set-home -u nobody /tmp/tests/bin/pip install ${TEST_DEPS} ${REPORTING_DEPS}
 

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -10,6 +10,9 @@ shift || :
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 
+# Populate the wheelhouse, if necessary.
+/tmp/tests/bin/pip wheel --wheel-dir "${WHEELHOUSE_PATH}" /tmp/project
+
 # Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
 # a package to be installed (with setuptools) then it'll fail on certain
 # platforms (travis's OX-X 10.12, Slackware 14.2) because PyPI's TLS

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -19,9 +19,9 @@ sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 # install things using pip!
 sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
 
-# Get a new, awesome version of pip.  For example, the distro-packaged
-# virtualenv's pip may not know about wheels.
-sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip
+# Get a new, awesome version of pip and setuptools.  For example, the
+# distro-packaged virtualenv's pip may not know about wheels.
+sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip setuptools
 
 # Populate the wheelhouse, if necessary.
 sudo --set-home -u nobody /tmp/tests/bin/pip \

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -21,7 +21,7 @@ sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
 
 # Get a new, awesome version of pip and setuptools.  For example, the
 # distro-packaged virtualenv's pip may not know about wheels.
-sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip setuptools
+sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip setuptools wheel
 
 # Populate the wheelhouse, if necessary.
 sudo --set-home -u nobody /tmp/tests/bin/pip -vvv \

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -10,16 +10,21 @@ shift || :
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests
 
-# Populate the wheelhouse, if necessary.
-/tmp/tests/bin/pip wheel --wheel-dir "${WHEELHOUSE_PATH}" /tmp/project
-
 # Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
 # a package to be installed (with setuptools) then it'll fail on certain
 # platforms (travis's OX-X 10.12, Slackware 14.2) because PyPI's TLS
 # requirements (TLS >= 1.2) are incompatible with the old TLS clients
 # available to those systems.  Installing it ahead of time (with pip) avoids
-# this problem.
+# this problem.  Make sure this step comes before any other attempts to
+# install things using pip!
 sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
+
+# Populate the wheelhouse, if necessary.
+sudo --set-home -u nobody /tmp/tests/bin/pip \
+     wheel \
+     --wheel-dir "${WHEELHOUSE_PATH}" \
+     /tmp/project
+
 
 # Python packages we need to support the test infrastructure.  *Not* packages
 # Tahoe-LAFS itself (implementation or test suite) need.

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -31,6 +31,7 @@ sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip setuptools wh
 # Populate the wheelhouse, if necessary.
 sudo --set-home -u nobody /tmp/tests/bin/pip \
      wheel \
+     --find-links "${PIP_FIND_LINKS}" \
      --wheel-dir "${WHEELHOUSE_PATH}" \
      /tmp/project
 

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -6,6 +6,10 @@ shift
 TAHOE_LAFS_TOX_ARGS=$1
 shift || :
 
+# Make sure the ownership of the pip cache directory is correct.  The CircleCI
+# cache management operations seem to mess it up.
+sudo chown --recursive nobody:nogroup /tmp/nobody/.cache
+
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.
 sudo --set-home -u nobody virtualenv --python python2.7 /tmp/tests

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -24,7 +24,7 @@ sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
 sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip setuptools wheel
 
 # Populate the wheelhouse, if necessary.
-sudo --set-home -u nobody /tmp/tests/bin/pip -vvv \
+sudo --set-home -u nobody /tmp/tests/bin/pip \
      wheel \
      --wheel-dir "${WHEELHOUSE_PATH}" \
      /tmp/project

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -8,7 +8,7 @@ shift || :
 
 # Make sure the ownership of the pip cache directory is correct.  The CircleCI
 # cache management operations seem to mess it up.
-sudo chown --recursive nobody:nogroup /tmp/nobody/.cache
+sudo chown --recursive nobody /tmp/nobody/.cache
 
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -7,8 +7,9 @@ TAHOE_LAFS_TOX_ARGS=$1
 shift || :
 
 # Make sure the ownership of the pip cache directory is correct.  The CircleCI
-# cache management operations seem to mess it up.
-sudo chown --recursive nobody /tmp/nobody/.cache
+# cache management operations seem to mess it up.  The cache directory might
+# not exist if there was no matching cache to restore.
+[ -e /tmp/nobody/.cache ] && sudo chown --recursive nobody /tmp/nobody/.cache
 
 # Set up the virtualenv as a non-root user so we can run the test suite as a
 # non-root user.  See below.

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -24,7 +24,7 @@ sudo --set-home -u nobody /tmp/tests/bin/pip install certifi
 sudo --set-home -u nobody /tmp/tests/bin/pip install --upgrade pip setuptools
 
 # Populate the wheelhouse, if necessary.
-sudo --set-home -u nobody /tmp/tests/bin/pip \
+sudo --set-home -u nobody /tmp/tests/bin/pip -vvv \
      wheel \
      --wheel-dir "${WHEELHOUSE_PATH}" \
      /tmp/project

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ skipsdist = True
 
 [testenv]
 basepython=python2.7
-passenv = TAHOE_LAFS_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
+passenv = TAHOE_LAFS_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
 # Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
 # a package to be installed (with setuptools) then it'll fail on certain
 # platforms (travis's OX-X 10.12, Slackware 14.2) because PyPI's TLS


### PR DESCRIPTION
Speed up the CircleCI builds by caching pip's http download cache and a wheelhouse with all of the wheels we depend on (transitively).  Cache is invalidated when `setup.py` or `_auto_deps.py` change.