### PR TITLE
Fix the Magic-Folder tests on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,6 +71,14 @@ artifacts:
   - path: 'dist\*'
   - path: trial_test_log.txt
     name: Trial test.log
+  - path: eliot.log
+    name: Eliot test log
+
+on_failure:
+  # Artifacts are not normally uploaded when the job fails.  To get the test
+  # logs, we have to push them ourselves.
+  - ps: Push-AppveyorArtifact _trial_temp\test.log -Filename trial.log
+  - ps: Push-AppveyorArtifact eliot.log -Filename eliot.log
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/newsfragments/2997.bugfix
+++ b/newsfragments/2997.bugfix
@@ -1,0 +1,1 @@
+The Magic-Folder frontend is now more responsive to subtree changes on Windows.

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -1153,7 +1153,7 @@ class Uploader(QueueMixin):
                     | IN_EXCL_UNLINK
                     )
         self._notifier.watch(self._local_filepath, mask=self.mask, callbacks=[self._notify],
-                             recursive=False)#True)
+                             recursive=True)
 
     def start_monitoring(self):
         action = START_MONITORING(**self._log_fields)

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -1281,7 +1281,6 @@ class Uploader(QueueMixin):
                 success_fields[u"ignored"] = True
             else:
                 self._add_pending(relpath_u)
-                self._call_hook(path, 'inotify')
 
             # Always fire the inotify hook.  If an accident of timing causes a
             # second inotify event for a particular path before the first has

--- a/src/allmydata/frontends/magic_folder.py
+++ b/src/allmydata/frontends/magic_folder.py
@@ -1282,6 +1282,12 @@ class Uploader(QueueMixin):
             else:
                 self._add_pending(relpath_u)
                 self._call_hook(path, 'inotify')
+
+            # Always fire the inotify hook.  If an accident of timing causes a
+            # second inotify event for a particular path before the first has
+            # been processed, the expectation is still that any code that was
+            # waiting for the second inotify event should be notified.
+            self._call_hook(path, 'inotify')
             action.add_success_fields(**success_fields)
 
     def _process(self, item):

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -553,7 +553,7 @@ class FileOperationsHelper(object):
         self._maybe_notify(to_fname, self._inotify.IN_MOVED_TO)
         # hmm? we weren't faking IN_MOVED_FROM previously .. but seems like we should have been?
         # self._uploader._notifier.event(to_filepath(from_fname), self._inotify.IN_MOVED_FROM)
-        return d
+        return d.addTimeout(self._timeout, reactor)
 
     @log_call_deferred(action_type=u"fileops:write")
     def write(self, path_u, contents):
@@ -575,7 +575,7 @@ class FileOperationsHelper(object):
         d = self._uploader.set_hook('inotify')
         os.mkdir(fname)
         self._maybe_notify(fname, self._inotify.IN_CREATE | self._inotify.IN_ISDIR)
-        return d
+        return d.addTimeout(self._timeout, reactor)
 
     @log_call_deferred(action_type=u"fileops:delete")
     def delete(self, path_u):

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -584,7 +584,7 @@ class FileOperationsHelper(object):
         os.unlink(fname)
 
         self._maybe_notify(fname, self._inotify.IN_DELETE)
-        return d
+        return d.addTimeout(self._timeout, reactor)
 
     def _maybe_notify(self, fname, mask):
         if self._fake_inotify:

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -1919,18 +1919,19 @@ class SingleMagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, Reall
 
     @inline_callbacks
     def test_delete_file_in_sub_directory(self):
-        relpath_u = u'subdir/some-file'
+        dmd_relpath_u = u'/'.join((u'subdir', u'some-file'))
+        platform_relpath_u = join(u'subdir', u'some-file')
         content = u'some great content'
         yield self._create_directory_with_file(
-            relpath_u,
+            platform_relpath_u,
             content,
         )
         # Delete the file in the sub-directory.
-        yield self.fileops.delete(os.path.join(self.local_dir, relpath_u))
+        yield self.fileops.delete(os.path.join(self.local_dir, platform_relpath_u))
         # Let the deletion be processed.
         yield iterate(self.magicfolder)
         # Verify the deletion was uploaded.
-        encoded_path_u = magicpath.path2magic(relpath_u)
+        encoded_path_u = magicpath.path2magic(dmd_relpath_u)
         downloader = self.magicfolder.downloader
         node, metadata = yield downloader._get_collective_latest_file(encoded_path_u)
         self.assertThat(node, Not(Is(None)))

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -536,6 +536,7 @@ class FileOperationsHelper(object):
 
     We could write this as a mixin instead; might fit existing style better?
     """
+    _timeout = 5.0
 
     def __init__(self, uploader, inject_events=False):
         self._uploader = uploader
@@ -566,7 +567,7 @@ class FileOperationsHelper(object):
             f.write(contents)
 
         self._maybe_notify(fname, self._inotify.IN_CLOSE_WRITE)
-        return d
+        return d.addTimeout(self._timeout, reactor)
 
     @log_call_deferred(action_type=u"fileops:mkdir")
     def mkdir(self, path_u):

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -1890,19 +1890,19 @@ class SingleMagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, Reall
     @inline_callbacks
     def test_create_file_in_sub_directory(self):
         reldir_u = u'subdir'
-        # Intentionally avoid doing a platform-respecting directory separator
-        # here.  _create_directory_with_file can deal with any separator.
-        # _get_collective_latest_file requires exactly / as a separator.
-        relpath_u = u'/'.join((reldir_u, u'some-file'))
+        # The OS and the DMD may have conflicting conventions for directory
+        # the separator.  Construct a value for each.
+        dmd_relpath_u = u'/'.join((reldir_u, u'some-file'))
+        platform_relpath_u = join(reldir_u, u'some-file')
         content = u'some great content'
         yield self._create_directory_with_file(
-            relpath_u,
+            platform_relpath_u,
             content,
         )
         # The new directory and file should have been noticed and uploaded.
         downloader = self.magicfolder.downloader
         encoded_dir_u = magicpath.path2magic(reldir_u + u"/")
-        encoded_path_u = magicpath.path2magic(relpath_u)
+        encoded_path_u = magicpath.path2magic(dmd_relpath_u)
 
         with start_action(action_type=u"retrieve-metadata"):
             dir_node, dir_meta = yield downloader._get_collective_latest_file(

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -1890,7 +1890,10 @@ class SingleMagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, Reall
     @inline_callbacks
     def test_create_file_in_sub_directory(self):
         reldir_u = u'subdir'
-        relpath_u = os.path.join(reldir_u, u'some-file')
+        # Intentionally avoid doing a platform-respecting directory separator
+        # here.  _create_directory_with_file can deal with any separator.
+        # _get_collective_latest_file requires exactly / as a separator.
+        relpath_u = u'/'.join((reldir_u, u'some-file'))
         content = u'some great content'
         yield self._create_directory_with_file(
             relpath_u,

--- a/src/allmydata/util/eliotutil.py
+++ b/src/allmydata/util/eliotutil.py
@@ -93,6 +93,9 @@ from twisted.application.service import Service
 from .fileutil import (
     PathInfo,
 )
+from .fake_inotify import (
+    humanReadableMask,
+)
 
 class _GeneratorContext(object):
     def __init__(self, execution_context):

--- a/src/allmydata/util/eliotutil.py
+++ b/src/allmydata/util/eliotutil.py
@@ -18,6 +18,9 @@ __all__ = [
     "opt_help_eliot_destinations",
     "validateInstanceOf",
     "validateSetMembership",
+    "MAYBE_NOTIFY",
+    "CALLBACK",
+    "INOTIFY_EVENTS",
     "RELPATH",
     "VERSION",
     "LAST_UPLOADED_URI",
@@ -54,6 +57,7 @@ from eliot import (
     ILogger,
     Message,
     Field,
+    ActionType,
     FileDestination,
     add_destinations,
     remove_destination,
@@ -268,6 +272,27 @@ PATHINFO = Field(
     },
     u"The metadata for this version of this file.",
     validateInstanceOf((type(None), PathInfo)),
+)
+
+INOTIFY_EVENTS = Field(
+    u"inotify_events",
+    humanReadableMask,
+    u"Details about a filesystem event generating a notification event.",
+    validateInstanceOf((int, long)),
+)
+
+MAYBE_NOTIFY = ActionType(
+    u"filesystem:notification:maybe-notify",
+    [],
+    [],
+    u"A filesystem event is being considered for dispatch to an application handler.",
+)
+
+CALLBACK = ActionType(
+    u"filesystem:notification:callback",
+    [INOTIFY_EVENTS],
+    [],
+    u"A filesystem event is being dispatched to an application callback."
 )
 
 def eliot_logging_service(reactor, destinations):

--- a/src/allmydata/windows/inotify.py
+++ b/src/allmydata/windows/inotify.py
@@ -5,6 +5,7 @@
 import os, sys
 
 from eliot import (
+    start_action,
     Message,
     log_call,
 )
@@ -294,14 +295,15 @@ class INotify(PollMixin):
 
             while True:
                 self._state = STARTED
-                Message.log(
-                    message_type=u"read-changes",
+                action = start_action(
+                    action_type=u"read-changes",
                     directory=self._path.path,
                     recursive=self._recursive,
                     filter=self._filter,
                 )
                 try:
-                    fni.read_changes(self._hDirectory, self._recursive, self._filter)
+                    with action:
+                        fni.read_changes(self._hDirectory, self._recursive, self._filter)
                 except WindowsError as e:
                     self._state = STOPPING
 

--- a/src/allmydata/windows/inotify.py
+++ b/src/allmydata/windows/inotify.py
@@ -5,6 +5,7 @@
 import os, sys
 
 from eliot import (
+    Message,
     log_call,
 )
 

--- a/src/allmydata/windows/inotify.py
+++ b/src/allmydata/windows/inotify.py
@@ -313,8 +313,16 @@ class INotify(PollMixin):
                     # print info
                     path = self._path.preauthChild(info.filename)  # FilePath with Unicode path
                     if info.action == FILE_ACTION_MODIFIED and path.isdir():
-                        # print "Filtering out %r" % (info,)
+                        Message.log(
+                            message_type=u"filtering-out",
+                            info=repr(info),
+                        )
                         continue
+                    else:
+                        Message.log(
+                            message_type=u"processing",
+                            info=repr(info),
+                        )
                     #mask = _action_to_inotify_mask.get(info.action, IN_CHANGED)
 
                     @log_call(

--- a/src/allmydata/windows/inotify.py
+++ b/src/allmydata/windows/inotify.py
@@ -98,8 +98,8 @@ _action_to_inotify_mask = {
 
 INVALID_HANDLE_VALUE             = 0xFFFFFFFF
 
-TRUE  = 0
-FALSE = 1
+FALSE = 0
+TRUE = 1
 
 class Event(object):
     """

--- a/src/allmydata/windows/inotify.py
+++ b/src/allmydata/windows/inotify.py
@@ -272,6 +272,12 @@ class INotify(PollMixin):
 
             while True:
                 self._state = STARTED
+                Message.log(
+                    message_type=u"read-changes",
+                    directory=self._path.path,
+                    recursive=self._recursive,
+                    filter=self._filter,
+                )
                 try:
                     fni.read_changes(self._hDirectory, self._recursive, self._filter)
                 except WindowsError as e:

--- a/src/allmydata/windows/inotify.py
+++ b/src/allmydata/windows/inotify.py
@@ -187,7 +187,7 @@ def _open_directory(path_u):
 def simple_test():
     path_u = u"test"
     filter = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE
-    recursive = FALSE
+    recursive = TRUE
 
     hDirectory = _open_directory(path_u)
     fni = FileNotifyInformation()
@@ -197,6 +197,27 @@ def simple_test():
         print repr(fni.data)
         for info in fni:
             print info
+
+def medium_test():
+    from twisted.python.filepath import FilePath
+
+    def print_(*event):
+        print(event)
+
+    notifier = INotify()
+    notifier.set_pending_delay(1.0)
+    IN_EXCL_UNLINK = 0x04000000L
+    mask = (  IN_CREATE
+            | IN_CLOSE_WRITE
+            | IN_MOVED_TO
+            | IN_MOVED_FROM
+            | IN_DELETE
+            | IN_ONLYDIR
+            | IN_EXCL_UNLINK
+    )
+    notifier.watch(FilePath(u"test"), mask, callbacks=[print_], recursive=True)
+    notifier.startReading()
+    reactor.run()
 
 
 NOT_STARTED = "NOT_STARTED"


### PR DESCRIPTION
Fixes: ticket:2997

Note there were some tests failing due to path handling issues which are also fixed here.  However, the really interesting thing is the TRUE/FALSE issue which actually caused a significant functional regression on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/570)
<!-- Reviewable:end -->
