### PR TITLE
Bump dependency to Twisted 16.6 and add conch extra

### DIFF
--- a/newsfragments/2957.installation
+++ b/newsfragments/2957.installation
@@ -1,0 +1,1 @@
+Tahoe-LAFS now depends on Twisted 16.6 or newer.

--- a/src/allmydata/__init__.py
+++ b/src/allmydata/__init__.py
@@ -273,10 +273,38 @@ def get_package_versions_and_locations():
     return packages, cross_check_errors
 
 
+def split_requirement(req):
+    """
+    Split up a single requirement string into the different version constraint pieces.
+
+    This is like req.split(",") except it doesn't split on , found inside [].
+
+    :return: A list of the split up pieces.
+    """
+    in_extras = False
+    pieces = []
+    chunk = ''
+    for ch in req:
+        if in_extras:
+            if ch == ']':
+                in_extras = False
+            chunk += ch
+        else:
+            if ch == '[':
+                in_extras = True
+                chunk += ch
+            elif ch == ',':
+                pieces.append(chunk)
+                chunk = ''
+            else:
+                chunk += ch
+    pieces.append(chunk)
+    return pieces
+
+
 def check_requirement(req, vers_and_locs):
     # We support only conjunctions of <=, >=, and !=
-
-    reqlist = req.split(',')
+    reqlist = split_requirement(req)
     name = reqlist[0].split('<=')[0].split('>=')[0].split('!=')[0].strip(' ').split('[')[0]
     if name not in vers_and_locs:
         raise PackagingError("no version info for %s" % (name,))

--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -68,9 +68,15 @@ install_requires = [
     # * Twisted-16.1.0 fixes https://twistedmatrix.com/trac/ticket/8223,
     #   which otherwise causes test_system to fail (DirtyReactorError, due to
     #   leftover timers)
-    # * Twisted-16.4.0 instroduces twisted.trial which is needed for coverage
-    #   testing
-    "Twisted[tls] >= 16.4.0",
+    # * Twisted-16.4.0 introduces `python -m twisted.trial` which is needed
+    #   for coverage testing
+
+    # * Twisted 16.6.0 drops the undesirable gmpy dependency from the conch
+    #   extra, letting us use that extra instead of trying to duplicate its
+    #   dependencies here.  Twisted[conch] >18.7 introduces a dependency on
+    #   bcrypt.  It is nice to avoid that if the user ends up with an older
+    #   version of Twisted.  That's hard to express except by using the extra.
+    "Twisted[tls,conch] >= 16.6.0",
 
     # We need Nevow >= 0.11.1 which can be installed using pip.
     "Nevow >= 0.11.1",


### PR DESCRIPTION
This automatically brings in the bcrypt dependency coming along with a
forthcoming Twisted release.

Fixes ticket:2957

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/535)
<!-- Reviewable:end -->
