### PR TITLE
Remove the basepython declaration from the testenv

### DIFF
--- a/newsfragments/2956.other
+++ b/newsfragments/2956.other
@@ -1,0 +1,1 @@
+The Tox configuration has been fixed to work around a problem on Windows CI.

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ minversion = 2.4
 skipsdist = True
 
 [testenv]
-basepython=python2.7
 passenv = TAHOE_LAFS_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
 # Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
 # a package to be installed (with setuptools) then it'll fail on certain


### PR DESCRIPTION
This works around https://github.com/tox-dev/tox/issues/1020

Fixes ticket:2956

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/534)
<!-- Reviewable:end -->
