### PR TITLE
Bump Fedora to 28/29 and fix virtualenv install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ workflows:
           requires:
             - "ubuntu-18.04"
 
-      - "fedora-28"
-      - "fedora-27":
+      - "fedora-29"
+      - "fedora-28":
           requires:
-            - "fedora-28"
+            - "fedora-29"
 
       - "centos-7"
 
@@ -261,8 +261,8 @@ jobs:
                 python-devel \
                 libffi-devel \
                 openssl-devel \
-                libyaml-devel \
-                python-virtualenv
+                libyaml-devel
+            dnf install /usr/bin/virtualenv
 
             # XXX net-tools is actually a Tahoe-LAFS runtime dependency!
             yum install --assumeyes \
@@ -284,16 +284,16 @@ jobs:
       - run: *SUBMIT_COVERAGE
 
 
-  fedora-27:
-    <<: *RHEL_DERIV
-    docker:
-      - image: "fedora:27"
-
-
   fedora-28:
     <<: *RHEL_DERIV
     docker:
-      - image: "fedora"
+      - image: "fedora:28"
+
+
+  fedora-29:
+    <<: *RHEL_DERIV
+    docker:
+      - image: "fedora:29"
 
 
   slackware-14.2:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ jobs:
                 libffi-devel \
                 openssl-devel \
                 libyaml-devel
-            yum install /usr/bin/virtualenv
+            yum install --assumeyes /usr/bin/virtualenv
 
             # XXX net-tools is actually a Tahoe-LAFS runtime dependency!
             yum install --assumeyes \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ jobs:
                 libffi-devel \
                 openssl-devel \
                 libyaml-devel
-            dnf install /usr/bin/virtualenv
+            yum install /usr/bin/virtualenv
 
             # XXX net-tools is actually a Tahoe-LAFS runtime dependency!
             yum install --assumeyes \

--- a/newsfragments/2955.feature
+++ b/newsfragments/2955.feature
@@ -1,0 +1,1 @@
+Fedora 29 is now tested as part of the project's continuous integration system.

--- a/newsfragments/2955.removed
+++ b/newsfragments/2955.removed
@@ -1,0 +1,1 @@
+Fedora 27 is no longer tested as part of the project's continuous integration system.


### PR DESCRIPTION
Fedora python-virtualenv package no longer provides the /usr/bin/virtualenv
executable!  Switch to using dnf to install it so we don't have to guess the
right package name.

Fixes ticket:2955

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/533)
<!-- Reviewable:end -->
