### PR TITLE
Revert "Get pip 19 and pyinstaller 3.4 working together"

### DIFF
--- a/newsfragments/2958.other
+++ b/newsfragments/2958.other
@@ -1,1 +1,0 @@
-The PyInstaller CI job now works around a pip/pyinstaller incompatibility.

--- a/tox.ini
+++ b/tox.ini
@@ -118,9 +118,6 @@ commands =
          sphinx-build -b html -d {toxinidir}/docs/_build/doctrees {toxinidir}/docs {toxinidir}/docs/_build/html
 
 [testenv:pyinstaller]
-# We override this to pass --no-use-pep517 because pyinstaller (3.4, at least)
-# is broken when pep517 rules are followed.
-install_command = python -m pip --no-use-pep517 install {opts} {packages}
 extras =
 deps =
     packaging


### PR DESCRIPTION
Reverts tahoe-lafs/tahoe-lafs#536

The pyinstaller jobs are still failing.  They seem to use a version of pip that does not support the `--no-use-pep517` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/539)
<!-- Reviewable:end -->
