### PR TITLE
Return the result of the base stopService

### DIFF
--- a/newsfragments/2966.other
+++ b/newsfragments/2966.other
@@ -1,0 +1,1 @@
+The NoNetworkGrid implementation has been somewhat improved.

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -712,6 +712,8 @@ class Uploader(QueueMixin):
             d = self._notifier.wait_until_stopped()
         else:
             d = defer.succeed(None)
+        # Speed up shutdown
+        self._processing.cancel()
         # wait for processing loop to actually exit
         d.addCallback(lambda ign: self._processing)
         return d
@@ -1198,6 +1200,10 @@ class Downloader(QueueMixin, WriteFileMixin):
     def stop(self):
         self._log("stop")
         self._stopped = True
+
+        # Speed up shutdown
+        self._processing.cancel()
+
         d = defer.succeed(None)
         # wait for processing loop to actually exit
         d.addCallback(lambda ign: self._processing)

--- a/src/allmydata/test/cli/test_create_alias.py
+++ b/src/allmydata/test/cli/test_create_alias.py
@@ -33,8 +33,8 @@ class CreateAlias(GridTestMixin, CLITestMixin, unittest.TestCase):
 
         d = self.do_cli("create-alias", "tahoe")
         def _done((rc,stdout,stderr)):
-            self.failUnless("Alias 'tahoe' created" in stdout)
-            self.failIf(stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("Alias 'tahoe' created", stdout)
             aliases = get_aliases(self.get_clientdir())
             self.failUnless("tahoe" in aliases)
             self.failUnless(aliases["tahoe"].startswith("URI:DIR2:"))

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -231,7 +231,7 @@ class _NoNetworkClient(_Client):
     def startService(self):
         service.MultiService.startService(self)
     def stopService(self):
-        service.MultiService.stopService(self)
+        return service.MultiService.stopService(self)
     def init_control(self):
         pass
     def init_helper(self):

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -1448,6 +1448,9 @@ class SingleMagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, Reall
         self.local_dir = os.path.join(self.basedir, u"local_dir")
         self.mkdir_nonascii(self.local_dir)
 
+        from foolscap.eventual import flushEventualQueue
+        self.addCleanup(flushEventualQueue)
+
         d = self.create_invite_join_magic_folder(self.alice_nickname, self.local_dir)
         d.addCallback(self._restart_client)
         # note: _restart_client ultimately sets self.magicfolder to not-None

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -1448,6 +1448,15 @@ class SingleMagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, Reall
         self.local_dir = os.path.join(self.basedir, u"local_dir")
         self.mkdir_nonascii(self.local_dir)
 
+        # Magic-folder implementation somehow manages to leave a DelayedCall
+        # in the reactor from the eventual queue by the end of the test.  It
+        # may have something to do with the upload process but it's not
+        # entirely clear.  It's difficult to track things through the eventual
+        # queue.  It is almost certainly the case that some other Deferred
+        # involved in magic-folder that is already being waited on elsewhere
+        # *should* encompass this DelayedCall but I wasn't able to figure out
+        # where that association needs to be made.  So, as a work-around,
+        # explicitly flush the eventual queue at the end of the test, too.
         from foolscap.eventual import flushEventualQueue
         self.addCleanup(flushEventualQueue)
 


### PR DESCRIPTION
It is a Deferred that indicates when things have actually stopped.  Failing to
return it means callers will think everything stopped synchronously.  This is
certainly not the case.

Fixes: ticket:2966

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/543)
<!-- Reviewable:end -->
