### PR TITLE
let 'tahoe -e codechecks' run w/o making local changes

### DIFF
--- a/newsfragments/2941.bugfix
+++ b/newsfragments/2941.bugfix
@@ -1,0 +1,1 @@
+"tox -e codechecks" puts back the local file it mv's while doing code-checks

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,10 @@ commands =
 	 # file.  See pyproject.toml for legal <change type> values.
 	 python -m towncrier.check
 
+         # put it back
+	 mv pyproject.toml towncrier.pyproject.toml
+
+
 [testenv:deprecations]
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning


### PR DESCRIPTION
The issue here is that if you run "tox -e codechecks" locally, your `towncrier.pyproject.toml` will be deleted (because codechecks `mv`s it to `pyproject.toml`). So, this just moves it back after ..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/523)
<!-- Reviewable:end -->
