### PR TITLE
GitHub-detectable contributor guidelines

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -1,0 +1,20 @@
+.. -*- coding: utf-8 -*-
+
+.. This document is rendered on the GitHub PR creation page to guide
+   contributors.  It is also rendered into the overall documentation.
+
+Contributing to Tahoe-LAFS
+==========================
+
+As an open source project,
+Tahoe-LAFS welcomes contributions of many forms.
+
+Examples of contributions include:
+
+* `Code patches <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Patches>`_
+* `Documentation improvements <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Doc>`_
+* `Bug reports <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug>`_
+* `Patch reviews <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/PatchReviewProcess>`_
+
+Before authoring or reviewing a patch,
+please familiarize yourself with the `coding standard <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/CodingStandards>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Contents:
    frontends/download-status
 
    known_issues
+   ../.github/CONTRIBUTING
 
    servers
    helper
@@ -64,4 +65,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/newsfragments/3003.other
+++ b/newsfragments/3003.other
@@ -1,0 +1,1 @@
+The contributor guidelines are now linked from the GitHub pull request creation page.


### PR DESCRIPTION
Fixes: ticket:3003

Not sure what to make of the fact that GitHub didn't link to this doc from this very PR creation page.  Perhaps it has to be in master?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/573)
<!-- Reviewable:end -->
