### PR TITLE
Fix pyflakes 2.1.0 warnings

### DIFF
--- a/newsfragments/2960.other
+++ b/newsfragments/2960.other
@@ -1,0 +1,1 @@
+Several warnings from a new release of pyflakes have been fixed.

--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,11 @@ setup(name="tahoe-lafs", # also set in __init__.py
       extras_require={
           ':sys_platform=="win32"': ["pypiwin32"],
           "test": [
-              "pyflakes",
+              # Pin a specific pyflakes so we don't have different folks
+              # disagreeing on what is or is not a lint issue.  We can bump
+              # this version from time to time, but we will do it
+              # intentionally.
+              "pyflakes == 2.1.0",
               "coverage",
               "mock",
               "tox",

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -1351,22 +1351,6 @@ class EqButNotIs:
         return self.x == other
 
 class DictUtil(unittest.TestCase):
-    def _help_test_empty_dict(self, klass):
-        d1 = klass()
-        d2 = klass({})
-
-        self.failUnless(d1 == d2, "d1: %r, d2: %r" % (d1, d2,))
-        self.failUnless(len(d1) == 0)
-        self.failUnless(len(d2) == 0)
-
-    def _help_test_nonempty_dict(self, klass):
-        d1 = klass({'a': 1, 'b': "eggs", 3: "spam",})
-        d2 = klass({'a': 1, 'b': "eggs", 3: "spam",})
-
-        self.failUnless(d1 == d2)
-        self.failUnless(len(d1) == 3, "%s, %s" % (len(d1), d1,))
-        self.failUnless(len(d2) == 3)
-
     def test_dict_of_sets(self):
         ds = dictutil.DictOfSets()
         ds.add(1, "a")

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -1367,55 +1367,6 @@ class DictUtil(unittest.TestCase):
         self.failUnless(len(d1) == 3, "%s, %s" % (len(d1), d1,))
         self.failUnless(len(d2) == 3)
 
-    def _help_test_eq_but_notis(self, klass):
-        d = klass({'a': 3, 'b': EqButNotIs(3), 'c': 3})
-        d.pop('b')
-
-        d.clear()
-        d['a'] = 3
-        d['b'] = EqButNotIs(3)
-        d['c'] = 3
-        d.pop('b')
-
-        d.clear()
-        d['b'] = EqButNotIs(3)
-        d['a'] = 3
-        d['c'] = 3
-        d.pop('b')
-
-        d.clear()
-        d['a'] = EqButNotIs(3)
-        d['c'] = 3
-        d['a'] = 3
-
-        d.clear()
-        fake3 = EqButNotIs(3)
-        fake7 = EqButNotIs(7)
-        d[fake3] = fake7
-        d[3] = 7
-        d[3] = 8
-        self.failUnless(filter(lambda x: x is 8,  d.itervalues()))
-        self.failUnless(filter(lambda x: x is fake7,  d.itervalues()))
-        # The real 7 should have been ejected by the d[3] = 8.
-        self.failUnless(not filter(lambda x: x is 7,  d.itervalues()))
-        self.failUnless(filter(lambda x: x is fake3,  d.iterkeys()))
-        self.failUnless(filter(lambda x: x is 3,  d.iterkeys()))
-        d[fake3] = 8
-
-        d.clear()
-        d[3] = 7
-        fake3 = EqButNotIs(3)
-        fake7 = EqButNotIs(7)
-        d[fake3] = fake7
-        d[3] = 8
-        self.failUnless(filter(lambda x: x is 8,  d.itervalues()))
-        self.failUnless(filter(lambda x: x is fake7,  d.itervalues()))
-        # The real 7 should have been ejected by the d[3] = 8.
-        self.failUnless(not filter(lambda x: x is 7,  d.itervalues()))
-        self.failUnless(filter(lambda x: x is fake3,  d.iterkeys()))
-        self.failUnless(filter(lambda x: x is 3,  d.iterkeys()))
-        d[fake3] = 8
-
     def test_dict_of_sets(self):
         ds = dictutil.DictOfSets()
         ds.add(1, "a")

--- a/src/allmydata/web/filenode.py
+++ b/src/allmydata/web/filenode.py
@@ -370,7 +370,7 @@ class FileDownloader(rend.Page):
             def parse_range(r):
                 first, last = r.split('-', 1)
 
-                if first is '':
+                if first == '':
                     # suffix-byte-range-spec
                     first = filesize - long(last)
                     last = filesize - 1
@@ -381,7 +381,7 @@ class FileDownloader(rend.Page):
                     first = long(first)
 
                     # last-byte-pos
-                    if last is '':
+                    if last == '':
                         last = filesize - 1
                     else:
                         last = long(last)


### PR DESCRIPTION
Additionally, pin the pyflakes version so we don't get surprising CI failures just because a new pyflakes is released.

Fixes: ticket:2960

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/538)
<!-- Reviewable:end -->
