### PR TITLE
Async initializers.5

### DIFF
--- a/newsfragments/2870.bugfix
+++ b/newsfragments/2870.bugfix
@@ -1,0 +1,1 @@
+refactor initialization code to be more async-friendly

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -196,14 +196,13 @@ def create_client(basedir=u".", _client_factory=None):
     :returns: :class:`allmydata.client._Client` instance (or whatever
         `_client_factory` returns)
     """
-    # should we check for this directory existing first? (this used to
-    # be in Node's constructor)
     node.create_node_dir(basedir, CLIENT_README)
     config = read_config(basedir, u"client.port")
-
-    # read config file and create instance
-    config = read_config(basedir, u"client.port")
-    return create_client_from_config(config, _client_factory=_client_factory)  # async
+    # following call is async
+    return create_client_from_config(
+        config,
+        _client_factory=_client_factory,
+    )
 
 
 # this method is async
@@ -213,10 +212,13 @@ def create_client_from_config(config, _client_factory=None):
     Creates a new client instance (a subclass of Node).  Most code
     should probably use `create_client` instead.
 
+    :returns: Deferred yielding a _Client instance
+
     :param config: configuration instance (from read_config()) which
         encapsulates everything in the "node directory".
 
     :param _client_factory: for testing; the class to instantiate
+        instead of _Client
     """
     if _client_factory is None:
         _client_factory = _Client

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -365,7 +365,7 @@ def create_storage_farm_broker(config, default_connection_handlers, foolscap_con
             tub_options,
             default_connection_handlers,
             foolscap_connection_handlers,
-            handler_overrides=handler_overrides or {},
+            handler_overrides={} if handler_overrides is None else handler_overrides,
             **kwargs
         )
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -185,8 +185,6 @@ def read_config(basedir, portnumfile, generated_files=[]):
     )
 
 
-# this method is async
-# @defer.inlineCallbacks
 def create_client(basedir=u".", _client_factory=None):
     """
     Creates a new client instance (a subclass of Node).
@@ -268,13 +266,13 @@ def create_client_from_config(config, _client_factory=None):
 def _sequencer(config):
     """
     :returns: a 2-tuple consisting of a new announcement
-        sequence-number and (random) nonce. Reads and re-writes
-        configuration file "announcement-seqnum", starting at 1 if that
-        file doesn't exist.
+        sequence-number and random nonce (int, unicode). Reads and
+        re-writes configuration file "announcement-seqnum" (starting at 1
+        if that file doesn't exist).
     """
     seqnum_s = config.get_config_from_file("announcement-seqnum")
     if not seqnum_s:
-        seqnum_s = "0"
+        seqnum_s = u"0"
     seqnum = int(seqnum_s.strip())
     seqnum += 1  # increment
     config.write_config_file("announcement-seqnum", "{}\n".format(seqnum))

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -1,6 +1,7 @@
 import os, stat, time, weakref
 from base64 import urlsafe_b64encode
 from functools import partial
+from errno import ENOENT
 
 from zope.interface import implementer
 from twisted.internet import reactor, defer

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -1,5 +1,4 @@
 import os, stat, time, weakref
-from allmydata import node
 from base64 import urlsafe_b64encode
 from functools import partial
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -201,23 +201,26 @@ def create_client(basedir=u".", _client_factory=None):
     node.create_node_dir(basedir, CLIENT_README)
     config = read_config(basedir, u"client.port")
 
-    if _client_factory is None:
-        _client_factory = _Client
-
     # read config file and create instance
     config = read_config(basedir, u"client.port")
-    return create_client_from_config(config)  # async
+    return create_client_from_config(config, _client_factory=_client_factory)  # async
 
 
 # this method is async
 # @defer.inlineCallbacks
-def create_client_from_config(config):
+def create_client_from_config(config, _client_factory=None):
     """
-    Create a new _Client instance given a _Config instance (basedir
-    must already exist and be writable).
+    Creates a new client instance (a subclass of Node).  Most code
+    should probably use `create_client` instead.
 
-    Most code should probably use `create_client` instead.
+    :param config: configuration instance (from read_config()) which
+        encapsulates everything in the "node directory".
+
+    :param _client_factory: for testing; the class to instantiate
     """
+    if _client_factory is None:
+        _client_factory = _Client
+
     i2p_provider = create_i2p_provider(reactor, config)
     tor_provider = create_tor_provider(reactor, config)
     handlers = node.create_connection_handlers(reactor, config, i2p_provider, tor_provider)
@@ -236,7 +239,7 @@ def create_client_from_config(config):
         tub_options, introducer_clients
     )
 
-    client = _Client(
+    client = _client_factory(
         config,
         main_tub,
         control_tub,

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -1,7 +1,7 @@
 import os, stat, time, weakref
 from base64 import urlsafe_b64encode
 from functools import partial
-from errno import ENOENT
+from errno import ENOENT, EPERM
 
 from zope.interface import implementer
 from twisted.internet import reactor, defer
@@ -297,7 +297,11 @@ def create_introducer_clients(config, main_tub):
         with introducers_filepath.open() as f:
             introducers_yaml = yamlutil.safe_load(f)
             if introducers_yaml is None:
-                introducers_yaml = {}
+                raise EnvironmentError(
+                    EPERM,
+                    "Can't read '{}'".format(introducers_yaml_filename),
+                    introducers_yaml_filename,
+                )
             introducers = introducers_yaml.get("introducers", {})
             log.msg(
                 "found {} introducers in private/introducers.yaml".format(

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -296,6 +296,8 @@ def create_introducer_clients(config, main_tub):
     try:
         with introducers_filepath.open() as f:
             introducers_yaml = yamlutil.safe_load(f)
+            if introducers_yaml is None:
+                introducers_yaml = {}
             introducers = introducers_yaml.get("introducers", {})
             log.msg(
                 "found {} introducers in private/introducers.yaml".format(

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -336,7 +336,6 @@ def create_introducer_clients(config, main_tub):
             introducer_cache_filepath,
         )
         introducer_clients.append(ic)
-        # introducer_furls.append(introducer['furl'])
     return introducer_clients
 
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -1,6 +1,7 @@
 import os, stat, time, weakref
 from allmydata import node
 from base64 import urlsafe_b64encode
+from functools import partial
 
 from zope.interface import implementer
 from twisted.internet import reactor, defer
@@ -108,6 +109,7 @@ the files.   See the 'configuration.rst' documentation file for details.
 def _make_secret():
     return base32.b2a(os.urandom(hashutil.CRYPTO_VAL_SIZE)) + "\n"
 
+
 class SecretHolder:
     def __init__(self, lease_secret, convergence_secret):
         self._lease_secret = lease_secret
@@ -206,15 +208,15 @@ def create_client(basedir=u".", _client_factory=None):
 
     # pre-requisites
     config = read_config(basedir, u"client.port", _valid_config_sections=_valid_config_sections)
-    return create_client_from_config(basedir, config)
+    return create_client_from_config(config)
 
 
 # this can/should be async
 # @defer.inlineCallbacks
-def create_client_from_config(basedir, config):
-    i2p_provider = create_i2p_provider(reactor, basedir, config)
-    tor_provider = create_tor_provider(reactor, basedir, config)
-    handlers = create_connection_handlers(reactor, basedir, config, i2p_provider, tor_provider)
+def create_client_from_config(config):
+    i2p_provider = create_i2p_provider(reactor, config)
+    tor_provider = create_tor_provider(reactor, config)
+    handlers = create_connection_handlers(reactor, config, i2p_provider, tor_provider)
     default_connection_handlers, foolscap_connection_handlers = handlers
     tub_options = create_tub_options(config)
 
@@ -223,17 +225,112 @@ def create_client_from_config(basedir, config):
         foolscap_connection_handlers, i2p_provider, tor_provider,
     )
     control_tub = create_control_tub()
-    return defer.succeed(
-        _Client(
-            config,
-            main_tub,
-            control_tub,
-            i2p_provider,
-            tor_provider,
-            basedir,
-            tub_is_listening=is_listening,
-        )
+
+    introducer_clients, introducer_furls = create_introducer_clients(basedir, config, main_tub)
+    storage_broker = create_storage_farm_broker(
+        config, default_connection_handlers, foolscap_connection_handlers,
+        tub_options, introducer_clients
     )
+
+    client = _Client(
+        config,
+        main_tub,
+        control_tub,
+        i2p_provider,
+        tor_provider,
+        introducer_clients,
+        introducer_furls,
+        storage_broker,
+        basedir,
+        tub_is_listening=is_listening,
+    )
+    i2p_provider.setServiceParent(client)
+    tor_provider.setServiceParent(client)
+    return defer.succeed(client)
+
+
+def _sequencer(config):
+    seqnum_s = config.get_config_from_file("announcement-seqnum")
+    if not seqnum_s:
+        seqnum_s = "0"
+    seqnum = int(seqnum_s.strip())
+    seqnum += 1  # increment
+    node._write_config(config.get_config_path(), "announcement-seqnum", "%d\n" % seqnum)
+    nonce = _make_secret().strip()
+    return seqnum, nonce
+
+
+def create_introducer_clients(basedir, config, main_tub):
+    # Returns both of these:
+    introducer_clients = []
+    introducer_furls = []
+
+    introducers_yaml_filename = os.path.join(basedir, "private", "introducers.yaml")
+    introducers_filepath = FilePath(introducers_yaml_filename)
+
+    try:
+        with introducers_filepath.open() as f:
+            introducers_yaml = yamlutil.safe_load(f)
+            introducers = introducers_yaml.get("introducers", {})
+            log.msg("found %d introducers in private/introducers.yaml" %
+                    len(introducers))
+    except EnvironmentError:
+        introducers = {}
+
+    if "default" in introducers.keys():
+        raise ValueError("'default' introducer furl cannot be specified in introducers.yaml; please fix impossible configuration.")
+
+    # read furl from tahoe.cfg
+    tahoe_cfg_introducer_furl = config.get_config("client", "introducer.furl", None)
+    if tahoe_cfg_introducer_furl == "None":
+        raise ValueError("tahoe.cfg has invalid 'introducer.furl = None':"
+                         " to disable it, use 'introducer.furl ='"
+                         " or omit the key entirely")
+    if tahoe_cfg_introducer_furl:
+        introducers[u'default'] = {'furl':tahoe_cfg_introducer_furl}
+
+    for petname, introducer in introducers.items():
+        introducer_cache_filepath = FilePath(os.path.join(basedir, "private", "introducer_{}_cache.yaml".format(petname)))
+        ic = IntroducerClient(
+            main_tub,
+            introducer['furl'].encode("ascii"),
+            config.nickname,
+            str(allmydata.__full_version__),
+            str(_Client.OLDEST_SUPPORTED_VERSION),
+            config.get_app_versions(),
+            partial(_sequencer, config),
+            introducer_cache_filepath,
+        )
+        introducer_clients.append(ic)
+        introducer_furls.append(introducer['furl'])
+    return introducer_clients, introducer_furls
+
+
+def create_storage_farm_broker(config, default_connection_handlers, foolscap_connection_handlers, tub_options, introducer_clients):
+    """
+    create a StorageFarmBroker object, for use by Uploader/Downloader
+    (and everybody else who wants to use storage servers)
+    """
+    ps = config.get_config("client", "peers.preferred", "").split(",")
+    preferred_peers = tuple([p.strip() for p in ps if p != ""])
+
+    def tub_creator(handler_overrides={}, **kwargs):
+        return create_tub(
+            tub_options,
+            default_connection_handlers,
+            foolscap_connection_handlers,
+            handler_overrides=handler_overrides,
+            **kwargs
+        )
+
+    sb = storage_client.StorageFarmBroker(
+        permute_peers=True,
+        tub_maker=tub_creator,
+        preferred_peers=preferred_peers,
+    )
+    for ic in introducer_clients:
+        sb.use_introducer(ic)
+    return sb
 
 
 @implementer(IStatsProducer)
@@ -258,15 +355,25 @@ class _Client(node.Node, pollmixin.PollMixin):
                                    "max_segment_size": 128*KiB,
                                    }
 
-    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, tub_is_listening):
+    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, introducer_clients, introducer_furls,
+                 storage_farm_broker, tub_is_listening):
+        """
+        Use create_client() to instantiate one of these.
+        """
         node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, tub_is_listening)
-        # All tub.registerReference must happen *after* we upcall, since
-        # that's what does tub.setLocation()
+
         self._magic_folders = dict()
         self.started_timestamp = time.time()
-        self.logSource="Client"
+        self.logSource = "Client"
         self.encoding_params = self.DEFAULT_ENCODING_PARAMETERS.copy()
-        self.init_introducer_clients()
+
+        self.introducer_clients = introducer_clients
+        self.introducer_furls = introducer_furls  # appears completely unused (but for tests?)
+        for ic in introducer_clients:
+            ic.setServiceParent(self)
+        self.storage_broker = storage_farm_broker
+        self.storage_broker.setServiceParent(self)
+
         self.init_stats_provider()
         self.init_secrets()
         self.init_node_key()
@@ -303,56 +410,6 @@ class _Client(node.Node, pollmixin.PollMixin):
         webport = config.get_config("node", "web.port", None)
         if webport:
             self.init_web(webport) # strports string
-
-    def _sequencer(self):
-        seqnum_s = self.config.get_config_from_file("announcement-seqnum")
-        if not seqnum_s:
-            seqnum_s = "0"
-        seqnum = int(seqnum_s.strip())
-        seqnum += 1 # increment
-        self.config.write_config_file("announcement-seqnum", "%d\n" % seqnum)
-        nonce = _make_secret().strip()
-        return seqnum, nonce
-
-    def init_introducer_clients(self):
-        self.introducer_clients = []
-        self.introducer_furls = []
-
-        introducers_yaml_filename = self.config.get_private_path("introducers.yaml")
-        introducers_filepath = FilePath(introducers_yaml_filename)
-
-        try:
-            with introducers_filepath.open() as f:
-                introducers_yaml = yamlutil.safe_load(f)
-                introducers = introducers_yaml.get("introducers", {})
-                log.msg("found %d introducers in private/introducers.yaml" %
-                        len(introducers))
-        except EnvironmentError:
-            introducers = {}
-
-        if "default" in introducers.keys():
-            raise ValueError("'default' introducer furl cannot be specified in introducers.yaml; please fix impossible configuration.")
-
-        # read furl from tahoe.cfg
-        tahoe_cfg_introducer_furl = self.config.get_config("client", "introducer.furl", None)
-        if tahoe_cfg_introducer_furl == "None":
-            raise ValueError("tahoe.cfg has invalid 'introducer.furl = None':"
-                             " to disable it, use 'introducer.furl ='"
-                             " or omit the key entirely")
-        if tahoe_cfg_introducer_furl:
-            introducers[u'default'] = {'furl':tahoe_cfg_introducer_furl}
-
-        for petname, introducer in introducers.items():
-            introducer_cache_filepath = FilePath(self.config.get_private_path("introducer_{}_cache.yaml".format(petname)))
-            ic = IntroducerClient(self.tub, introducer['furl'].encode("ascii"),
-                                  self.nickname,
-                                  str(allmydata.__full_version__),
-                                  str(self.OLDEST_SUPPORTED_VERSION),
-                                  node.get_app_versions(), self._sequencer,
-                                  introducer_cache_filepath)
-            self.introducer_clients.append(ic)
-            self.introducer_furls.append(introducer['furl'])
-            ic.setServiceParent(self)
 
     def init_stats_provider(self):
         gatherer_furl = self.config.get_config("client", "stats_gatherer.furl", None)
@@ -492,7 +549,6 @@ class _Client(node.Node, pollmixin.PollMixin):
         # for the CLI to authenticate to local JSON endpoints
         self._create_auth_token()
 
-        self.init_client_storage_broker()
         self.history = History(self.stats_provider)
         self.terminator = Terminator()
         self.terminator.setServiceParent(self)
@@ -522,38 +578,6 @@ class _Client(node.Node, pollmixin.PollMixin):
             'api_auth_token',
             urlsafe_b64encode(os.urandom(32)) + '\n',
         )
-
-    def init_client_storage_broker(self):
-        # create a StorageFarmBroker object, for use by Uploader/Downloader
-        # (and everybody else who wants to use storage servers)
-        ps = self.config.get_config("client", "peers.preferred", "").split(",")
-        preferred_peers = tuple([p.strip() for p in ps if p != ""])
-
-        # this is temporary; create_client() should create a
-        # storage-broker and pass it in -- that method already has
-        # all these objects created...
-        default_connection_handlers, foolscap_connection_handlers = create_connection_handlers(reactor, self.basedir, self.config, self._i2p_provider, self._tor_provider)
-
-
-        def tub_creator(handler_overrides={}, **kwargs):
-            tub_options = create_tub_options(self.config)
-            return create_tub(
-                tub_options,
-                default_connection_handlers,
-                foolscap_connection_handlers,
-                handler_overrides=handler_overrides,
-                **kwargs
-            )
-
-        sb = storage_client.StorageFarmBroker(
-            permute_peers=True,
-            tub_maker=tub_creator,
-            preferred_peers=preferred_peers,
-        )
-        self.storage_broker = sb
-        sb.setServiceParent(self)
-        for ic in self.introducer_clients:
-            sb.use_introducer(ic)
 
     def get_storage_broker(self):
         return self.storage_broker

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -301,7 +301,9 @@ def create_introducer_clients(config, main_tub):
                     len(introducers),
                 )
             )
-    except EnvironmentError:
+    except EnvironmentError as e:
+        if e.errno != ENOENT:
+            raise
         introducers = {}
 
     if "default" in introducers.keys():

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -106,6 +106,10 @@ the files.   See the 'configuration.rst' documentation file for details.
 
 
 def _make_secret():
+    """
+    Returns a base32-encoded random secret of hashutil.CRYPTO_VAL_SIZE
+    bytes.
+    """
     return base32.b2a(os.urandom(hashutil.CRYPTO_VAL_SIZE)) + "\n"
 
 
@@ -258,6 +262,12 @@ def create_client_from_config(config, _client_factory=None):
 
 
 def _sequencer(config):
+    """
+    :returns: a 2-tuple consisting of a new announcement
+        sequence-number and (random) nonce. Reads and re-writes
+        configuration file "announcement-seqnum", starting at 1 if that
+        file doesn't exist.
+    """
     seqnum_s = config.get_config_from_file("announcement-seqnum")
     if not seqnum_s:
         seqnum_s = "0"
@@ -270,6 +280,8 @@ def _sequencer(config):
 
 def create_introducer_clients(config, main_tub):
     """
+    Read, validate and parse any 'introducers.yaml' configuration.
+
     :returns: a list of IntroducerClient instances
     """
     # we return this list
@@ -326,8 +338,20 @@ def create_introducer_clients(config, main_tub):
 
 def create_storage_farm_broker(config, default_connection_handlers, foolscap_connection_handlers, tub_options, introducer_clients):
     """
-    create a StorageFarmBroker object, for use by Uploader/Downloader
+    Create a StorageFarmBroker object, for use by Uploader/Downloader
     (and everybody else who wants to use storage servers)
+
+    :param config: a _Config instance
+
+    :param default_connection_handlers: default Foolscap handlers
+
+    :param foolscap_connection_handlers: available/configured Foolscap
+        handlers
+
+    :param dict tub_options: how to configure our Tub
+
+    :param list introducer_clients: IntroducerClient instances if
+        we're connecting to any
     """
     ps = config.get_config("client", "peers.preferred", "").split(",")
     preferred_peers = tuple([p.strip() for p in ps if p != ""])

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -376,7 +376,7 @@ class _Client(node.Node, pollmixin.PollMixin):
     def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, introducer_clients,
                  storage_farm_broker):
         """
-        Use create_client() to instantiate one of these.
+        Use :func:`allmydata.client.create_client` to instantiate one of these.
         """
         node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -233,7 +233,7 @@ def create_client_from_config(config, _client_factory=None):
     )
     control_tub = node.create_control_tub()
 
-    introducer_clients, introducer_furls = create_introducer_clients(config, main_tub)
+    introducer_clients = create_introducer_clients(config, main_tub)
     storage_broker = create_storage_farm_broker(
         config, default_connection_handlers, foolscap_connection_handlers,
         tub_options, introducer_clients
@@ -246,7 +246,6 @@ def create_client_from_config(config, _client_factory=None):
         i2p_provider,
         tor_provider,
         introducer_clients,
-        introducer_furls,
         storage_broker,
         tub_is_listening=is_listening,
     )
@@ -271,16 +270,10 @@ def _sequencer(config):
 
 def create_introducer_clients(config, main_tub):
     """
-    returns a 2-tuple containing two lists: introducer_clients,
-    introducer_furls
+    :returns: a list of IntroducerClient instances
     """
-    # (probably makes sense to return a list of 2-tuples instead of a
-    # 2-tuple of lists, but keeping variable names etc from when this
-    # was self.init_introducer_clients in Node)
-
-    # Returns both of these:
+    # we return this list
     introducer_clients = []
-    introducer_furls = []
 
     introducers_yaml_filename = config.get_private_path("introducers.yaml")
     introducers_filepath = FilePath(introducers_yaml_filename)
@@ -327,8 +320,8 @@ def create_introducer_clients(config, main_tub):
             introducer_cache_filepath,
         )
         introducer_clients.append(ic)
-        introducer_furls.append(introducer['furl'])
-    return introducer_clients, introducer_furls
+        # introducer_furls.append(introducer['furl'])
+    return introducer_clients
 
 
 def create_storage_farm_broker(config, default_connection_handlers, foolscap_connection_handlers, tub_options, introducer_clients):
@@ -380,7 +373,7 @@ class _Client(node.Node, pollmixin.PollMixin):
                                    "max_segment_size": 128*KiB,
                                    }
 
-    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, introducer_clients, introducer_furls,
+    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, introducer_clients,
                  storage_farm_broker, tub_is_listening):
         """
         Use create_client() to instantiate one of these.
@@ -393,7 +386,6 @@ class _Client(node.Node, pollmixin.PollMixin):
         self.encoding_params = self.DEFAULT_ENCODING_PARAMETERS.copy()
 
         self.introducer_clients = introducer_clients
-        self.introducer_furls = introducer_furls  # appears completely unused (but for tests?)
         self.storage_broker = storage_farm_broker
 
         self.init_stats_provider()

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -433,7 +433,7 @@ class _Client(node.Node, pollmixin.PollMixin):
     def init_stats_provider(self):
         gatherer_furl = self.config.get_config("client", "stats_gatherer.furl", None)
         self.stats_provider = StatsProvider(self, gatherer_furl)
-        self.add_service(self.stats_provider)
+        self.stats_provider.setServiceParent(self)
         self.stats_provider.register_producer(self)
 
     def get_stats(self):
@@ -545,7 +545,7 @@ class _Client(node.Node, pollmixin.PollMixin):
                            expiration_override_lease_duration=o_l_d,
                            expiration_cutoff_date=cutoff_date,
                            expiration_sharetypes=expiration_sharetypes)
-        self.add_service(ss)
+        ss.setServiceParent(self)
 
         furl_file = self.config.get_private_path("storage.furl").encode(get_filesystem_encoding())
         furl = self.tub.registerReference(ss, furlFile=furl_file)
@@ -571,8 +571,12 @@ class _Client(node.Node, pollmixin.PollMixin):
         self.history = History(self.stats_provider)
         self.terminator = Terminator()
         self.terminator.setServiceParent(self)
-        self.add_service(Uploader(helper_furl, self.stats_provider,
-                                  self.history))
+        uploader = Uploader(
+            helper_furl,
+            self.stats_provider,
+            self.history,
+        )
+        uploader.setServiceParent(self)
         self.init_blacklist()
         self.init_nodemaker()
 
@@ -670,7 +674,7 @@ class _Client(node.Node, pollmixin.PollMixin):
         staticdir_config = self.config.get_config("node", "web.static", "public_html").decode("utf-8")
         staticdir = self.config.get_config_path(staticdir_config)
         ws = WebishServer(self, webport, nodeurl_path, staticdir)
-        self.add_service(ws)
+        ws.setServiceParent(self)
 
     def init_ftp_server(self):
         if self.config.get_config("ftpd", "enabled", False, boolean=True):

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -229,7 +229,7 @@ def create_client_from_config(config, _client_factory=None):
     default_connection_handlers, foolscap_connection_handlers = handlers
     tub_options = node.create_tub_options(config)
 
-    main_tub, is_listening = node.create_main_tub(
+    main_tub = node.create_main_tub(
         config, tub_options, default_connection_handlers,
         foolscap_connection_handlers, i2p_provider, tor_provider,
     )
@@ -249,7 +249,6 @@ def create_client_from_config(config, _client_factory=None):
         tor_provider,
         introducer_clients,
         storage_broker,
-        tub_is_listening=is_listening,
     )
     i2p_provider.setServiceParent(client)
     tor_provider.setServiceParent(client)
@@ -376,11 +375,11 @@ class _Client(node.Node, pollmixin.PollMixin):
                                    }
 
     def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, introducer_clients,
-                 storage_farm_broker, tub_is_listening):
+                 storage_farm_broker):
         """
         Use create_client() to instantiate one of these.
         """
-        node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, tub_is_listening)
+        node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
 
         self._magic_folders = dict()
         self.started_timestamp = time.time()
@@ -403,7 +402,7 @@ class _Client(node.Node, pollmixin.PollMixin):
         self.load_static_servers()
         self.helper = None
         if config.get_config("helper", "enabled", False, boolean=True):
-            if not self._tub_is_listening:
+            if not self._is_tub_listening():
                 raise ValueError("config error: helper is enabled, but tub "
                                  "is not listening ('tub.port=' is empty)")
             self.init_helper()
@@ -488,7 +487,7 @@ class _Client(node.Node, pollmixin.PollMixin):
         # should we run a storage server (and publish it for others to use)?
         if not self.config.get_config("storage", "enabled", True, boolean=True):
             return
-        if not self._tub_is_listening:
+        if not self._is_tub_listening():
             raise ValueError("config error: storage is enabled, but tub "
                              "is not listening ('tub.port=' is empty)")
         readonly = self.config.get_config("storage", "readonly", False, boolean=True)

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -18,7 +18,7 @@ from allmydata.immutable.offloaded import Helper
 from allmydata.control import ControlServer
 from allmydata.introducer.client import IntroducerClient
 from allmydata.util import (hashutil, base32, pollmixin, log, keyutil, idlib,
-                            yamlutil, fileutil)
+                            yamlutil)
 from allmydata.util.encodingutil import (get_filesystem_encoding,
                                          from_utf8_or_none)
 from allmydata.util.abbreviate import parse_abbreviated_size
@@ -183,7 +183,7 @@ def read_config(basedir, portnumfile, generated_files=[]):
 
 # this method is async
 # @defer.inlineCallbacks
-def create_client(basedir=u"."):
+def create_client(basedir=u".", _client_factory=None):
     """
     Creates a new client instance (a subclass of Node).
 
@@ -205,7 +205,7 @@ def create_client(basedir=u"."):
         _client_factory = _Client
 
     # read config file and create instance
-    config = read_config(basedir, u"client.port", _valid_config_sections=_valid_config_sections)
+    config = read_config(basedir, u"client.port")
     return create_client_from_config(config)  # async
 
 
@@ -220,15 +220,15 @@ def create_client_from_config(config):
     """
     i2p_provider = create_i2p_provider(reactor, config)
     tor_provider = create_tor_provider(reactor, config)
-    handlers = create_connection_handlers(reactor, config, i2p_provider, tor_provider)
+    handlers = node.create_connection_handlers(reactor, config, i2p_provider, tor_provider)
     default_connection_handlers, foolscap_connection_handlers = handlers
-    tub_options = create_tub_options(config)
+    tub_options = node.create_tub_options(config)
 
-    main_tub, is_listening = create_main_tub(
+    main_tub, is_listening = node.create_main_tub(
         config, tub_options, default_connection_handlers,
         foolscap_connection_handlers, i2p_provider, tor_provider,
     )
-    control_tub = create_control_tub()
+    control_tub = node.create_control_tub()
 
     introducer_clients, introducer_furls = create_introducer_clients(config, main_tub)
     storage_broker = create_storage_farm_broker(
@@ -319,7 +319,7 @@ def create_introducer_clients(config, main_tub):
             config.nickname,
             str(allmydata.__full_version__),
             str(_Client.OLDEST_SUPPORTED_VERSION),
-            config.get_app_versions(),
+            node.get_app_versions(),
             partial(_sequencer, config),
             introducer_cache_filepath,
         )
@@ -337,7 +337,7 @@ def create_storage_farm_broker(config, default_connection_handlers, foolscap_con
     preferred_peers = tuple([p.strip() for p in ps if p != ""])
 
     def tub_creator(handler_overrides={}, **kwargs):
-        return create_tub(
+        return node.create_tub(
             tub_options,
             default_connection_handlers,
             foolscap_connection_handlers,

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -181,8 +181,9 @@ def read_config(basedir, portnumfile, generated_files=[]):
     )
 
 
+# this method is async
 # @defer.inlineCallbacks
-def create_client(basedir=u".", _client_factory=None):
+def create_client(basedir=u"."):
     """
     Creates a new client instance (a subclass of Node).
 
@@ -195,9 +196,6 @@ def create_client(basedir=u".", _client_factory=None):
     :returns: :class:`allmydata.client._Client` instance (or whatever
         `_client_factory` returns)
     """
-    from allmydata.node import read_config, create_connection_handlers, create_tub_options
-    from allmydata.node import create_main_tub, create_control_tub, create_tub
-
     # should we check for this directory existing first? (this used to
     # be in Node's constructor)
     node.create_node_dir(basedir, CLIENT_README)
@@ -206,14 +204,20 @@ def create_client(basedir=u".", _client_factory=None):
     if _client_factory is None:
         _client_factory = _Client
 
-    # pre-requisites
+    # read config file and create instance
     config = read_config(basedir, u"client.port", _valid_config_sections=_valid_config_sections)
-    return create_client_from_config(config)
+    return create_client_from_config(config)  # async
 
 
-# this can/should be async
+# this method is async
 # @defer.inlineCallbacks
 def create_client_from_config(config):
+    """
+    Create a new _Client instance given a _Config instance (basedir
+    must already exist and be writable).
+
+    Most code should probably use `create_client` instead.
+    """
     i2p_provider = create_i2p_provider(reactor, config)
     tor_provider = create_tor_provider(reactor, config)
     handlers = create_connection_handlers(reactor, config, i2p_provider, tor_provider)
@@ -221,12 +225,12 @@ def create_client_from_config(config):
     tub_options = create_tub_options(config)
 
     main_tub, is_listening = create_main_tub(
-        basedir, config, tub_options, default_connection_handlers,
+        config, tub_options, default_connection_handlers,
         foolscap_connection_handlers, i2p_provider, tor_provider,
     )
     control_tub = create_control_tub()
 
-    introducer_clients, introducer_furls = create_introducer_clients(basedir, config, main_tub)
+    introducer_clients, introducer_furls = create_introducer_clients(config, main_tub)
     storage_broker = create_storage_farm_broker(
         config, default_connection_handlers, foolscap_connection_handlers,
         tub_options, introducer_clients
@@ -241,7 +245,6 @@ def create_client_from_config(config):
         introducer_clients,
         introducer_furls,
         storage_broker,
-        basedir,
         tub_is_listening=is_listening,
     )
     i2p_provider.setServiceParent(client)
@@ -258,42 +261,58 @@ def _sequencer(config):
         seqnum_s = "0"
     seqnum = int(seqnum_s.strip())
     seqnum += 1  # increment
-    node._write_config(config.get_config_path(), "announcement-seqnum", "%d\n" % seqnum)
+    config.write_config_file("announcement-seqnum", "{}\n".format(seqnum))
     nonce = _make_secret().strip()
     return seqnum, nonce
 
 
-def create_introducer_clients(basedir, config, main_tub):
+def create_introducer_clients(config, main_tub):
+    """
+    returns a 2-tuple containing two lists: introducer_clients,
+    introducer_furls
+    """
+    # (probably makes sense to return a list of 2-tuples instead of a
+    # 2-tuple of lists, but keeping variable names etc from when this
+    # was self.init_introducer_clients in Node)
+
     # Returns both of these:
     introducer_clients = []
     introducer_furls = []
 
-    introducers_yaml_filename = os.path.join(basedir, "private", "introducers.yaml")
+    introducers_yaml_filename = config.get_private_path("introducers.yaml")
     introducers_filepath = FilePath(introducers_yaml_filename)
 
     try:
         with introducers_filepath.open() as f:
             introducers_yaml = yamlutil.safe_load(f)
             introducers = introducers_yaml.get("introducers", {})
-            log.msg("found %d introducers in private/introducers.yaml" %
-                    len(introducers))
+            log.msg(
+                "found {} introducers in private/introducers.yaml".format(
+                    len(introducers),
+                )
+            )
     except EnvironmentError:
         introducers = {}
 
     if "default" in introducers.keys():
-        raise ValueError("'default' introducer furl cannot be specified in introducers.yaml; please fix impossible configuration.")
+        raise ValueError(
+            "'default' introducer furl cannot be specified in introducers.yaml;"
+            " please fix impossible configuration."
+        )
 
     # read furl from tahoe.cfg
     tahoe_cfg_introducer_furl = config.get_config("client", "introducer.furl", None)
     if tahoe_cfg_introducer_furl == "None":
-        raise ValueError("tahoe.cfg has invalid 'introducer.furl = None':"
-                         " to disable it, use 'introducer.furl ='"
-                         " or omit the key entirely")
+        raise ValueError(
+            "tahoe.cfg has invalid 'introducer.furl = None':"
+            " to disable it, use 'introducer.furl ='"
+            " or omit the key entirely"
+        )
     if tahoe_cfg_introducer_furl:
         introducers[u'default'] = {'furl':tahoe_cfg_introducer_furl}
 
     for petname, introducer in introducers.items():
-        introducer_cache_filepath = FilePath(os.path.join(basedir, "private", "introducer_{}_cache.yaml".format(petname)))
+        introducer_cache_filepath = FilePath(config.get_private_path("introducer_{}_cache.yaml".format(petname)))
         ic = IntroducerClient(
             main_tub,
             introducer['furl'].encode("ascii"),

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -359,12 +359,12 @@ def create_storage_farm_broker(config, default_connection_handlers, foolscap_con
     ps = config.get_config("client", "peers.preferred", "").split(",")
     preferred_peers = tuple([p.strip() for p in ps if p != ""])
 
-    def tub_creator(handler_overrides={}, **kwargs):
+    def tub_creator(handler_overrides=None, **kwargs):
         return node.create_tub(
             tub_options,
             default_connection_handlers,
             foolscap_connection_handlers,
-            handler_overrides=handler_overrides,
+            handler_overrides=handler_overrides or {},
             **kwargs
         )
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -246,6 +246,9 @@ def create_client_from_config(config):
     )
     i2p_provider.setServiceParent(client)
     tor_provider.setServiceParent(client)
+    for ic in introducer_clients:
+        ic.setServiceParent(client)
+    storage_broker.setServiceParent(client)
     return defer.succeed(client)
 
 
@@ -369,10 +372,7 @@ class _Client(node.Node, pollmixin.PollMixin):
 
         self.introducer_clients = introducer_clients
         self.introducer_furls = introducer_furls  # appears completely unused (but for tests?)
-        for ic in introducer_clients:
-            ic.setServiceParent(self)
         self.storage_broker = storage_farm_broker
-        self.storage_broker.setServiceParent(self)
 
         self.init_stats_provider()
         self.init_secrets()

--- a/src/allmydata/introducer/__init__.py
+++ b/src/allmydata/introducer/__init__.py
@@ -1,12 +1,13 @@
 
-# This is for compatibilty with old .tac files, which reference
-# allmydata.introducer.IntroducerNode
-
 from allmydata.introducer.server import create_introducer
-# apparently need to support "old .tac files" that may have this name burned in
-# don't use this in new code
+
+# apparently need to support "old .tac files" that may have
+# "allmydata.introducer.IntroducerNode" burned in -- don't use this in
+# new code
 from allmydata.introducer.server import _IntroducerNode as IntroducerNode
 
 # hush pyflakes
-_unused = [create_introducer, IntroducerNode]
-del _unused
+__all__ = (
+    "create_introducer",
+    "IntroducerNode",
+)

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -7,8 +7,6 @@ from foolscap.api import Referenceable
 import allmydata
 from allmydata import node
 from allmydata.util import log, rrefutil
-from allmydata.util import fileutil
-from allmydata.util.fileutil import abspath_expanduser_unicode
 from allmydata.util.i2p_provider import create as create_i2p_provider
 from allmydata.util.tor_provider import create as create_tor_provider
 from allmydata.introducer.interfaces import \
@@ -16,6 +14,7 @@ from allmydata.introducer.interfaces import \
 from allmydata.introducer.common import unsign_from_foolscap, \
      SubscriberDescriptor, AnnouncementDescriptor
 from allmydata.node import read_config
+from allmydata.node import create_node_dir
 from allmydata.node import create_connection_handlers
 from allmydata.node import create_control_tub
 from allmydata.node import create_tub_options

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -95,7 +95,7 @@ class _IntroducerNode(node.Node):
             raise ValueError("config error: we are Introducer, but tub "
                              "is not listening ('tub.port=' is empty)")
         introducerservice = IntroducerService()
-        self.add_service(introducerservice)
+        introducerservice.setServiceParent(self)
 
         old_public_fn = self.config.get_config_path(u"introducer.furl")
         private_fn = self.config.get_private_path(u"introducer.furl")
@@ -125,7 +125,7 @@ class _IntroducerNode(node.Node):
         config_staticdir = self.get_config("node", "web.static", "public_html").decode('utf-8')
         staticdir = self.config.get_config_path(config_staticdir)
         ws = IntroducerWebishServer(self, webport, nodeurl_path, staticdir)
-        self.add_service(ws)
+        ws.setServiceParent(self)
 
 @implementer(RIIntroducerPublisherAndSubscriberService_v2)
 class IntroducerService(service.MultiService, Referenceable):

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -59,6 +59,8 @@ def create_introducer(basedir=u"."):
     default_connection_handlers, foolscap_connection_handlers = create_connection_handlers(reactor, basedir, config, i2p_provider, tor_provider)
     tub_options = create_tub_options(config)
 
+    # we don't remember these because the Introducer doesn't make
+    # outbound connections.
     i2p_provider = None
     tor_provider = None
     main_tub, is_listening = create_main_tub(

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -62,7 +62,7 @@ def create_introducer(basedir=u"."):
     # outbound connections.
     i2p_provider = None
     tor_provider = None
-    main_tub, is_listening = create_main_tub(
+    main_tub = create_main_tub(
         config, tub_options, default_connection_handlers,
         foolscap_connection_handlers, i2p_provider, tor_provider,
     )
@@ -74,7 +74,6 @@ def create_introducer(basedir=u"."):
         control_tub,
         i2p_provider,
         tor_provider,
-        tub_is_listening=is_listening,
     )
     return defer.succeed(node)
 
@@ -82,15 +81,15 @@ def create_introducer(basedir=u"."):
 class _IntroducerNode(node.Node):
     NODETYPE = "introducer"
 
-    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, tub_is_listening):
-        node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, tub_is_listening)
+    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider):
+        node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
         self.init_introducer()
         webport = self.get_config("node", "web.port", None)
         if webport:
             self.init_web(webport) # strports string
 
     def init_introducer(self):
-        if not self._tub_is_listening:
+        if not self._is_tub_listening():
             raise ValueError("config error: we are Introducer, but tub "
                              "is not listening ('tub.port=' is empty)")
         introducerservice = IntroducerService()

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -53,10 +53,10 @@ def create_introducer(basedir=u"."):
         _valid_config_sections=_valid_config_sections,
     )
 
-    i2p_provider = create_i2p_provider(reactor, basedir, config)
-    tor_provider = create_tor_provider(reactor, basedir, config)
+    i2p_provider = create_i2p_provider(reactor, config)
+    tor_provider = create_tor_provider(reactor, config)
 
-    default_connection_handlers, foolscap_connection_handlers = create_connection_handlers(reactor, basedir, config, i2p_provider, tor_provider)
+    default_connection_handlers, foolscap_connection_handlers = create_connection_handlers(reactor, config, i2p_provider, tor_provider)
     tub_options = create_tub_options(config)
 
     # we don't remember these because the Introducer doesn't make
@@ -64,7 +64,7 @@ def create_introducer(basedir=u"."):
     i2p_provider = None
     tor_provider = None
     main_tub, is_listening = create_main_tub(
-        basedir, config, tub_options, default_connection_handlers,
+        config, tub_options, default_connection_handlers,
         foolscap_connection_handlers, i2p_provider, tor_provider,
     )
     control_tub = create_control_tub()
@@ -75,7 +75,6 @@ def create_introducer(basedir=u"."):
         control_tub,
         i2p_provider,
         tor_provider,
-        basedir,
         tub_is_listening=is_listening,
     )
     return defer.succeed(node)

--- a/src/allmydata/introducer/server.py
+++ b/src/allmydata/introducer/server.py
@@ -15,6 +15,12 @@ from allmydata.introducer.interfaces import \
      RIIntroducerPublisherAndSubscriberService_v2
 from allmydata.introducer.common import unsign_from_foolscap, \
      SubscriberDescriptor, AnnouncementDescriptor
+from allmydata.node import read_config
+from allmydata.node import create_connection_handlers
+from allmydata.node import create_control_tub
+from allmydata.node import create_tub_options
+from allmydata.node import create_main_tub
+
 
 # this is put into README in new node-directories
 INTRODUCER_README = """
@@ -37,10 +43,6 @@ class FurlFileConflictError(Exception):
 def create_introducer(basedir=u"."):
     # ideally we would pass in reactor
     from twisted.internet import reactor
-    from allmydata.node import read_config, create_connection_handlers
-    from allmydata.node import create_control_tub
-    from allmydata.node import create_tub_options, create_main_tub
-    from allmydata.node import create_node_dir
 
     if not os.path.exists(basedir):
         create_node_dir(basedir, INTRODUCER_README)
@@ -51,7 +53,6 @@ def create_introducer(basedir=u"."):
         _valid_config_sections=_valid_config_sections,
     )
 
-    # XXX fix up imports etc (also: reactor)
     i2p_provider = create_i2p_provider(reactor, basedir, config)
     tor_provider = create_tor_provider(reactor, basedir, config)
 
@@ -65,7 +66,6 @@ def create_introducer(basedir=u"."):
         foolscap_connection_handlers, i2p_provider, tor_provider,
     )
     control_tub = create_control_tub()
-
 
     node = _IntroducerNode(
         config,

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -721,16 +721,16 @@ class Node(service.MultiService):
 
         self.tub = main_tub
         if self.tub is not None:
-            self.nodeid = b32decode(self.tub.tubID.upper()) # binary format
-            self.short_nodeid = b32encode(self.nodeid).lower()[:8] # for printing
+            self.nodeid = b32decode(self.tub.tubID.upper())  # binary format
+            self.short_nodeid = b32encode(self.nodeid).lower()[:8]  # for printing
             self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
-            self.tub.setServiceParent(self)  # is this okay in __init__?
+            self.tub.setServiceParent(self)
         else:
             self.nodeid = self.short_nodeid = None
 
         self.control_tub = control_tub
         if self.control_tub is not None:
-            self.control_tub.setServiceParent(self)  # is this okay in __init__?
+            self.control_tub.setServiceParent(self)
 
         self.log("Node constructed. " + get_package_versions_string())
         iputil.increase_rlimits()

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -510,10 +510,16 @@ def _convert_tub_port(s):
     return s
 
 
-def _tub_portlocation(config, cfg_tubport, cfg_location):
-    # return None, or tuple of (port, location)
-    tubport_disabled = False
+def _tub_portlocation(config):
+    """
+    :returns: None or tuple of (port, location) for the main tub based
+        on the given configuration. May raise ValueError or PrivacyError
+        if there are problems with the config
+    """
+    cfg_tubport = config.get_config("node", "tub.port", None)
+    cfg_location = config.get_config("node", "tub.location", None)
     reveal_ip = config.get_config("node", "reveal-IP-address", True, boolean=True)
+    tubport_disabled = False
 
     if cfg_tubport is not None:
         cfg_tubport = cfg_tubport.strip()
@@ -592,9 +598,7 @@ def create_main_tub(config, tub_options,
                     default_connection_handlers, foolscap_connection_handlers,
                     i2p_provider, tor_provider,
                     handler_overrides={}, cert_filename="node.pem"):
-    cfg_tubport = config.get_config("node", "tub.port", None)
-    cfg_location = config.get_config("node", "tub.location", None)
-    portlocation = _tub_portlocation(config, cfg_tubport, cfg_location)
+    portlocation = _tub_portlocation(config)
 
     certfile = config.get_private_path("node.pem")  # FIXME? "node.pem" was the CERTFILE option/thing
     tub = create_tub(tub_options, default_connection_handlers, foolscap_connection_handlers,

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -273,12 +273,6 @@ class _Config(object):
     def validate(self, valid_config_sections):
         configutil.validate_config(self._config_fname, self.config, valid_config_sections)
 
-    def write_config_file(self, name, value, mode="w"):
-        """
-        writes the given 'value' into a file called 'name' in the config
-        directory
-        """
-        fn = os.path.join(self._basedir, name)
         try:
             fileutil.write(fn, value, mode)
         except EnvironmentError:
@@ -675,13 +669,9 @@ class Node(service.MultiService):
         self.nickname = config.nickname # XXX stopgap
 
         # this can go away once Client.init_client_storage_broker is moved into create_client()
+        # (tests sometimes have None here)
         self._i2p_provider = i2p_provider
         self._tor_provider = tor_provider
-        # tests can provide None
-        if i2p_provider:
-            self._i2p_provider.setServiceParent(self)
-        if tor_provider:
-            self._tor_provider.setServiceParent(self)
 
         self.init_tempdir()
 

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -566,7 +566,7 @@ def _tub_portlocation(config):
 
     if cfg_tubport is None:
         # For 'tub.port', tahoe.cfg overrides the individual file on
-        # disk. So only read self._portnumfile if tahoe.cfg doesn't
+        # disk. So only read config.portnum_fname if tahoe.cfg doesn't
         # provide a value.
         if os.path.exists(config.portnum_fname):
             file_tubport = fileutil.read(config.portnum_fname).strip()

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -557,6 +557,10 @@ def _tub_portlocation(config):
     else:
         tubport = _convert_tub_port(cfg_tubport)
 
+    for port in tubport.split(","):
+        if port in ("0", "tcp:0"):
+            raise ValueError("tub.port cannot be 0: you must choose")
+
     if cfg_location is None:
         cfg_location = "AUTO"
 
@@ -607,8 +611,6 @@ def create_main_tub(config, tub_options,
     if portlocation:
         tubport, location = portlocation
         for port in tubport.split(","):
-            if port in ("0", "tcp:0"):
-                raise ValueError("tub.port cannot be 0: you must choose")
             if port == "listen:i2p":
                 # the I2P provider will read its section of tahoe.cfg and
                 # return either a fully-formed Endpoint, or a descriptor

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -409,6 +409,13 @@ class _Config(object):
 
 
 def create_tub_options(config):
+    """
+    :param config: a _Config instance
+
+    :returns: dict containing all Foolscap Tub-related options,
+        overriding defaults with appropriate config from `config`
+        instance.
+    """
     # XXX this is code moved from Node -- but why are some options
     # camelCase and some snake_case? can we FIXME?
     tub_options = {
@@ -430,6 +437,9 @@ def create_tub_options(config):
 
 
 def _make_tcp_handler():
+    """
+    :returns: a Foolscap default TCP handler
+    """
     # this is always available
     from foolscap.connections.tcp import default
     return default()
@@ -488,8 +498,16 @@ def create_connection_handlers(reactor, config, i2p_provider, tor_provider):
 
 def create_tub(tub_options, default_connection_handlers, foolscap_connection_handlers,
                handler_overrides={}, **kwargs):
-    # Create a Tub with the right options and handlers. It will be
-    # ephemeral unless the caller provides certFile=
+    """
+    Create a Tub with the right options and handlers. It will be
+    ephemeral unless the caller provides certFile= in kwargs
+
+    :param handler_overrides: anything in this will override anything
+        in `default_connection_handlers` for just this call.
+
+    :param dict tub_options: every key-value pair in here will be set in
+        the new Tub via `Tub.setOption`
+    """
     tub = Tub(**kwargs)
     for (name, value) in tub_options.items():
         tub.setOption(name, value)
@@ -504,6 +522,10 @@ def create_tub(tub_options, default_connection_handlers, foolscap_connection_han
 
 
 def _convert_tub_port(s):
+    """
+    :returns: a proper Twisted endpoint string like (`tcp:X`) is `s`
+        is a bare number, or returns `s` as-is
+    """
     if re.search(r'^\d+$', s):
         return "tcp:{}".format(int(s))
     return s
@@ -601,6 +623,26 @@ def create_main_tub(config, tub_options,
                     default_connection_handlers, foolscap_connection_handlers,
                     i2p_provider, tor_provider,
                     handler_overrides={}, cert_filename="node.pem"):
+    """
+    Creates a 'main' Foolscap Tub, typically for use as the top-level
+    access point for a running Node.
+
+    :param Config: a `_Config` instance
+
+    :param dict tub_options: any options to change in the tub
+
+    :param default_connection_handlers: default Foolscap connection
+        handlers
+
+    :param foolscap_connection_handlers: Foolscap connection
+        handlers for this tub
+
+    :param i2p_provider: None, or a _Provider instance if I2P is
+        installed.
+
+    :param tor_provider: None, or a _Provider instance if txtorcon +
+        Tor are installed.
+    """
     portlocation = _tub_portlocation(config)
 
     certfile = config.get_private_path("node.pem")  # FIXME? "node.pem" was the CERTFILE option/thing
@@ -632,8 +674,11 @@ def create_main_tub(config, tub_options,
 
 
 def create_control_tub():
-    # the control port uses a localhost-only ephemeral Tub, with no
-    # control over the listening port or location
+    """
+    Creates a Foolscap Tub for use by the control port. This is a
+    localhost-only ephemeral Tub, with no control over the listening
+    port or location
+    """
     control_tub = Tub()
     portnum = iputil.allocate_tcp_port()
     port = "tcp:%d:interface=127.0.0.1" % portnum
@@ -642,7 +687,6 @@ def create_control_tub():
     control_tub.setLocation(location)
     log.msg("Control Tub location set to %s" % (location,))
     return control_tub
-
 
 
 class Node(service.MultiService):

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -788,7 +788,3 @@ class Node(service.MultiService):
 
     def log(self, *args, **kwargs):
         return log.msg(*args, **kwargs)
-
-    def add_service(self, s):
-        s.setServiceParent(self)
-        return s

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -197,6 +197,7 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config_sections
     return _Config(parser, portnumfile, basedir, config_fname)
 
 
+# XXX consider re-ordering args to match read_config()
 def config_from_string(config_str, portnumfile, basedir):
     """
     load configuration from in-memory string

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -758,7 +758,8 @@ class Node(service.MultiService):
         _assert(os.path.dirname(test_name) == tempdir, test_name, tempdir)
         os.close(temp_fd)  # avoid leak of unneeded fd
 
-    # XXX probably want to pull this outside too?
+    # pull this outside of Node's __init__ too, see:
+    # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2948
     def create_log_tub(self):
         # The logport uses a localhost-only ephemeral Tub, with no control
         # over the listening port or location. This might change if we

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -193,7 +193,6 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config_sections
     # make sure we have a private configuration area
     fileutil.make_dirs(os.path.join(basedir, "private"), 0o700)
 
-    configutil.validate_config(config_fname, parser, _valid_config_sections())
     return _Config(parser, portnumfile, basedir, config_fname)
 
 

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -196,11 +196,11 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config_sections
     return _Config(parser, portnumfile, basedir, config_fname)
 
 
-# XXX consider re-ordering args to match read_config()
-def config_from_string(config_str, portnumfile, basedir):
+def config_from_string(basedir, portnumfile, config_str):
     """
     load configuration from in-memory string
     """
+    # load configuration from in-memory string
     parser = ConfigParser.SafeConfigParser()
     parser.readfp(BytesIO(config_str))
     return _Config(parser, portnumfile, basedir, '<in-memory>')

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -416,8 +416,8 @@ def create_tub_options(config):
         overriding defaults with appropriate config from `config`
         instance.
     """
-    # XXX this is code moved from Node -- but why are some options
-    # camelCase and some snake_case? can we FIXME?
+    # We can't unify the camelCase vs. dashed-name divide here,
+    # because these are options for Foolscap
     tub_options = {
         "logLocalFailures": True,
         "logRemoteFailures": True,

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -624,15 +624,12 @@ def create_main_tub(config, tub_options,
                 port_or_endpoint = port
             tub.listenOn(port_or_endpoint)
         tub.setLocation(location)
-        tub_is_listening = True
         log.msg("Tub location set to %s" % (location,))
         # the Tub is now ready for tub.registerReference()
     else:
-        tub_is_listening = False
         log.msg("Tub is not listening")
 
-    # XXX can we get rid of the tub_is_listening part?
-    return tub, tub_is_listening
+    return tub
 
 
 def create_control_tub():
@@ -657,14 +654,13 @@ class Node(service.MultiService):
     CERTFILE = "node.pem"
     GENERATED_FILES = []
 
-    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider, tub_is_listening):
+    def __init__(self, config, main_tub, control_tub, i2p_provider, tor_provider):
         """
         Initialize the node with the given configuration. Its base directory
         is the current directory by default.
         """
         service.MultiService.__init__(self)
 
-        self._tub_is_listening = tub_is_listening  # holdover; do we really need this?
         self.config = config
         self.get_config = config.get_config # XXX stopgap
         self.nickname = config.nickname # XXX stopgap
@@ -695,6 +691,12 @@ class Node(service.MultiService):
 
         self.log("Node constructed. " + get_package_versions_string())
         iputil.increase_rlimits()
+
+    def _is_tub_listening(self):
+        """
+        :returns: True if the main tub is listening
+        """
+        return len(self.tub.getListeners()) > 0
 
     def init_tempdir(self):
         """

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -273,14 +273,6 @@ class _Config(object):
     def validate(self, valid_config_sections):
         configutil.validate_config(self._config_fname, self.config, valid_config_sections)
 
-        try:
-            fileutil.write(fn, value, mode)
-        except EnvironmentError:
-            log.err(
-                Failure(),
-                "Unable to write config file '{}'".format(fn),
-            )
-
     def write_config_file(self, name, value, mode="w"):
         """
         writes the given 'value' into a file called 'name' in the config
@@ -289,9 +281,11 @@ class _Config(object):
         fn = os.path.join(self._basedir, name)
         try:
             fileutil.write(fn, value, mode)
-        except EnvironmentError as e:
-            log.msg("Unable to write config file '{}'".format(fn))
-            log.err(e)
+        except EnvironmentError:
+            log.err(
+                Failure(),
+                "Unable to write config file '{}'".format(fn),
+            )
 
     def get_config(self, section, option, default=_None, boolean=False):
         try:

--- a/src/allmydata/scripts/tahoe_daemonize.py
+++ b/src/allmydata/scripts/tahoe_daemonize.py
@@ -154,9 +154,6 @@ class DaemonizeTheRealService(Service, HookMixin):
             d.addCallback(created)
             d.addErrback(handle_config_error)
             d.addBoth(self._call_hook, 'running')
-            # we've handled error via hook now (otherwise Twisted will
-            # want to fail some things)
-            d.addErrback(lambda _: None)
             return d
 
         from twisted.internet import reactor

--- a/src/allmydata/scripts/tahoe_daemonize.py
+++ b/src/allmydata/scripts/tahoe_daemonize.py
@@ -12,7 +12,6 @@ from allmydata.util import fileutil
 from allmydata.node import read_config
 from allmydata.util.encodingutil import listdir_unicode, quote_local_unicode_path
 from allmydata.util.configutil import UnknownConfigError
-from twisted.application.service import Service
 from allmydata.util.deferredutil import HookMixin
 
 

--- a/src/allmydata/test/check_memory.py
+++ b/src/allmydata/test/check_memory.py
@@ -163,15 +163,11 @@ class SystemFramework(pollmixin.PollMixin):
         d.addCallback(lambda res: passthrough)
         return d
 
-    def add_service(self, s):
-        s.setServiceParent(self.sparent)
-        return s
-
     def make_introducer(self):
         iv_basedir = os.path.join(self.testdir, "introducer")
         os.mkdir(iv_basedir)
-        iv = introducer.IntroducerNode(basedir=iv_basedir)
-        self.introducer = self.add_service(iv)
+        self.introducer = introducer.IntroducerNode(basedir=iv_basedir)
+        self.introducer.setServiceParent(self)
         self.introducer_furl = self.introducer.introducer_url
 
     def make_nodes(self):
@@ -201,7 +197,8 @@ class SystemFramework(pollmixin.PollMixin):
                 # so our internal nodes can refuse requests
                 f.write("readonly = true\n")
             f.close()
-            c = self.add_service(client.Client(basedir=nodedir))
+            c = client.Client(basedir=nodedir)
+            c.setServiceParent(self)
             self.nodes.append(c)
         # the peers will start running, eventually they will connect to each
         # other and the introducer

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -202,15 +202,10 @@ def create_no_network_client(basedir):
         introducer_clients=[],
         storage_farm_broker=storage_broker,
     )
-    storage_broker.client = client
-    return defer.succeed(client)
-
-#    c = yield create_client(basedir, _client_factory=_NoNetworkClient)
     # XXX we should probably make a way to pass this in instead of
     # changing it later.. also, a reference-cycle (but, existed before :/)
-#    c.storage_broker = NoNetworkStorageBroker()
-#    c.storage_broker.client = c
-#    defer.returnValue(c)
+    storage_broker.client = client
+    return defer.succeed(client)
 
 
 class _NoNetworkClient(_Client):

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -27,7 +27,6 @@ from allmydata.util.assertutil import _assert
 
 from allmydata import uri as tahoe_uri
 from allmydata.client import _Client
-from allmydata.client import create_client
 from allmydata.storage.server import StorageServer, storage_index_to_dir
 from allmydata.util import fileutil, idlib, hashutil
 from allmydata.util.hashutil import permute_server_hash

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -187,6 +187,10 @@ class NoNetworkStorageBroker(object):
 
 # @defer.inlineCallbacks
 def create_no_network_client(basedir):
+    """
+    :return: an instance of _Client subclass which does no actual
+       networking but has the same API.
+    """
     basedir = abspath_expanduser_unicode(unicode(basedir))
     fileutil.make_dirs(os.path.join(basedir, "private"), 0700)
 
@@ -209,6 +213,9 @@ def create_no_network_client(basedir):
 
 
 class _NoNetworkClient(_Client):
+    """
+    Overrides all _Client networking functionality to do nothing.
+    """
 
     def init_connections(self):
         pass

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -205,8 +205,8 @@ def create_no_network_client(basedir):
         introducer_clients=[],
         storage_farm_broker=storage_broker,
     )
-    # XXX we should probably make a way to pass this in instead of
-    # changing it later.. also, a reference-cycle (but, existed before :/)
+    # this is a (pre-existing) reference-cycle and also a bad idea, see:
+    # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2949
     storage_broker.client = client
     return defer.succeed(client)
 

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -200,7 +200,6 @@ def create_no_network_client(basedir):
         i2p_provider=None,
         tor_provider=None,
         introducer_clients=[],
-        introducer_furls=[],
         storage_farm_broker=storage_broker,
         tub_is_listening=True,
     )

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -210,9 +210,6 @@ def create_no_network_client(basedir):
 
 class _NoNetworkClient(_Client):
 
-    def _is_tub_listening(self):
-        return True
-
     def init_connections(self):
         pass
     def create_main_tub(self):

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -201,7 +201,6 @@ def create_no_network_client(basedir):
         tor_provider=None,
         introducer_clients=[],
         storage_farm_broker=storage_broker,
-        tub_is_listening=True,
     )
     storage_broker.client = client
     return defer.succeed(client)
@@ -215,6 +214,9 @@ def create_no_network_client(basedir):
 
 
 class _NoNetworkClient(_Client):
+
+    def _is_tub_listening(self):
+        return True
 
     def init_connections(self):
         pass

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -169,6 +169,8 @@ class NoNetworkServer(object):
 
 @implementer(IStorageBroker)
 class NoNetworkStorageBroker(object):
+    def setServiceParent(self, _):
+        pass
     def get_servers_for_psi(self, peer_selection_index):
         def _permuted(server):
             seed = server.get_permutation_seed()
@@ -187,7 +189,12 @@ class NoNetworkStorageBroker(object):
 
 
 def create_no_network_client(basedir):
-    return create_client(basedir, _client_factory=_NoNetworkClient)
+    c = create_client(basedir, _client_factory=_NoNetworkClient)
+    # XXX we should probably make a way to pass this in instead of
+    # changing it later.. also, a reference-cycle (but, existed before :/)
+    c.storage_broker = NoNetworkStorageBroker()
+    storage_broker.client = c
+    return c
 
 
 class _NoNetworkClient(_Client):

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -185,11 +185,10 @@ class NoNetworkStorageBroker(object):
         return []  # FIXME?
 
 
-# @defer.inlineCallbacks
 def create_no_network_client(basedir):
     """
-    :return: an instance of _Client subclass which does no actual
-       networking but has the same API.
+    :return: a Deferred yielding an instance of _Client subclass which
+        does no actual networking but has the same API.
     """
     basedir = abspath_expanduser_unicode(unicode(basedir))
     fileutil.make_dirs(os.path.join(basedir, "private"), 0700)

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -169,8 +169,6 @@ class NoNetworkServer(object):
 
 @implementer(IStorageBroker)
 class NoNetworkStorageBroker(object):
-    def setServiceParent(self, _):
-        pass
     def get_servers_for_psi(self, peer_selection_index):
         def _permuted(server):
             seed = server.get_permutation_seed()

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -39,6 +39,22 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         return client.create_client(basedir)
 
     @defer.inlineCallbacks
+    def test_unreadable_introducers(self):
+        """
+        An error when private/introducers.yaml is unreadable (but exists)
+        """
+        basedir = "test_client.Basic.test_unreadable_introduers"
+        os.mkdir(basedir, 0o700)
+        os.mkdir(os.path.join(basedir, 'private'), 0o700)
+        intro_fname = os.path.join(basedir, 'private', 'introducers.yaml')
+        with open(intro_fname, 'w') as f:
+            f.write("---\n")
+        os.chmod(intro_fname, 0o000)
+
+        with self.assertRaises(EnvironmentError):
+            yield client.create_client(basedir)
+
+    @defer.inlineCallbacks
     def test_comment(self):
         """
         test using common comment-character in furls

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -319,6 +319,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         with self.assertRaises(NeedRootcapLookupScheme):
             yield client.create_client(basedir)
 
+    @defer.inlineCallbacks
     def _storage_dir_test(self, basedir, storage_path, expected_path):
         os.mkdir(basedir)
         cfg_path = os.path.join(basedir, "tahoe.cfg")
@@ -334,7 +335,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
                 "storage_dir = %s\n" % (storage_path,),
                 mode="ab",
         )
-        c = client.create_client(basedir)
+        c = yield client.create_client(basedir)
         self.assertEqual(
             c.getServiceNamed("storage").storedir,
             expected_path,
@@ -352,7 +353,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
             abspath_expanduser_unicode(basedir),
             u"storage",
         )
-        self._storage_dir_test(
+        return self._storage_dir_test(
             basedir,
             config_path,
             expected_path,
@@ -371,7 +372,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
             abspath_expanduser_unicode(basedir),
             u"myowndir",
         )
-        self._storage_dir_test(
+        return self._storage_dir_test(
             basedir,
             config_path,
             expected_path,
@@ -394,7 +395,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
             u"client.Basic.test_absolute_storage_dir_myowndir/" + base
         )
         config_path = expected_path.encode("utf-8")
-        self._storage_dir_test(
+        return self._storage_dir_test(
             basedir,
             config_path,
             expected_path,

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -51,10 +51,10 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
         with open(intro_fname, 'w') as f:
             f.write("---\n")
         os.chmod(intro_fname, 0o000)
+        self.addCleanup(lambda: os.chmod(intro_fname, 0o700))
 
         with self.assertRaises(EnvironmentError):
             yield client.create_client(basedir)
-        os.chmod(intro_fname, 0o700)
 
     @defer.inlineCallbacks
     def test_comment(self):

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -10,6 +10,7 @@ import allmydata.frontends.magic_folder
 import allmydata.util.log
 
 from allmydata.node import OldConfigError, OldConfigOptionError, UnescapedHashError, _Config, read_config, create_node_dir
+from allmydata.node import config_from_string
 from allmydata.frontends.auth import NeedRootcapLookupScheme
 from allmydata import client
 from allmydata.storage_client import StorageFarmBroker
@@ -570,6 +571,24 @@ def flush_but_dont_ignore(res):
         return res
     d.addCallback(_done)
     return d
+
+
+class IntroducerClients(unittest.TestCase):
+
+    def test_invalid_introducer_furl(self):
+        cfg = (
+            "[client]\n"
+            "introducer.furl = None\n"
+        )
+        config = config_from_string(cfg, "client.port", "basedir")
+
+        with self.assertRaises(ValueError) as ctx:
+            client.create_introducer_clients(config, main_tub=None)
+        self.assertIn(
+            "invalid 'introducer.furl = None'",
+            str(ctx.exception)
+        )
+
 
 class Run(unittest.TestCase, testutil.StallMixin):
 

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -580,7 +580,7 @@ class IntroducerClients(unittest.TestCase):
             "[client]\n"
             "introducer.furl = None\n"
         )
-        config = config_from_string(cfg, "client.port", "basedir")
+        config = config_from_string("basedir", "client.port", cfg)
 
         with self.assertRaises(ValueError) as ctx:
             client.create_introducer_clients(config, main_tub=None)

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -41,7 +41,8 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
     @defer.inlineCallbacks
     def test_unreadable_introducers(self):
         """
-        An error when private/introducers.yaml is unreadable (but exists)
+        The Deferred from create_client fails when
+        private/introducers.yaml is unreadable (but exists)
         """
         basedir = "test_client.Basic.test_unreadable_introduers"
         os.mkdir(basedir, 0o700)
@@ -53,6 +54,7 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
         with self.assertRaises(EnvironmentError):
             yield client.create_client(basedir)
+        os.chmod(intro_fname, 0o700)
 
     @defer.inlineCallbacks
     def test_comment(self):

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -648,7 +648,8 @@ class IntroducerClients(unittest.TestCase):
 
     def test_invalid_introducer_furl(self):
         """
-        An introducer.furl of 'None' is invalid
+        An introducer.furl of 'None' is invalid and causes
+        create_introducer_clients to fail.
         """
         cfg = (
             "[client]\n"

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -59,7 +59,8 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
     @defer.inlineCallbacks
     def test_comment(self):
         """
-        test using common comment-character in furls
+        An unescaped comment character (#) in a furl results in an
+        UnescapedHashError Failure.
         """
         should_fail = [r"test#test", r"#testtest", r"test\\#test"]
         should_not_fail = [r"test\#test", r"test\\\#test", r"testtest"]

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -40,6 +40,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_comment(self):
+        """
+        test using common comment-character in furls
+        """
         should_fail = [r"test#test", r"#testtest", r"test\\#test"]
         should_not_fail = [r"test\#test", r"test\\\#test", r"testtest"]
 
@@ -134,6 +137,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_secrets(self):
+        """
+        A new client has renewal + cancel secrets
+        """
         basedir = "test_client.Basic.test_secrets"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
@@ -148,6 +154,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_nodekey_yes_storage(self):
+        """
+        We have a nodeid if we're providing storage
+        """
         basedir = "test_client.Basic.test_nodekey_yes_storage"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),
@@ -157,6 +166,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_nodekey_no_storage(self):
+        """
+        We have a nodeid if we're not providing storage
+        """
         basedir = "test_client.Basic.test_nodekey_no_storage"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),
@@ -166,6 +178,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_reserved_1(self):
+        """
+        reserved_space option is propagated
+        """
         basedir = "client.Basic.test_reserved_1"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
@@ -178,6 +193,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_reserved_2(self):
+        """
+        reserved_space option understands 'K' to mean kilobytes
+        """
         basedir = "client.Basic.test_reserved_2"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),  \
@@ -190,6 +208,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_reserved_3(self):
+        """
+        reserved_space option understands 'mB' to mean megabytes
+        """
         basedir = "client.Basic.test_reserved_3"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
@@ -203,6 +224,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_reserved_4(self):
+        """
+        reserved_space option understands 'Gb' to mean gigabytes
+        """
         basedir = "client.Basic.test_reserved_4"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
@@ -216,6 +240,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_reserved_bad(self):
+        """
+        reserved_space option produces errors on non-numbers
+        """
         basedir = "client.Basic.test_reserved_bad"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
@@ -245,6 +272,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_web_staticdir(self):
+        """
+        a relative web.static dir is expanded properly
+        """
         basedir = u"client.Basic.test_web_staticdir"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),
@@ -281,6 +311,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_ftp_auth_keyfile(self):
+        """
+        ftpd accounts.file is parsed properly
+        """
         basedir = u"client.Basic.test_ftp_auth_keyfile"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),
@@ -296,6 +329,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_ftp_auth_url(self):
+        """
+        ftpd accounts.url is parsed properly
+        """
         basedir = u"client.Basic.test_ftp_auth_url"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),
@@ -309,6 +345,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_ftp_auth_no_accountfile_or_url(self):
+        """
+        ftpd requires some way to look up accounts
+        """
         basedir = u"client.Basic.test_ftp_auth_no_accountfile_or_url"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"),
@@ -321,6 +360,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def _storage_dir_test(self, basedir, storage_path, expected_path):
+        """
+        generic helper for following storage_dir tests
+        """
         os.mkdir(basedir)
         cfg_path = os.path.join(basedir, "tahoe.cfg")
         fileutil.write(
@@ -430,6 +472,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_versions(self):
+        """
+        A client knows the versions of software it has
+        """
         basedir = "test_client.Basic.test_versions"
         os.mkdir(basedir)
         fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
@@ -453,6 +498,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_helper_furl(self):
+        """
+        various helper.furl arguments are parsed correctly
+        """
         basedir = "test_client.Basic.test_helper_furl"
         os.mkdir(basedir)
 
@@ -473,6 +521,9 @@ class Basic(testutil.ReallyEqualMixin, testutil.NonASCIIPathMixin, unittest.Test
 
     @defer.inlineCallbacks
     def test_create_magic_folder_service(self):
+        """
+        providing magic-folder options actually creates a MagicFolder service
+        """
         boom = False
         class Boom(Exception):
             pass
@@ -577,6 +628,9 @@ def flush_but_dont_ignore(res):
 class IntroducerClients(unittest.TestCase):
 
     def test_invalid_introducer_furl(self):
+        """
+        An introducer.furl of 'None' is invalid
+        """
         cfg = (
             "[client]\n"
             "introducer.furl = None\n"

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -443,29 +443,15 @@ class Privacy(unittest.TestCase):
             str(ctx.exception),
             "tub.location uses AUTO",
         )
-        return
-        n = FakeNode(BASECONFIG+"[node]\nreveal-IP-address = false\n")
-        n._portnumfile = "missing"
-        n.check_privacy()
-        e = self.assertRaises(PrivacyError, n.get_tub_portlocation,
-                              None, "AUTO")
-        self.assertEqual(str(e), "tub.location uses AUTO")
-
-        n = FakeNode(BASECONFIG+"[node]\nreveal-IP-address = false\n")
-        n._portnumfile = "missing"
-        n.check_privacy()
-        e = self.assertRaises(PrivacyError, n.get_tub_portlocation,
-                              None, "AUTO,tcp:hostname:1234")
-        self.assertEqual(str(e), "tub.location uses AUTO")
 
     def test_tub_location_tcp(self):
         config = config_from_string(
-            BASECONFIG + "[node]\nreveal-IP-address = false\n",
+            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=tcp:hostname:1234\n",
             "fake.port",
             "no-basedir",
         )
         with self.assertRaises(PrivacyError) as ctx:
-            _tub_portlocation(config, None, "tcp:hostname:1234")
+            _tub_portlocation(config)
         self.assertEqual(
             str(ctx.exception),
             "tub.location includes tcp: hint",
@@ -473,13 +459,13 @@ class Privacy(unittest.TestCase):
 
     def test_tub_location_legacy_tcp(self):
         config = config_from_string(
-            BASECONFIG + "[node]\nreveal-IP-address = false\n",
+            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=hostname:1234\n",
             "fake.port",
             "no-basedir",
         )
 
         with self.assertRaises(PrivacyError) as ctx:
-            _tub_portlocation(config, None, "hostname:1234")
+            _tub_portlocation(config)
 
         self.assertEqual(
             str(ctx.exception),

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -31,7 +31,7 @@ class TCP(unittest.TestCase):
             "fake.port",
             "no-basedir",
         )
-        _, foolscap_handlers = create_connection_handlers(None, 'basedir', config, mock.Mock(), mock.Mock())
+        _, foolscap_handlers = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertIsInstance(
             foolscap_handlers['tcp'],
             tcp.DefaultTCP,
@@ -46,7 +46,7 @@ class Tor(unittest.TestCase):
             "fake.port",
             "no-basedir",
         )
-        tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+        tor_provider = create_tor_provider(reactor, config)
         h = tor_provider.get_tor_handler()
         self.assertEqual(h, None)
 
@@ -54,7 +54,7 @@ class Tor(unittest.TestCase):
         with mock.patch("allmydata.util.tor_provider._import_tor",
                         return_value=None):
             config = config_from_string(BASECONFIG, "fake.port", "no-basedir")
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
         self.assertEqual(h, None)
 
@@ -64,7 +64,7 @@ class Tor(unittest.TestCase):
                         return_value=h1) as f:
 
             config = config_from_string(BASECONFIG, "fake.port", "no-basedir")
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
         self.assertEqual(f.mock_calls, [mock.call()])
         self.assertIdentical(h, h1)
@@ -78,8 +78,8 @@ class Tor(unittest.TestCase):
         with mock.patch("foolscap.connections.tor.control_endpoint_maker",
                         return_value=h1) as f:
 
-            config = config_from_string(config, "fake.port", "no-basedir")
-            tp = create_tor_provider("reactor", 'BASEDIR', config)
+            config = config_from_string(config, "fake.port", ".")
+            tp = create_tor_provider("reactor", config)
             h = tp.get_tor_handler()
 
             private_dir = config.get_config_path("private")
@@ -120,7 +120,7 @@ class Tor(unittest.TestCase):
                 "fake.port",
                 "no-basedir",
             )
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
         self.assertTrue(IStreamClientEndpoint.providedBy(f.mock_calls[0]))
         self.assertIdentical(h, h1)
@@ -134,7 +134,7 @@ class Tor(unittest.TestCase):
                 "fake.port",
                 "no-basedir",
             )
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
         self.assertTrue(IStreamClientEndpoint.providedBy(f.mock_calls[0]))
         self.assertIdentical(h, h1)
@@ -148,7 +148,7 @@ class Tor(unittest.TestCase):
                 "fake.port",
                 "no-basedir",
             )
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
         self.assertTrue(IStreamClientEndpoint.providedBy(f.mock_calls[0]))
         self.assertIdentical(h, h1)
@@ -160,7 +160,7 @@ class Tor(unittest.TestCase):
             "no-basedir",
         )
         with self.assertRaises(ValueError) as ctx:
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             tor_provider.get_tor_handler()
         self.assertIn(
             "Unknown endpoint type: 'meow'",
@@ -174,7 +174,7 @@ class Tor(unittest.TestCase):
             "no-basedir",
         )
         with self.assertRaises(ValueError) as ctx:
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             tor_provider.get_tor_handler()
         self.assertIn(
             "invalid literal for int() with base 10: 'kumquat'",
@@ -190,7 +190,7 @@ class Tor(unittest.TestCase):
                 "fake.port",
                 "no-basedir",
             )
-            tor_provider = create_tor_provider(reactor, 'BASEDIR', config)
+            tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
             self.assertEqual(len(f.mock_calls), 1)
             ep = f.mock_calls[0][1][0]
@@ -205,7 +205,7 @@ class I2P(unittest.TestCase):
             "fake.port",
             "no-basedir",
         )
-        i2p_provider = create_i2p_provider(None, 'BASEDIR', config)
+        i2p_provider = create_i2p_provider(None, config)
         h = i2p_provider.get_i2p_handler()
         self.assertEqual(h, None)
 
@@ -217,7 +217,7 @@ class I2P(unittest.TestCase):
         )
         with mock.patch("allmydata.util.i2p_provider._import_i2p",
                         return_value=None):
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             h = i2p_provider.get_i2p_handler()
         self.assertEqual(h, None)
 
@@ -226,7 +226,7 @@ class I2P(unittest.TestCase):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.default",
                         return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             h = i2p_provider.get_i2p_handler()
         self.assertEqual(f.mock_calls, [mock.call(reactor, keyfile=None)])
         self.assertIdentical(h, h1)
@@ -240,7 +240,7 @@ class I2P(unittest.TestCase):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.sam_endpoint",
                         return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             h = i2p_provider.get_i2p_handler()
 
         self.assertEqual(len(f.mock_calls), 1)
@@ -256,7 +256,7 @@ class I2P(unittest.TestCase):
             "no-basedir",
         )
         with self.assertRaises(ValueError) as ctx:
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             i2p_provider.get_i2p_handler()
         self.assertIn(
             "must not set both sam.port and launch",
@@ -272,7 +272,7 @@ class I2P(unittest.TestCase):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
                         return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             h = i2p_provider.get_i2p_handler()
             exp = mock.call(i2p_configdir=None, i2p_binary=None)
         self.assertEqual(f.mock_calls, [exp])
@@ -287,7 +287,7 @@ class I2P(unittest.TestCase):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
                         return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             h = i2p_provider.get_i2p_handler()
             exp = mock.call(i2p_configdir=None, i2p_binary="i2p")
         self.assertEqual(f.mock_calls, [exp])
@@ -302,7 +302,7 @@ class I2P(unittest.TestCase):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
                         return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             h = i2p_provider.get_i2p_handler()
             exp = mock.call(i2p_configdir="cfg", i2p_binary=None)
         self.assertEqual(f.mock_calls, [exp])
@@ -318,7 +318,7 @@ class I2P(unittest.TestCase):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
                         return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(reactor, config)
             h = i2p_provider.get_i2p_handler()
             exp = mock.call(i2p_configdir="cfg", i2p_binary="i2p")
         self.assertEqual(f.mock_calls, [exp])
@@ -333,7 +333,7 @@ class I2P(unittest.TestCase):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.local_i2p",
                         return_value=h1) as f:
-            i2p_provider = create_i2p_provider(None, 'BASEDIR', config)
+            i2p_provider = create_i2p_provider(None, config)
             h = i2p_provider.get_i2p_handler()
 
         self.assertEqual(f.mock_calls, [mock.call("cfg")])
@@ -346,7 +346,7 @@ class Connections(unittest.TestCase):
         self.config = config_from_string(BASECONFIG, "fake.port", self.basedir)
 
     def test_default(self):
-        default_connection_handlers, _ = create_connection_handlers(None, self.basedir, self.config, mock.Mock(), mock.Mock())
+        default_connection_handlers, _ = create_connection_handlers(None, self.config, mock.Mock(), mock.Mock())
         self.assertEqual(default_connection_handlers["tcp"], "tcp")
         self.assertEqual(default_connection_handlers["tor"], "tor")
         self.assertEqual(default_connection_handlers["i2p"], "i2p")
@@ -357,7 +357,7 @@ class Connections(unittest.TestCase):
             "fake.port",
             "no-basedir",
         )
-        default_connection_handlers, _ = create_connection_handlers(None, self.basedir, config, mock.Mock(), mock.Mock())
+        default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
 
         self.assertEqual(default_connection_handlers["tcp"], "tor")
         self.assertEqual(default_connection_handlers["tor"], "tor")
@@ -372,8 +372,8 @@ class Connections(unittest.TestCase):
                 "no-basedir",
             )
             with self.assertRaises(ValueError) as ctx:
-                tor_provider = create_tor_provider(reactor, 'BASEDIR', self.config)
-                default_connection_handlers, _ = create_connection_handlers(None, self.basedir, self.config, mock.Mock(), tor_provider)
+                tor_provider = create_tor_provider(reactor, self.config)
+                default_connection_handlers, _ = create_connection_handlers(None, self.config, mock.Mock(), tor_provider)
         self.assertEqual(
             str(ctx.exception),
             "'tahoe.cfg [connections] tcp='"
@@ -388,7 +388,7 @@ class Connections(unittest.TestCase):
             "no-basedir",
         )
         with self.assertRaises(ValueError) as ctx:
-            create_connection_handlers(None, self.basedir, config, mock.Mock(), mock.Mock())
+            create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertIn("'tahoe.cfg [connections] tcp='", str(ctx.exception))
         self.assertIn("uses unknown handler type 'unknown'", str(ctx.exception))
 
@@ -398,7 +398,7 @@ class Connections(unittest.TestCase):
             "fake.port",
             "no-basedir",
         )
-        default_connection_handlers, _ = create_connection_handlers(None, self.basedir, config, mock.Mock(), mock.Mock())
+        default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertEqual(default_connection_handlers["tcp"], None)
         self.assertEqual(default_connection_handlers["tor"], "tor")
         self.assertEqual(default_connection_handlers["i2p"], "i2p")
@@ -413,7 +413,7 @@ class Privacy(unittest.TestCase):
         )
 
         with self.assertRaises(PrivacyError) as ctx:
-            create_connection_handlers(None, 'BASEDIR', config, mock.Mock(), mock.Mock())
+            create_connection_handlers(None, config, mock.Mock(), mock.Mock())
 
         self.assertEqual(
             str(ctx.exception),
@@ -427,7 +427,7 @@ class Privacy(unittest.TestCase):
             "fake.port",
             "no-basedir",
         )
-        default_connection_handlers, _ = create_connection_handlers(None, 'BASEDIR', config, mock.Mock(), mock.Mock())
+        default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertEqual(default_connection_handlers["tcp"], None)
 
     def test_tub_location_auto(self):
@@ -438,7 +438,7 @@ class Privacy(unittest.TestCase):
         )
 
         with self.assertRaises(PrivacyError) as ctx:
-            create_main_tub('basedir', config, {}, {}, {}, mock.Mock(), mock.Mock())
+            create_main_tub(config, {}, {}, {}, mock.Mock(), mock.Mock())
         self.assertEqual(
             str(ctx.exception),
             "tub.location uses AUTO",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -12,12 +12,6 @@ from ..util.i2p_provider import create as create_i2p_provider
 from ..util.tor_provider import create as create_tor_provider
 
 
-class FakeNode(Node):
-    def __init__(self, config_str):
-        self.config = config_from_string("fake.port", "no-basedir", config_str)
-        self._reveal_ip = True
-        self.services = []
-
 BASECONFIG = ("[client]\n"
               "introducer.furl = \n"
               )

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -6,9 +6,10 @@ from twisted.internet.interfaces import IStreamClientEndpoint
 from foolscap.connections import tcp
 from ..node import Node, PrivacyError, config_from_string
 from ..node import create_connection_handlers
-from ..node import create_i2p_provider, create_tor_provider
 from ..node import create_main_tub, _tub_portlocation
 from ..util import connection_status
+from ..util.i2p_provider import create as create_i2p_provider
+from ..util.tor_provider import create as create_tor_provider
 
 
 class FakeNode(Node):

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -4,7 +4,7 @@ from twisted.trial import unittest
 from twisted.internet import reactor, endpoints, defer
 from twisted.internet.interfaces import IStreamClientEndpoint
 from foolscap.connections import tcp
-from ..node import Node, PrivacyError, config_from_string
+from ..node import PrivacyError, config_from_string
 from ..node import create_connection_handlers
 from ..node import create_main_tub, _tub_portlocation
 from ..util import connection_status

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -14,7 +14,7 @@ from ..util.tor_provider import create as create_tor_provider
 
 class FakeNode(Node):
     def __init__(self, config_str):
-        self.config = config_from_string(config_str, "fake.port", "no-basedir")
+        self.config = config_from_string("fake.port", "no-basedir", config_str)
         self._reveal_ip = True
         self.services = []
 
@@ -27,9 +27,9 @@ class TCP(unittest.TestCase):
 
     def test_default(self):
         config = config_from_string(
-            BASECONFIG,
             "fake.port",
             "no-basedir",
+            BASECONFIG,
         )
         _, foolscap_handlers = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertIsInstance(
@@ -42,9 +42,9 @@ class Tor(unittest.TestCase):
 
     def test_disabled(self):
         config = config_from_string(
-            BASECONFIG + "[tor]\nenabled = false\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[tor]\nenabled = false\n",
         )
         tor_provider = create_tor_provider(reactor, config)
         h = tor_provider.get_tor_handler()
@@ -53,7 +53,7 @@ class Tor(unittest.TestCase):
     def test_unimportable(self):
         with mock.patch("allmydata.util.tor_provider._import_tor",
                         return_value=None):
-            config = config_from_string(BASECONFIG, "fake.port", "no-basedir")
+            config = config_from_string("fake.port", "no-basedir", BASECONFIG)
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
         self.assertEqual(h, None)
@@ -63,7 +63,7 @@ class Tor(unittest.TestCase):
         with mock.patch("foolscap.connections.tor.default_socks",
                         return_value=h1) as f:
 
-            config = config_from_string(BASECONFIG, "fake.port", "no-basedir")
+            config = config_from_string("fake.port", "no-basedir", BASECONFIG)
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
         self.assertEqual(f.mock_calls, [mock.call()])
@@ -78,7 +78,7 @@ class Tor(unittest.TestCase):
         with mock.patch("foolscap.connections.tor.control_endpoint_maker",
                         return_value=h1) as f:
 
-            config = config_from_string(config, "fake.port", ".")
+            config = config_from_string("fake.port", ".", config)
             tp = create_tor_provider("reactor", config)
             h = tp.get_tor_handler()
 
@@ -116,9 +116,9 @@ class Tor(unittest.TestCase):
         with mock.patch("foolscap.connections.tor.socks_endpoint",
                         return_value=h1) as f:
             config = config_from_string(
-                BASECONFIG + "[tor]\nsocks.port = unix:/var/lib/fw-daemon/tor_socks.socket\n",
                 "fake.port",
                 "no-basedir",
+                BASECONFIG + "[tor]\nsocks.port = unix:/var/lib/fw-daemon/tor_socks.socket\n",
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -130,9 +130,9 @@ class Tor(unittest.TestCase):
         with mock.patch("foolscap.connections.tor.socks_endpoint",
                         return_value=h1) as f:
             config = config_from_string(
-                BASECONFIG + "[tor]\nsocks.port = tcp:127.0.0.1:1234\n",
                 "fake.port",
                 "no-basedir",
+                BASECONFIG + "[tor]\nsocks.port = tcp:127.0.0.1:1234\n",
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -144,9 +144,9 @@ class Tor(unittest.TestCase):
         with mock.patch("foolscap.connections.tor.socks_endpoint",
                         return_value=h1) as f:
             config = config_from_string(
-                BASECONFIG + "[tor]\nsocks.port = tcp:otherhost:1234\n",
-                "fake.port",
                 "no-basedir",
+                "fake.port",
+                BASECONFIG + "[tor]\nsocks.port = tcp:otherhost:1234\n",
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -155,9 +155,9 @@ class Tor(unittest.TestCase):
 
     def test_socksport_bad_endpoint(self):
         config = config_from_string(
-            BASECONFIG + "[tor]\nsocks.port = meow:unsupported\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[tor]\nsocks.port = meow:unsupported\n",
         )
         with self.assertRaises(ValueError) as ctx:
             tor_provider = create_tor_provider(reactor, config)
@@ -169,9 +169,9 @@ class Tor(unittest.TestCase):
 
     def test_socksport_not_integer(self):
         config = config_from_string(
-            BASECONFIG + "[tor]\nsocks.port = tcp:localhost:kumquat\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[tor]\nsocks.port = tcp:localhost:kumquat\n",
         )
         with self.assertRaises(ValueError) as ctx:
             tor_provider = create_tor_provider(reactor, config)
@@ -186,9 +186,9 @@ class Tor(unittest.TestCase):
         with mock.patch("foolscap.connections.tor.control_endpoint",
                         return_value=h1) as f:
             config = config_from_string(
-                BASECONFIG + "[tor]\ncontrol.port = tcp:localhost:1234\n",
                 "fake.port",
                 "no-basedir",
+                BASECONFIG + "[tor]\ncontrol.port = tcp:localhost:1234\n",
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -201,9 +201,9 @@ class I2P(unittest.TestCase):
 
     def test_disabled(self):
         config = config_from_string(
-            BASECONFIG + "[i2p]\nenabled = false\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[i2p]\nenabled = false\n",
         )
         i2p_provider = create_i2p_provider(None, config)
         h = i2p_provider.get_i2p_handler()
@@ -211,9 +211,9 @@ class I2P(unittest.TestCase):
 
     def test_unimportable(self):
         config = config_from_string(
-            BASECONFIG,
             "fake.port",
             "no-basedir",
+            BASECONFIG,
         )
         with mock.patch("allmydata.util.i2p_provider._import_i2p",
                         return_value=None):
@@ -222,7 +222,7 @@ class I2P(unittest.TestCase):
         self.assertEqual(h, None)
 
     def test_default(self):
-        config = config_from_string(BASECONFIG, "fake.port", "no-basedir")
+        config = config_from_string("fake.port", "no-basedir", BASECONFIG)
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.default",
                         return_value=h1) as f:
@@ -233,9 +233,9 @@ class I2P(unittest.TestCase):
 
     def test_samport(self):
         config = config_from_string(
-            BASECONFIG + "[i2p]\nsam.port = tcp:localhost:1234\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[i2p]\nsam.port = tcp:localhost:1234\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.sam_endpoint",
@@ -250,10 +250,10 @@ class I2P(unittest.TestCase):
 
     def test_samport_and_launch(self):
         config = config_from_string(
+            "no-basedir",
+            "fake.port",
             BASECONFIG + "[i2p]\n" +
             "sam.port = tcp:localhost:1234\n" + "launch = true\n",
-            "fake.port",
-            "no-basedir",
         )
         with self.assertRaises(ValueError) as ctx:
             i2p_provider = create_i2p_provider(reactor, config)
@@ -265,9 +265,9 @@ class I2P(unittest.TestCase):
 
     def test_launch(self):
         config = config_from_string(
-            BASECONFIG + "[i2p]\nlaunch = true\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[i2p]\nlaunch = true\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -280,9 +280,9 @@ class I2P(unittest.TestCase):
 
     def test_launch_executable(self):
         config = config_from_string(
-            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.executable = i2p\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.executable = i2p\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -295,9 +295,9 @@ class I2P(unittest.TestCase):
 
     def test_launch_configdir(self):
         config = config_from_string(
-            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.configdir = cfg\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.configdir = cfg\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -310,10 +310,10 @@ class I2P(unittest.TestCase):
 
     def test_launch_configdir_and_executable(self):
         config = config_from_string(
+            "no-basedir",
+            "fake.port",
             BASECONFIG + "[i2p]\nlaunch = true\n" +
             "i2p.executable = i2p\n" + "i2p.configdir = cfg\n",
-            "fake.port",
-            "no-basedir",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -326,9 +326,9 @@ class I2P(unittest.TestCase):
 
     def test_configdir(self):
         config = config_from_string(
-            BASECONFIG + "[i2p]\ni2p.configdir = cfg\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[i2p]\ni2p.configdir = cfg\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.local_i2p",
@@ -343,7 +343,7 @@ class Connections(unittest.TestCase):
 
     def setUp(self):
         self.basedir = 'BASEDIR'
-        self.config = config_from_string(BASECONFIG, "fake.port", self.basedir)
+        self.config = config_from_string("fake.port", self.basedir, BASECONFIG)
 
     def test_default(self):
         default_connection_handlers, _ = create_connection_handlers(None, self.config, mock.Mock(), mock.Mock())
@@ -353,9 +353,9 @@ class Connections(unittest.TestCase):
 
     def test_tor(self):
         config = config_from_string(
-            BASECONFIG + "[connections]\ntcp = tor\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[connections]\ntcp = tor\n",
         )
         default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
 
@@ -367,9 +367,9 @@ class Connections(unittest.TestCase):
         with mock.patch("allmydata.util.tor_provider._import_tor",
                         return_value=None):
             self.config = config_from_string(
-                BASECONFIG + "[connections]\ntcp = tor\n",
                 "fake.port",
                 "no-basedir",
+                BASECONFIG + "[connections]\ntcp = tor\n",
             )
             with self.assertRaises(ValueError) as ctx:
                 tor_provider = create_tor_provider(reactor, self.config)
@@ -383,9 +383,9 @@ class Connections(unittest.TestCase):
 
     def test_unknown(self):
         config = config_from_string(
-            BASECONFIG + "[connections]\ntcp = unknown\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[connections]\ntcp = unknown\n",
         )
         with self.assertRaises(ValueError) as ctx:
             create_connection_handlers(None, config, mock.Mock(), mock.Mock())
@@ -394,9 +394,9 @@ class Connections(unittest.TestCase):
 
     def test_tcp_disabled(self):
         config = config_from_string(
-            BASECONFIG + "[connections]\ntcp = disabled\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[connections]\ntcp = disabled\n",
         )
         default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertEqual(default_connection_handlers["tcp"], None)
@@ -407,9 +407,9 @@ class Privacy(unittest.TestCase):
 
     def test_connections(self):
         config = config_from_string(
-            BASECONFIG + "[node]\nreveal-IP-address = false\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[node]\nreveal-IP-address = false\n",
         )
 
         with self.assertRaises(PrivacyError) as ctx:
@@ -422,19 +422,19 @@ class Privacy(unittest.TestCase):
 
     def test_connections_tcp_disabled(self):
         config = config_from_string(
+            "no-basedir",
+            "fake.port",
             BASECONFIG + "[connections]\ntcp = disabled\n" +
             "[node]\nreveal-IP-address = false\n",
-            "fake.port",
-            "no-basedir",
         )
         default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertEqual(default_connection_handlers["tcp"], None)
 
     def test_tub_location_auto(self):
         config = config_from_string(
-            BASECONFIG + "[node]\nreveal-IP-address = false\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[node]\nreveal-IP-address = false\n",
         )
 
         with self.assertRaises(PrivacyError) as ctx:
@@ -446,9 +446,9 @@ class Privacy(unittest.TestCase):
 
     def test_tub_location_tcp(self):
         config = config_from_string(
-            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=tcp:hostname:1234\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=tcp:hostname:1234\n",
         )
         with self.assertRaises(PrivacyError) as ctx:
             _tub_portlocation(config)
@@ -459,9 +459,9 @@ class Privacy(unittest.TestCase):
 
     def test_tub_location_legacy_tcp(self):
         config = config_from_string(
-            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=hostname:1234\n",
             "fake.port",
             "no-basedir",
+            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=hostname:1234\n",
         )
 
         with self.assertRaises(PrivacyError) as ctx:

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -78,7 +78,7 @@ class Node(testutil.SignalMixin, testutil.ReallyEqualMixin, unittest.TestCase):
             fake_tub = Mock()
             config = read_config(basedir, "portnum")
 
-            with self.assertRaises(EnvironmentError) as ctx:
+            with self.assertRaises(EnvironmentError):
                 create_introducer_clients(config, fake_tub)
 
     @defer.inlineCallbacks

--- a/src/allmydata/test/test_multi_introducers.py
+++ b/src/allmydata/test/test_multi_introducers.py
@@ -83,7 +83,7 @@ class MultiIntroTests(unittest.TestCase):
 
         # get a client and first introducer_furl
         myclient = yield create_client(self.basedir)
-        tahoe_cfg_furl = myclient.introducer_furls[0]
+        tahoe_cfg_furl = myclient.introducer_clients[0].introducer_furl
 
         # assertions
         self.failUnlessEqual(fake_furl, tahoe_cfg_furl)
@@ -142,14 +142,14 @@ class NoDefault(unittest.TestCase):
             }}
         self.yaml_path.setContent(yamlutil.safe_dump(connections))
         myclient = yield create_client(self.basedir)
-        tahoe_cfg_furl = myclient.introducer_furls[0]
+        tahoe_cfg_furl = myclient.introducer_clients[0].introducer_furl
         self.assertEquals(tahoe_cfg_furl, 'furl1')
 
     @defer.inlineCallbacks
     def test_real_yaml(self):
         self.yaml_path.setContent(SIMPLE_YAML)
         myclient = yield create_client(self.basedir)
-        tahoe_cfg_furl = myclient.introducer_furls[0]
+        tahoe_cfg_furl = myclient.introducer_clients[0].introducer_furl
         self.assertEquals(tahoe_cfg_furl, 'furl1')
 
     @defer.inlineCallbacks
@@ -167,7 +167,7 @@ class NoDefault(unittest.TestCase):
         connections = {'introducers': {} }
         self.yaml_path.setContent(yamlutil.safe_dump(connections))
         myclient = yield create_client(self.basedir)
-        self.assertEquals(len(myclient.introducer_furls), 0)
+        self.assertEquals(len(myclient.introducer_clients), 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -606,7 +606,13 @@ class Listeners(unittest.TestCase):
 
         self.assertEqual(i2p_provider.get_listener.mock_calls, [mock.call()])
         self.assertEqual(tor_provider.get_listener.mock_calls, [mock.call()])
-##        self.assertEqual(t.listening_ports, [i2p_ep, tor_ep])
+        self.assertEqual(
+            t.listening_ports,
+            [
+                i2p_provider.get_listener(),
+                tor_provider.get_listener(),
+            ]
+        )
 
 
 class ClientNotListening(unittest.TestCase):

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -26,6 +26,8 @@ from allmydata.util import fileutil, iputil
 from allmydata.util import i2p_provider, tor_provider
 from allmydata.util.namespace import Namespace
 from allmydata.util.configutil import UnknownConfigError
+from allmydata.util.i2p_provider import create as create_i2p_provider
+from allmydata.util.tor_provider import create as create_tor_provider
 import allmydata.test.common_util as testutil
 
 
@@ -36,7 +38,6 @@ class LoggingMultiService(service.MultiService):
 
 def testing_tub(config_data=''):
     from twisted.internet import reactor
-    from allmydata.node import create_i2p_provider, create_tor_provider
     basedir = 'dummy_basedir'
     config = config_from_string(config_data, 'DEFAULT_PORTNUMFILE_BLANK', basedir)
     fileutil.make_dirs(os.path.join(basedir, 'private'))

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -673,12 +673,12 @@ class Listeners(unittest.TestCase):
 
         i2p_provider = mock.Mock()
         tor_provider = mock.Mock()
-        dfh, fch = create_connection_handlers(None, basedir, config, i2p_provider, tor_provider)
+        dfh, fch = create_connection_handlers(None, config, i2p_provider, tor_provider)
         tub_options = create_tub_options(config)
         t = FakeTub()
 
         with mock.patch("allmydata.node.Tub", return_value=t):
-            create_main_tub(basedir, config, tub_options, dfh, fch, i2p_provider, tor_provider)
+            create_main_tub(config, tub_options, dfh, fch, i2p_provider, tor_provider)
         self.assertEqual(t.listening_ports,
                          ["tcp:%d:interface=127.0.0.1" % port1,
                           "tcp:%d:interface=127.0.0.1" % port2])
@@ -713,10 +713,10 @@ class Listeners(unittest.TestCase):
         tub_options = create_tub_options(config)
         t = FakeTub()
 
-        dfh, fch = create_connection_handlers(None, basedir, config, i2p_provider, tor_provider)
+        dfh, fch = create_connection_handlers(None, config, i2p_provider, tor_provider)
 
         with mock.patch("allmydata.node.Tub", return_value=t):
-            create_main_tub(basedir, config, tub_options, dfh, fch, i2p_provider, tor_provider)
+            create_main_tub(config, tub_options, dfh, fch, i2p_provider, tor_provider)
 
         self.assertEqual(i2p_provider.get_listener.mock_calls, [mock.call()])
         self.assertEqual(tor_provider.get_listener.mock_calls, [mock.call()])

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -528,6 +528,32 @@ class FakeTub:
 
 class Listeners(unittest.TestCase):
 
+    def test_listen_on_zero(self):
+        """
+        Trying to listen on port 0 should be an error
+        """
+        basedir = self.mktemp()
+        create_node_dir(basedir, "testing")
+        with open(os.path.join(basedir, "tahoe.cfg"), "w") as f:
+            f.write(BASE_CONFIG)
+            f.write("tub.port = tcp:0\n")
+            f.write("tub.location = AUTO\n")
+
+        config = client.read_config(basedir, "client.port")
+        i2p_provider = mock.Mock()
+        tor_provider = mock.Mock()
+        dfh, fch = create_connection_handlers(None, config, i2p_provider, tor_provider)
+        tub_options = create_tub_options(config)
+        t = FakeTub()
+
+        with mock.patch("allmydata.node.Tub", return_value=t):
+            with self.assertRaises(ValueError) as ctx:
+                create_main_tub(config, tub_options, dfh, fch, i2p_provider, tor_provider)
+        self.assertIn(
+            "you must choose",
+            str(ctx.exception),
+        )
+
     def test_multiple_ports(self):
         basedir = self.mktemp()
         create_node_dir(basedir, "testing")

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -43,7 +43,7 @@ class LoggingMultiService(service.MultiService):
 def testing_tub(config_data=''):
     from twisted.internet import reactor
     basedir = 'dummy_basedir'
-    config = config_from_string(config_data, 'DEFAULT_PORTNUMFILE_BLANK', basedir)
+    config = config_from_string(basedir, 'DEFAULT_PORTNUMFILE_BLANK', config_data)
     fileutil.make_dirs(os.path.join(basedir, 'private'))
 
     i2p_provider = create_i2p_provider(reactor, config)
@@ -226,7 +226,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         f.close()
 
         basedir = fileutil.abspath_expanduser_unicode(basedir)
-        config = config_from_string("", "", basedir)
+        config = config_from_string(basedir, "", "")
 
         self.assertEqual(config.get_private_config("already"), "secret")
         self.assertEqual(config.get_private_config("not", "default"), "default")
@@ -255,7 +255,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         """
         basedir = "test_node/configdir"
         fileutil.make_dirs(basedir)
-        config = config_from_string("", "", basedir)
+        config = config_from_string(basedir, "", "")
         with open(os.path.join(basedir, "bad"), "w") as f:
             f.write("bad")
         os.chmod(os.path.join(basedir, "bad"), 0o000)
@@ -337,7 +337,7 @@ class TestMissingPorts(unittest.TestCase):
             "tub.port = tcp:777\n"
             "tub.location = AUTO\n"
         )
-        config = config_from_string(config_data, self.basedir, "portnum")
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with get_addr, alloc_port:
             tubport, tublocation = _tub_portlocation(config)
@@ -359,7 +359,7 @@ class TestMissingPorts(unittest.TestCase):
         config_data = (
             "[node]\n"
         )
-        config = config_from_string(config_data, "portnum", self.basedir)
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with get_addr, alloc_port:
             tubport, tublocation = _tub_portlocation(config)
@@ -382,7 +382,7 @@ class TestMissingPorts(unittest.TestCase):
             "[node]\n"
             "tub.location = tcp:HOST:888,AUTO\n"
         )
-        config = config_from_string(config_data, "portnum", self.basedir)
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with get_addr, alloc_port:
             tubport, tublocation = _tub_portlocation(config)
@@ -406,7 +406,7 @@ class TestMissingPorts(unittest.TestCase):
             "tub.port = disabled\n"
             "tub.location = disabled\n"
         )
-        config = config_from_string(config_data, "portnum", self.basedir)
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with get_addr, alloc_port:
             res = _tub_portlocation(config)
@@ -420,7 +420,7 @@ class TestMissingPorts(unittest.TestCase):
             "[node]\n"
             "tub.port = \n"
         )
-        config = config_from_string(config_data, "portnum", self.basedir)
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with self.assertRaises(ValueError) as ctx:
             _tub_portlocation(config)
@@ -437,7 +437,7 @@ class TestMissingPorts(unittest.TestCase):
             "[node]\n"
             "tub.location = \n"
         )
-        config = config_from_string(config_data, "portnum", self.basedir)
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with self.assertRaises(ValueError) as ctx:
             _tub_portlocation(config)
@@ -455,7 +455,7 @@ class TestMissingPorts(unittest.TestCase):
             "tub.port = disabled\n"
             "tub.location = not_disabled\n"
         )
-        config = config_from_string(config_data, "portnum", self.basedir)
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with self.assertRaises(ValueError) as ctx:
             _tub_portlocation(config)
@@ -473,7 +473,7 @@ class TestMissingPorts(unittest.TestCase):
             "tub.port = not_disabled\n"
             "tub.location = disabled\n"
         )
-        config = config_from_string(config_data, "portnum", self.basedir)
+        config = config_from_string(self.basedir, "portnum", config_data)
 
         with self.assertRaises(ValueError) as ctx:
             _tub_portlocation(config)

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -41,6 +41,9 @@ class LoggingMultiService(service.MultiService):
 
 
 def testing_tub(config_data=''):
+    """
+    Creates a 'main' Tub for testing purposes, from config data
+    """
     from twisted.internet import reactor
     basedir = 'dummy_basedir'
     config = config_from_string(basedir, 'DEFAULT_PORTNUMFILE_BLANK', config_data)

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -52,7 +52,7 @@ def testing_tub(config_data=''):
     default_connection_handlers, foolscap_connection_handlers = handlers
     tub_options = create_tub_options(config)
 
-    main_tub, is_listening = create_main_tub(
+    main_tub = create_main_tub(
         config, tub_options, default_connection_handlers,
         foolscap_connection_handlers, i2p_provider, tor_provider,
         cert_filename='DEFAULT_CERTFILE_BLANK'

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -307,7 +307,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         self.patch(foolscap.logging.log, 'setLogDir', call_setLogDir)
 
         create_node_dir(basedir, "nothing to see here")
-        c = yield client.create_client(basedir)
+        yield client.create_client(basedir)
         self.failUnless(ns.called)
 
 

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -15,15 +15,17 @@ from foolscap.api import flushEventualQueue
 import foolscap.logging.log
 
 from twisted.application import service
-from allmydata.node import create_tub_options
-from allmydata.node import create_main_tub
-from allmydata.node import create_node_dir
-from allmydata.node import create_connection_handlers
-from allmydata.node import config_from_string
-from allmydata.node import read_config
-from allmydata.node import MissingConfigEntry
-from allmydata.node import _tub_portlocation
-from allmydata.node import formatTimeTahoeStyle
+from allmydata.node import (
+    create_tub_options,
+    create_main_tub,
+    create_node_dir,
+    create_connection_handlers,
+    config_from_string,
+    read_config,
+    MissingConfigEntry,
+    _tub_portlocation,
+    formatTimeTahoeStyle,
+)
 from allmydata.introducer.server import create_introducer
 from allmydata import client
 

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -332,12 +332,15 @@ class TestMissingPorts(unittest.TestCase):
             "allmydata.util.iputil.allocate_tcp_port",
             return_value=999,
         )
-        config = read_config(self.basedir, "portnum")
+        config_data = (
+            "[node]\n"
+            "tub.port = tcp:777\n"
+            "tub.location = AUTO\n"
+        )
+        config = config_from_string(config_data, self.basedir, "portnum")
 
         with get_addr, alloc_port:
-            cfg_tubport = "tcp:777"
-            cfg_location = "AUTO"
-            tubport, tublocation = _tub_portlocation(config, cfg_tubport, cfg_location)
+            tubport, tublocation = _tub_portlocation(config)
         self.assertEqual(tubport, "tcp:777")
         self.assertEqual(tublocation, "tcp:LOCAL:777")
 
@@ -353,12 +356,13 @@ class TestMissingPorts(unittest.TestCase):
             "allmydata.util.iputil.allocate_tcp_port",
             return_value=999,
         )
-        config = read_config(self.basedir, "portnum")
+        config_data = (
+            "[node]\n"
+        )
+        config = config_from_string(config_data, "portnum", self.basedir)
 
         with get_addr, alloc_port:
-            cfg_tubport = None
-            cfg_location = None
-            tubport, tublocation = _tub_portlocation(config, cfg_tubport, cfg_location)
+            tubport, tublocation = _tub_portlocation(config)
         self.assertEqual(tubport, "tcp:999")
         self.assertEqual(tublocation, "tcp:LOCAL:999")
 
@@ -374,12 +378,14 @@ class TestMissingPorts(unittest.TestCase):
             "allmydata.util.iputil.allocate_tcp_port",
             return_value=999,
         )
-        config = read_config(self.basedir, "portnum")
+        config_data = (
+            "[node]\n"
+            "tub.location = tcp:HOST:888,AUTO\n"
+        )
+        config = config_from_string(config_data, "portnum", self.basedir)
 
         with get_addr, alloc_port:
-            cfg_tubport = None
-            cfg_location = "tcp:HOST:888,AUTO"
-            tubport, tublocation = _tub_portlocation(config, cfg_tubport, cfg_location)
+            tubport, tublocation = _tub_portlocation(config)
         self.assertEqual(tubport, "tcp:999")
         self.assertEqual(tublocation, "tcp:HOST:888,tcp:LOCAL:999")
 
@@ -395,12 +401,15 @@ class TestMissingPorts(unittest.TestCase):
             "allmydata.util.iputil.allocate_tcp_port",
             return_value=999,
         )
-        config = read_config(self.basedir, "portnum")
+        config_data = (
+            "[node]\n"
+            "tub.port = disabled\n"
+            "tub.location = disabled\n"
+        )
+        config = config_from_string(config_data, "portnum", self.basedir)
 
         with get_addr, alloc_port:
-            cfg_tubport = "disabled"
-            cfg_location = "disabled"
-            res = _tub_portlocation(config, cfg_tubport, cfg_location)
+            res = _tub_portlocation(config)
         self.assertTrue(res is None)
 
     def test_empty_tub_port(self):
@@ -414,7 +423,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            _tub_portlocation(config, "", None)
+            _tub_portlocation(config)
         self.assertIn(
             "tub.port must not be empty",
             str(ctx.exception)
@@ -431,7 +440,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            _tub_portlocation(config, None, "")
+            _tub_portlocation(config)
         self.assertIn(
             "tub.location must not be empty",
             str(ctx.exception)
@@ -449,7 +458,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            _tub_portlocation(config, "disabled", "not_disabled")
+            _tub_portlocation(config)
         self.assertIn(
             "tub.port is disabled, but not tub.location",
             str(ctx.exception)
@@ -467,7 +476,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            _tub_portlocation(config, "not_disabled", "disabled")
+            _tub_portlocation(config)
         self.assertIn(
             "tub.location is disabled, but not tub.port",
             str(ctx.exception)

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -483,7 +483,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string('', '')
         basedir = fileutil.abspath_expanduser_unicode(basedir)
         config = config_from_string('', '', basedir)
-        Node(config, None, None, None, None, basedir, False)
+        Node(config, None, None, None, None, False)
         self.failUnless(ns.called)
 
 

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -42,14 +42,14 @@ def testing_tub(config_data=''):
     config = config_from_string(config_data, 'DEFAULT_PORTNUMFILE_BLANK', basedir)
     fileutil.make_dirs(os.path.join(basedir, 'private'))
 
-    i2p_provider = create_i2p_provider(reactor, basedir, config)
-    tor_provider = create_tor_provider(reactor, basedir, config)
-    handlers = create_connection_handlers(reactor, basedir, config, i2p_provider, tor_provider)
+    i2p_provider = create_i2p_provider(reactor, config)
+    tor_provider = create_tor_provider(reactor, config)
+    handlers = create_connection_handlers(reactor, config, i2p_provider, tor_provider)
     default_connection_handlers, foolscap_connection_handlers = handlers
     tub_options = create_tub_options(config)
 
     main_tub, is_listening = create_main_tub(
-        basedir, config, tub_options, default_connection_handlers,
+        config, tub_options, default_connection_handlers,
         foolscap_connection_handlers, i2p_provider, tor_provider,
         cert_filename='DEFAULT_CERTFILE_BLANK'
     )
@@ -486,11 +486,6 @@ class TestMissingPorts(unittest.TestCase):
         Node(config, None, None, None, None, basedir, False)
         self.failUnless(ns.called)
 
-
-class EmptyNode(Node):
-    def __init__(self):
-        config = config_from_string("", "no portfile", 'no basedir')
-        Node.__init__(self, config, 'no basedir')
 
 EXPECTED = {
     # top-level key is tub.port category

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -16,14 +16,18 @@ import foolscap.logging.log
 
 from twisted.application import service
 from allmydata.node import create_tub_options
-from allmydata.node import create_tub
 from allmydata.node import create_main_tub
+from allmydata.node import create_node_dir
 from allmydata.node import create_connection_handlers
+from allmydata.node import config_from_string
+from allmydata.node import read_config
+from allmydata.node import MissingConfigEntry
+from allmydata.node import _tub_portlocation
+from allmydata.node import formatTimeTahoeStyle
 from allmydata.introducer.server import create_introducer
 from allmydata import client
 
 from allmydata.util import fileutil, iputil
-from allmydata.util import i2p_provider, tor_provider
 from allmydata.util.namespace import Namespace
 from allmydata.util.configutil import UnknownConfigError
 from allmydata.util.i2p_provider import create as create_i2p_provider
@@ -75,12 +79,11 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
 
     def _test_location(self, basedir, expected_addresses, tub_port=None, tub_location=None, local_addresses=None):
         create_node_dir(basedir, "testing")
-        with open(os.path.join(basedir, 'tahoe.cfg'), 'wt') as f:
-            f.write("[node]\n")
-            if tub_port:
-                f.write("tub.port = {}\n".format(tub_port))
-            if tub_location is not None:
-                f.write("tub.location = {}\n".format(tub_location))
+        config_data = "[node]\n"
+        if tub_port:
+            config_data += "tub.port = {}\n".format(tub_port)
+        if tub_location is not None:
+            config_data += "tub.location = {}\n".format(tub_location)
 
         if local_addresses:
             self.patch(iputil, 'get_local_addresses_sync',
@@ -292,6 +295,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         bits = stat.S_IMODE(st[stat.ST_MODE])
         self.failUnless(bits & 0001 == 0, bits)
 
+    @defer.inlineCallbacks
     def test_logdir_is_str(self):
         basedir = "test_node/test_logdir_is_str"
 
@@ -303,7 +307,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         self.patch(foolscap.logging.log, 'setLogDir', call_setLogDir)
 
         create_node_dir(basedir, "nothing to see here")
-        TestNode(basedir)
+        c = yield client.create_client(basedir)
         self.failUnless(ns.called)
 
 
@@ -331,12 +335,9 @@ class TestMissingPorts(unittest.TestCase):
         config = read_config(self.basedir, "portnum")
 
         with get_addr, alloc_port:
-            n = Node(config)
-            # could probably refactor this get_tub_portlocation into a
-            # bare helper instead of method.
             cfg_tubport = "tcp:777"
             cfg_location = "AUTO"
-            tubport, tublocation = n.get_tub_portlocation(cfg_tubport, cfg_location)
+            tubport, tublocation = _tub_portlocation(config, cfg_tubport, cfg_location)
         self.assertEqual(tubport, "tcp:777")
         self.assertEqual(tublocation, "tcp:LOCAL:777")
 
@@ -355,12 +356,9 @@ class TestMissingPorts(unittest.TestCase):
         config = read_config(self.basedir, "portnum")
 
         with get_addr, alloc_port:
-            n = Node(config)
-            # could probably refactor this get_tub_portlocation into a
-            # bare helper instead of method.
             cfg_tubport = None
             cfg_location = None
-            tubport, tublocation = n.get_tub_portlocation(cfg_tubport, cfg_location)
+            tubport, tublocation = _tub_portlocation(config, cfg_tubport, cfg_location)
         self.assertEqual(tubport, "tcp:999")
         self.assertEqual(tublocation, "tcp:LOCAL:999")
 
@@ -379,12 +377,9 @@ class TestMissingPorts(unittest.TestCase):
         config = read_config(self.basedir, "portnum")
 
         with get_addr, alloc_port:
-            n = Node(config)
-            # could probably refactor this get_tub_portlocation into a
-            # bare helper instead of method.
             cfg_tubport = None
             cfg_location = "tcp:HOST:888,AUTO"
-            tubport, tublocation = n.get_tub_portlocation(cfg_tubport, cfg_location)
+            tubport, tublocation = _tub_portlocation(config, cfg_tubport, cfg_location)
         self.assertEqual(tubport, "tcp:999")
         self.assertEqual(tublocation, "tcp:HOST:888,tcp:LOCAL:999")
 
@@ -403,12 +398,9 @@ class TestMissingPorts(unittest.TestCase):
         config = read_config(self.basedir, "portnum")
 
         with get_addr, alloc_port:
-            n = Node(config)
-            # could probably refactor this get_tub_portlocation into a
-            # bare helper instead of method.
             cfg_tubport = "disabled"
             cfg_location = "disabled"
-            res = n.get_tub_portlocation(cfg_tubport, cfg_location)
+            res = _tub_portlocation(config, cfg_tubport, cfg_location)
         self.assertTrue(res is None)
 
     def test_empty_tub_port(self):
@@ -422,7 +414,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            Node(config)
+            _tub_portlocation(config, "", None)
         self.assertIn(
             "tub.port must not be empty",
             str(ctx.exception)
@@ -439,7 +431,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            Node(config)
+            _tub_portlocation(config, None, "")
         self.assertIn(
             "tub.location must not be empty",
             str(ctx.exception)
@@ -457,7 +449,7 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            Node(config)
+            _tub_portlocation(config, "disabled", "not_disabled")
         self.assertIn(
             "tub.port is disabled, but not tub.location",
             str(ctx.exception)
@@ -475,134 +467,12 @@ class TestMissingPorts(unittest.TestCase):
         config = config_from_string(config_data, "portnum", self.basedir)
 
         with self.assertRaises(ValueError) as ctx:
-            Node(config)
+            _tub_portlocation(config, "not_disabled", "disabled")
         self.assertIn(
             "tub.location is disabled, but not tub.port",
             str(ctx.exception)
         )
-        config = config_from_string('', '')
-        basedir = fileutil.abspath_expanduser_unicode(basedir)
-        config = config_from_string('', '', basedir)
-        Node(config, None, None, None, None, False)
-        self.failUnless(ns.called)
 
-
-EXPECTED = {
-    # top-level key is tub.port category
-    "missing": {
-        # 2nd-level key is tub.location category
-        "missing": "alloc/auto",
-        "empty": "ERR2",
-        "disabled": "ERR4",
-        "hintstring": "alloc/file",
-        },
-    "empty": {
-        "missing": "ERR1",
-        "empty": "ERR1",
-        "disabled": "ERR1",
-        "hintstring": "ERR1",
-        },
-    "disabled": {
-        "missing": "ERR3",
-        "empty": "ERR2",
-        "disabled": "no-listen",
-        "hintstring": "ERR3",
-        },
-    "endpoint": {
-        "missing": "auto",
-        "empty": "ERR2",
-        "disabled": "ERR4",
-        "hintstring": "manual",
-        },
-    }
-
-class PortLocation(unittest.TestCase):
-
-    def test_all(self):
-        for tp in EXPECTED.keys():
-            for tl in EXPECTED[tp].keys():
-                exp = EXPECTED[tp][tl]
-                self._try(tp, tl, exp)
-
-    def _try(self, tp, tl, exp):
-        log.msg("PortLocation._try:", tp, tl, exp)
-        cfg_tubport = {"missing": None,
-                       "empty": "",
-                       "disabled": "disabled",
-                       "endpoint": "tcp:777",
-                       }[tp]
-        cfg_location = {"missing": None,
-                        "empty": "",
-                        "disabled": "disabled",
-                        "hintstring": "tcp:HOST:888,AUTO",
-                        }[tl]
-
-        basedir = os.path.join("test_node/portlocation/%s/%s" % (tp, tl))
-        fileutil.make_dirs(basedir)
-        config = read_config(basedir, "node.port")
-        from allmydata.node import _tub_portlocation
-
-        if exp in ("ERR1", "ERR2", "ERR3", "ERR4"):
-            with self.assertRaises(ValueError) as ctx:
-                _tub_portlocation(config, cfg_tubport, cfg_location)
-
-            if exp == "ERR1":
-                self.assertEqual(
-                    "tub.port must not be empty",
-                    str(ctx.exception),
-                )
-            elif exp == "ERR2":
-                self.assertEqual(
-                    "tub.location must not be empty",
-                    str(ctx.exception),
-                )
-            elif exp == "ERR3":
-                self.assertEqual(
-                    "tub.port is disabled, but not tub.location",
-                    str(ctx.exception),
-                )
-            elif exp == "ERR4":
-                self.assertEqual(
-                    "tub.location is disabled, but not tub.port",
-                    str(ctx.exception),
-                )
-            else:
-                self.assert_(False)
-        elif exp == "no-listen":
-            from allmydata.node import _tub_portlocation
-            res = _tub_portlocation(config, cfg_tubport, cfg_location)
-            self.assertEqual(res, None)
-        elif exp in ("alloc/auto", "alloc/file", "auto", "manual"):
-            with mock.patch("allmydata.util.iputil.get_local_addresses_sync",
-                            return_value=["LOCAL"]):
-                with mock.patch("allmydata.util.iputil.allocate_tcp_port",
-                                return_value=999):
-                    port, location = _tub_portlocation(config, cfg_tubport, cfg_location)
-            try:
-                with open(config.portnum_fname, "r") as f:
-                    saved_port = f.read().strip()
-            except EnvironmentError:
-                saved_port = None
-            if exp == "alloc/auto":
-                self.assertEqual(port, "tcp:999")
-                self.assertEqual(location, "tcp:LOCAL:999")
-                self.assertEqual(saved_port, "tcp:999")
-            elif exp == "alloc/file":
-                self.assertEqual(port, "tcp:999")
-                self.assertEqual(location, "tcp:HOST:888,tcp:LOCAL:999")
-                self.assertEqual(saved_port, "tcp:999")
-            elif exp == "auto":
-                self.assertEqual(port, "tcp:777")
-                self.assertEqual(location, "tcp:LOCAL:777")
-                self.assertEqual(saved_port, None)
-            elif exp == "manual":
-                self.assertEqual(port, "tcp:777")
-                self.assertEqual(location, "tcp:HOST:888,tcp:LOCAL:777")
-                self.assertEqual(saved_port, None)
-            else:
-                self.assert_(False)
-        else:
-            self.assert_(False)
 
 BASE_CONFIG = """
 [client]
@@ -662,10 +532,7 @@ class Listeners(unittest.TestCase):
             f.write("tub.port = %s\n" % port)
             f.write("tub.location = %s\n" % location)
 
-        # we're doing a lot of calling-into-setup-methods here, it might be
-        # better to just create a real Node instance, I'm not sure.
-        config = read_config(basedir, "client.port", _valid_config_sections=client_valid_config_sections)
-
+        config = client.read_config(basedir, "client.port")
         i2p_provider = mock.Mock()
         tor_provider = mock.Mock()
         dfh, fch = create_connection_handlers(None, config, i2p_provider, tor_provider)
@@ -687,27 +554,12 @@ class Listeners(unittest.TestCase):
             f.write(BASE_CONFIG)
             f.write("tub.port = listen:i2p,listen:tor\n")
             f.write("tub.location = tcp:example.org:1234\n")
-        # we're doing a lot of calling-into-setup-methods here, it might be
-        # better to just create a real Node instance, I'm not sure.
-        config = client.read_config(
-            basedir,
-            "client.port",
-        )
-
-        i2p_ep = object()
-        i2p_prov = i2p_provider.Provider(config, mock.Mock())
-        i2p_prov.get_listener = mock.Mock(return_value=i2p_ep)
-        i2p_x = mock.Mock()
-        i2p_x.Provider = lambda c, r: i2p_prov
-        i2p_mock = mock.patch('allmydata.node.i2p_provider', new=i2p_x)
-
-        tor_ep = object()
-
-        tor_provider.get_listener = mock.Mock(return_value=tor_ep)
-
+        config = client.read_config(basedir, "client.port")
         tub_options = create_tub_options(config)
         t = FakeTub()
 
+        i2p_provider = mock.Mock()
+        tor_provider = mock.Mock()
         dfh, fch = create_connection_handlers(None, config, i2p_provider, tor_provider)
 
         with mock.patch("allmydata.node.Tub", return_value=t):
@@ -715,7 +567,7 @@ class Listeners(unittest.TestCase):
 
         self.assertEqual(i2p_provider.get_listener.mock_calls, [mock.call()])
         self.assertEqual(tor_provider.get_listener.mock_calls, [mock.call()])
-        self.assertEqual(t.listening_ports, [i2p_ep, tor_ep])
+##        self.assertEqual(t.listening_ports, [i2p_ep, tor_ep])
 
 
 class ClientNotListening(unittest.TestCase):

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -40,6 +40,7 @@ class LoggingMultiService(service.MultiService):
         pass
 
 
+# see https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2946
 def testing_tub(config_data=''):
     """
     Creates a 'main' Tub for testing purposes, from config data

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -558,7 +558,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
                 f.write(SYSTEM_TEST_CERTS[0])
                 f.close()
         self.introducer = yield create_introducer(basedir=iv_dir)
-        self.introducer.setServiceParent(self)
+        self.introducer.setServiceParent(self.sparent)
         self._get_introducer_web()
         if use_stats_gatherer:
             yield self._set_up_stats_gatherer(None)
@@ -610,7 +610,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         fileutil.write(os.path.join(statsdir, "port"), port_endpoint)
         self.stats_gatherer_svc = StatsGathererService(statsdir)
         self.stats_gatherer = self.stats_gatherer_svc.stats_gatherer
-        self.stats_gatherer_svc.setServiceParent(self)
+        self.stats_gatherer_svc.setServiceParent(self.sparent)
 
         d = fireEventually()
         sgf = os.path.join(statsdir, 'stats_gatherer.furl')
@@ -634,7 +634,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         # start clients[0], wait for it's tub to be ready (at which point it
         # will have registered the helper furl).
         c = yield client.create_client(basedirs[0])
-        c.setServiceParent(self)
+        c.setServiceParent(self.sparent)
         self.clients.append(c)
         c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
 
@@ -652,7 +652,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         # this starts the rest of the clients
         for i in range(1, self.numclients):
             c = yield client.create_client(basedirs[i])
-            c.setServiceParent(self)
+            c.setServiceParent(self.sparent)
             self.clients.append(c)
             c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
         log.msg("STARTING")
@@ -751,7 +751,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
             new_c = yield client.create_client(self.getdir("client%d" % num))
             self.clients[num] = new_c
             new_c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
-            new_c.setServiceParent(self)
+            new_c.setServiceParent(self.sparent)
         d.addCallback(_stopped)
         d.addCallback(lambda res: self.wait_for_connections())
         def _maybe_get_webport(res):

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -557,8 +557,8 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
                 f = open(os.path.join(iv_dir, "private", "node.pem"), "w")
                 f.write(SYSTEM_TEST_CERTS[0])
                 f.close()
-        iv = yield create_introducer(basedir=iv_dir)
-        self.introducer = self.add_service(iv)
+        self.introducer = yield create_introducer(basedir=iv_dir)
+        self.introducer.setServiceParent(self)
         self._get_introducer_web()
         if use_stats_gatherer:
             yield self._set_up_stats_gatherer(None)
@@ -610,7 +610,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         fileutil.write(os.path.join(statsdir, "port"), port_endpoint)
         self.stats_gatherer_svc = StatsGathererService(statsdir)
         self.stats_gatherer = self.stats_gatherer_svc.stats_gatherer
-        self.add_service(self.stats_gatherer_svc)
+        self.stats_gatherer_svc.setServiceParent(self)
 
         d = fireEventually()
         sgf = os.path.join(statsdir, 'stats_gatherer.furl')
@@ -633,8 +633,8 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
 
         # start clients[0], wait for it's tub to be ready (at which point it
         # will have registered the helper furl).
-        the_client = yield client.create_client(basedirs[0])
-        c = self.add_service(the_client)
+        c = yield client.create_client(basedirs[0])
+        c.setServiceParent(self)
         self.clients.append(c)
         c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
 
@@ -651,8 +651,8 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
 
         # this starts the rest of the clients
         for i in range(1, self.numclients):
-            the_client = yield client.create_client(basedirs[i])
-            c = self.add_service(the_client)
+            c = yield client.create_client(basedirs[i])
+            c.setServiceParent(self)
             self.clients.append(c)
             c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
         log.msg("STARTING")
@@ -751,7 +751,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
             new_c = yield client.create_client(self.getdir("client%d" % num))
             self.clients[num] = new_c
             new_c.set_default_mutable_keysize(TEST_RSA_KEY_SIZE)
-            self.add_service(new_c)
+            new_c.setServiceParent(self)
         d.addCallback(_stopped)
         d.addCallback(lambda res: self.wait_for_connections())
         def _maybe_get_webport(res):

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -535,6 +535,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         s.setServiceParent(self.sparent)
         return s
 
+    # @inlineCallbacks
     def _create_introducer(self):
         """
         :returns: (via Deferred) an Introducer instance
@@ -557,14 +558,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
                 f = open(os.path.join(iv_dir, "private", "node.pem"), "w")
                 f.write(SYSTEM_TEST_CERTS[0])
                 f.close()
-        self.introducer = yield create_introducer(basedir=iv_dir)
-        self.introducer.setServiceParent(self.sparent)
-        self._get_introducer_web()
-        if use_stats_gatherer:
-            yield self._set_up_stats_gatherer(None)
-        yield self._set_up_nodes_2(None)
-        if use_stats_gatherer:
-            yield self._grab_stats(None)
+        return create_introducer(basedir=iv_dir)
 
     def _get_introducer_web(self):
         with open(os.path.join(self.getdir("introducer"), "node.url"), "r") as f:
@@ -592,7 +586,8 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         """
         self.numclients = NUMCLIENTS
 
-        self.introducer = self.add_service(self._create_introducer())
+        self.introducer = yield self._create_introducer()
+        self.add_service(self.introducer)
         self.introweb_url = self._get_introducer_web()
 
         if use_stats_gatherer:

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -535,7 +535,6 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
         s.setServiceParent(self.sparent)
         return s
 
-    # @inlineCallbacks
     def _create_introducer(self):
         """
         :returns: (via Deferred) an Introducer instance

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -438,6 +438,9 @@ class Provider_CheckOnionConfig(unittest.TestCase):
             )
 
     def test_no_launch_no_control(self):
+        """
+        onion=true but no way to launch/connect to tor
+        """
         with self.assertRaises(ValueError) as ctx:
             tor_provider.create("reactor", FakeConfig(onion=True))
         self.assertEqual(
@@ -446,7 +449,10 @@ class Provider_CheckOnionConfig(unittest.TestCase):
             "launch=true nor control.port="
         )
 
-    def test_missing_keys0(self):
+    def test_onion_no_local_port(self):
+        """
+        onion=true but no local_port configured is an error
+        """
         with self.assertRaises(ValueError) as ctx:
             tor_provider.create("reactor", FakeConfig(onion=True, launch=True))
         self.assertEqual(
@@ -455,7 +461,10 @@ class Provider_CheckOnionConfig(unittest.TestCase):
             "but onion.local_port= is missing"
         )
 
-    def test_missing_keys1(self):
+    def test_onion_no_external_port(self):
+        """
+        onion=true but no external_port configured is an error
+        """
         with self.assertRaises(ValueError) as ctx:
             tor_provider.create("reactor",
                                 FakeConfig(onion=True, launch=True,
@@ -466,7 +475,10 @@ class Provider_CheckOnionConfig(unittest.TestCase):
             "[tor] onion = true, but onion.external_port= is missing"
         )
 
-    def test_missing_keys2(self):
+    def test_onion_no_private_key_file(self):
+        """
+        onion=true but no private_key_file configured is an error
+        """
         with self.assertRaises(ValueError) as ctx:
             tor_provider.create("reactor",
                                 FakeConfig(onion=True, launch=True,
@@ -486,6 +498,7 @@ class Provider_CheckOnionConfig(unittest.TestCase):
                                               "onion.private_key_file": "z",
                                            }))
         p.check_onion_config()
+
 
 class Provider_Service(unittest.TestCase):
     def test_no_onion(self):

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -515,7 +515,7 @@ class Provider_Service(unittest.TestCase):
 
         txtorcon = mock.Mock()
         with mock_txtorcon(txtorcon):
-            p = tor_provider.create(reactor, basedir, cfg)
+            p = tor_provider.create(reactor, cfg)
         tor_state = mock.Mock()
         tor_state.protocol = object()
         ehs = mock.Mock()
@@ -556,7 +556,7 @@ class Provider_Service(unittest.TestCase):
 
         txtorcon = mock.Mock()
         with mock_txtorcon(txtorcon):
-            p = tor_provider.create(reactor, basedir, cfg)
+            p = tor_provider.create(reactor, cfg)
         tor_state = mock.Mock()
         tor_state.protocol = object()
         txtorcon.build_tor_connection = mock.Mock(return_value=tor_state)

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -3,7 +3,6 @@ from twisted.trial import unittest
 from foolscap.api import fireEventually, flushEventualQueue
 from twisted.internet import defer
 from allmydata.introducer import create_introducer
-from allmydata.util import fileutil
 from allmydata import node
 from .common import FAVICON_MARKUP
 from ..common_web import do_http
@@ -21,15 +20,15 @@ class IntroducerWeb(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_welcome(self):
-        config = (
-            "[node]\n"
-            "tub.location = 127.0.0.1:1\n"
-            "web.port = tcp:0\n"
-        )
         basedir = self.mktemp()
         node.create_node_dir(basedir, "testing")
+        with open(join(basedir, "tahoe.cfg"), "w") as f:
+            f.write(
+                "[node]\n"
+                "tub.location = 127.0.0.1:1\n"
+                "web.port = tcp:0\n"
+            )
 
-        from allmydata.node import config_from_string
         self.node = yield create_introducer(basedir)
         self.ws = self.node.getServiceNamed("webish")
 

--- a/src/allmydata/util/i2p_provider.py
+++ b/src/allmydata/util/i2p_provider.py
@@ -8,7 +8,7 @@ from twisted.internet.error import ConnectionRefusedError, ConnectError
 from twisted.application import service
 
 
-def create(reactor, basedir, config):
+def create(reactor, config):
     """
     Create a new Provider service (this is an IService so must be
     hooked up to a parent or otherwise started).
@@ -18,7 +18,7 @@ def create(reactor, basedir, config):
     to start an I2P Destination too, then this `create()` method will
     throw a nice error (and startService will throw an ugly error).
     """
-    provider = _Provider(basedir, config, reactor)
+    provider = _Provider(config, reactor)
     provider.check_dest_config()
     return provider
 

--- a/src/allmydata/util/tor_provider.py
+++ b/src/allmydata/util/tor_provider.py
@@ -11,7 +11,7 @@ from .observer import OneShotObserverList
 from .iputil import allocate_tcp_port
 
 
-def create(reactor, basedir, config):
+def create(reactor, config):
     """
     Create a new _Provider service (this is an IService so must be
     hooked up to a parent or otherwise started).
@@ -21,7 +21,7 @@ def create(reactor, basedir, config):
     to start an onion service too, then this `create()` method will
     throw a nice error (and startService will throw an ugly error).
     """
-    provider = _Provider(basedir, config, reactor)
+    provider = _Provider(config, reactor)
     provider.check_onion_config()
     return provider
 
@@ -266,7 +266,11 @@ class _Provider(service.MultiService):
         # this fires with a tuple of (control_endpoint, tor_protocol)
         if not self._tor_launched:
             self._tor_launched = OneShotObserverList()
+<<<<<<< HEAD
             private_dir = self._config.get_config_path("private")
+=======
+            private_dir = os.path.join(self._config._basedir, "private")
+>>>>>>> pull 'basedir' entirely into _Config
             tor_binary = self._get_tor_config("tor.executable", None)
             d = _launch_tor(reactor, tor_binary, private_dir, self._txtorcon)
             d.addBoth(self._tor_launched.fire)

--- a/src/allmydata/util/tor_provider.py
+++ b/src/allmydata/util/tor_provider.py
@@ -266,11 +266,7 @@ class _Provider(service.MultiService):
         # this fires with a tuple of (control_endpoint, tor_protocol)
         if not self._tor_launched:
             self._tor_launched = OneShotObserverList()
-<<<<<<< HEAD
             private_dir = self._config.get_config_path("private")
-=======
-            private_dir = os.path.join(self._config._basedir, "private")
->>>>>>> pull 'basedir' entirely into _Config
             tor_binary = self._get_tor_config("tor.executable", None)
             d = _launch_tor(reactor, tor_binary, private_dir, self._txtorcon)
             d.addBoth(self._tor_launched.fire)


### PR DESCRIPTION
Most-recently updated "async initializers" branch (updated/rebased versions of #525 #469 #521 et al).

This makes initialization of several core objects more "async-friendly", using a pattern of "pass in the objects required" instead of using `__init__` to create them. This allows dependency-injection for tests, and allows (possible-async) creation methods to do arbitrary work before creating `Node` and/or `Client` objects.

We don't alter *all* initializers in this PR, but make some progress on important core objects. These re-factorings are to support some "Accounting" features, ultimately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/526)
<!-- Reviewable:end -->
