### PR TITLE
Whitelist "mv" to appease some tox check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -279,6 +279,9 @@ setup(name="tahoe-lafs", # also set in __init__.py
               "txi2p >= 0.3.2", # in case pip's resolver doesn't work
           ],
       },
+      dependency_links=[
+          "git+ssh://git@github.com/leastauthority/towncrier.git@9366f33#egg=towncrier",
+      ],
       package_data={"allmydata.web": ["*.xhtml",
                                       "static/*.js", "static/*.png", "static/*.css",
                                       "static/img/*.png",

--- a/setup.py
+++ b/setup.py
@@ -279,9 +279,6 @@ setup(name="tahoe-lafs", # also set in __init__.py
               "txi2p >= 0.3.2", # in case pip's resolver doesn't work
           ],
       },
-      dependency_links=[
-          "git+ssh://git@github.com/leastauthority/towncrier.git@9366f33#egg=towncrier",
-      ],
       package_data={"allmydata.web": ["*.xhtml",
                                       "static/*.js", "static/*.png", "static/*.css",
                                       "static/img/*.png",

--- a/towncrier.pyproject.toml
+++ b/towncrier.pyproject.toml
@@ -46,3 +46,8 @@
         directory = "other"
         name = "Other Changes"
         showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "misc"
+        name = "Miscellaneous"
+        showcontent = false

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,8 @@ commands =
 	 # https://github.com/pypa/pip/issues/5696
 	 /bin/mv towncrier.pyproject.toml pyproject.toml
 
+	 pip install --upgrade 'git+ssh://git@github.com/leastauthority/towncrier.git@9366f33#egg=towncrier'
+
 	 # If towncrier.check fails, you forgot to add a towncrier news
 	 # fragment explaining the change in this branch.  Create one at
 	 # `newsfragments/<ticket>.<change type>` with some text for the news

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands =
 	 # https://github.com/pypa/pip/issues/5696
 	 /bin/mv towncrier.pyproject.toml pyproject.toml
 
-	 pip install --upgrade 'git+ssh://git@github.com/leastauthority/towncrier.git@9366f33#egg=towncrier'
+	 pip install --upgrade 'https://github.com/LeastAuthority/towncrier/archive/report-git-failure-output.zip'
 
 	 # If towncrier.check fails, you forgot to add a towncrier news
 	 # fragment explaining the change in this branch.  Create one at

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,8 @@ commands =
          coverage xml
 
 [testenv:codechecks]
+whitelist_externals =
+		    /bin/mv
 commands =
          pyflakes src static misc setup.py
          python misc/coding_tools/check-umids.py src
@@ -60,7 +62,7 @@ commands =
 	 #
 	 # Some discussion is available at
 	 # https://github.com/pypa/pip/issues/5696
-	 mv towncrier.pyproject.toml pyproject.toml
+	 /bin/mv towncrier.pyproject.toml pyproject.toml
 
 	 # If towncrier.check fails, you forgot to add a towncrier news
 	 # fragment explaining the change in this branch.  Create one at


### PR DESCRIPTION
Follow-up to #517 which seemed to work exactly until it landed on master and then began to fail with:

> WARNING: test command found but not installed in testenv

And

```
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/towncrier/check.py", line 86, in <module>
    _main()
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/towncrier/check.py", line 26, in _main
    return __main(compare_with, directory)
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/towncrier/check.py", line 35, in __main
    _run(["git", "diff", "--name-only", comparewith + "..."], cwd=base_directory)
  File "/home/travis/build/LeastAuthority/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/towncrier/check.py", line 19, in _run
    return check_output(args, **kwargs)
  File "/opt/python/2.7.14/lib/python2.7/subprocess.py", line 219, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['git', 'diff', '--name-only', u'origin/master...']' returned non-zero exit status 128
```
