### PR TITLE
Fix CircleCI Slackware 14.2 job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,14 @@ jobs:
           name: "Install Git"
           command: |
             slackpkg update
-            slackpkg install openssh-7.4p1 git-2.14.4 </dev/null
+
+            # Be careful with slackpkg.  If the package name given doesn't
+            # match anything, slackpkg still claims to succeed but you're
+            # totally screwed.  Slackware updates versions of packaged
+            # software so including too much version prefix is a good way to
+            # have your install commands suddenly begin not installing
+            # anything.
+            slackpkg install openssh-7 git-2 </dev/null
 
       - "checkout"
 

--- a/newsfragments/2961.other
+++ b/newsfragments/2961.other
@@ -1,0 +1,1 @@
+Some Slackware 14.2 continuous integration problems have been resolved.


### PR DESCRIPTION
The version of Git available in the Slackware package repository got bumped.  This caused the overly-specific installation command to fail to install git (but not in a way we noticed).  Much later, this caused Tahoe-LAFS to be unable to determine its version string.

Fixes: ticket:2961

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/541)
<!-- Reviewable:end -->
