### PR TITLE
removed use of backticks for repr for python3 compatibility

### DIFF
--- a/newsfragments/3027.other
+++ b/newsfragments/3027.other
@@ -1,0 +1,1 @@
+Removed used of backticks for "repr" for Python3 compatibility.

--- a/src/allmydata/test/test_base62.py
+++ b/src/allmydata/test/test_base62.py
@@ -12,7 +12,7 @@ class T(unittest.TestCase):
     def _test_ende(self, bs):
         ascii=base62.b2a(bs)
         bs2=base62.a2b(ascii)
-        assert bs2 == bs, "bs2: %s:%s, bs: %s:%s, ascii: %s:%s" % (len(bs2), `bs2`, len(bs), `bs`, len(ascii), `ascii`)
+        assert bs2 == bs, "bs2: %s:%s, bs: %s:%s, ascii: %s:%s" % (len(bs2), repr(bs2), len(bs), repr(bs), len(ascii), repr(ascii))
 
     def test_num_octets_that_encode_to_this_many_chars(self):
         return self._test_num_octets_that_encode_to_this_many_chars(2, 1)

--- a/src/allmydata/util/humanreadable.py
+++ b/src/allmydata/util/humanreadable.py
@@ -26,7 +26,7 @@ class BetterRepr(Repr):
             return '<' + obj.im_class.__name__ + '.' + obj.im_func.__name__ + '() at (builtin)'
 
     def repr_long(self, obj, level):
-        s = `obj` # XXX Hope this isn't too slow...
+        s = repr(obj) # XXX Hope this isn't too slow...
         if len(s) > self.maxlong:
             i = max(0, (self.maxlong-3)/2)
             j = max(0, self.maxlong-3-i)


### PR DESCRIPTION
Fixes: ticket:3027

https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3027#ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/602)
<!-- Reviewable:end -->