### PR TITLE
Less aggressive version pinning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,30 +329,30 @@ jobs:
 
             slackpkg install \
                 ca-certificates \
-                sudo-1.8.20p2 \
-                make-4.1 \
-                automake-1.15 \
+                sudo-1 \
+                make-4 \
+                automake-1 \
                 kernel-headers \
-                glibc-2.23 \
-                binutils-2.26 \
-                gcc-5.5.0 \
-                gcc-g++-5.5.0 \
-                python-2.7.15 \
-                libffi-3.2.1 \
-                libyaml-0.1.6 \
-                sqlite-3.13.0 \
-                icu4c-56.1 \
-                libmpc-1.0.3 </dev/null
+                glibc-2 \
+                binutils-2 \
+                gcc-5 \
+                gcc-g++-5 \
+                python-2 \
+                libffi-3 \
+                libyaml-0 \
+                sqlite-3 \
+                icu4c-56 \
+                libmpc-1 </dev/null
 
             slackpkg upgrade \
-                openssl-1.0 </dev/null
+                openssl-1 </dev/null
 
             # neither virtualenv nor pip is packaged.
             # do it the hard way.
             # and it is extra hard since it is slackware.
             slackpkg install \
-                cyrus-sasl-2.1.26 \
-                curl-7.60 </dev/null
+                cyrus-sasl-2 \
+                curl-7 </dev/null
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python get-pip.py
             pip install virtualenv


### PR DESCRIPTION
Old versions are removed from the package repository, as far as I can
tell.  This happened to curl and broke the build.