### PR TITLE
Fix the macOS pyinstaller travis job

### DIFF
--- a/newsfragments/2958.other
+++ b/newsfragments/2958.other
@@ -1,0 +1,1 @@
+The PyInstaller CI job now works around a pip/pyinstaller incompatibility.

--- a/tox.ini
+++ b/tox.ini
@@ -118,6 +118,9 @@ commands =
          sphinx-build -b html -d {toxinidir}/docs/_build/doctrees {toxinidir}/docs {toxinidir}/docs/_build/html
 
 [testenv:pyinstaller]
+# We override this to pass --no-use-pep517 because pyinstaller (3.4, at least)
+# is broken when this feature is enabled.
+install_command = python -m pip install --no-use-pep517 {opts} {packages}
 extras =
 deps =
     packaging


### PR DESCRIPTION
PyInstaller and the new release of pip aren't compatible.  This works around the issue.

Fixes: ticket:2958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/540)
<!-- Reviewable:end -->
