### PR TITLE
Storage client abstraction

### DIFF
--- a/src/allmydata/control.py
+++ b/src/allmydata/control.py
@@ -123,9 +123,9 @@ class ControlServer(Referenceable, service.Service):
             return results
         server = everyone_left.pop(0)
         server_name = server.get_longname()
-        connection = server.get_rref()
+        storage_server = server.get_storage_server()
         start = time.time()
-        d = connection.callRemote("get_buckets", "\x00"*16)
+        d = storage_server.get_buckets("\x00" * 16)
         def _done(ignored):
             stop = time.time()
             elapsed = stop - start

--- a/src/allmydata/immutable/checker.py
+++ b/src/allmydata/immutable/checker.py
@@ -496,16 +496,19 @@ class Checker(log.PrefixingLogMixin):
         that we want to track and report whether or not each server
         responded.)"""
 
-        rref = s.get_rref()
+        storage_server = s.get_storage_server()
         lease_seed = s.get_lease_seed()
         if self._add_lease:
             renew_secret = self._get_renewal_secret(lease_seed)
             cancel_secret = self._get_cancel_secret(lease_seed)
-            d2 = rref.callRemote("add_lease", storageindex,
-                                 renew_secret, cancel_secret)
+            d2 = storage_server.add_lease(
+                storageindex,
+                renew_secret,
+                cancel_secret,
+            )
             d2.addErrback(self._add_lease_failed, s.get_name(), storageindex)
 
-        d = rref.callRemote("get_buckets", storageindex)
+        d = storage_server.get_buckets(storageindex)
         def _wrap_results(res):
             return (res, True)
 

--- a/src/allmydata/immutable/downloader/finder.py
+++ b/src/allmydata/immutable/downloader/finder.py
@@ -139,7 +139,7 @@ class ShareFinder(object):
         # TODO: get the timer from a Server object, it knows best
         self.overdue_timers[req] = reactor.callLater(self.OVERDUE_TIMEOUT,
                                                      self.overdue, req)
-        d = server.get_rref().callRemote("get_buckets", self._storage_index)
+        d = server.get_storage_server().get_buckets(self._storage_index)
         d.addBoth(incidentally, self._request_retired, req)
         d.addCallbacks(self._got_response, self._got_error,
                        callbackArgs=(server, req, d_ev, time_sent, lp),
@@ -221,5 +221,3 @@ class ShareFinder(object):
         self.log(format="got error from [%(name)s]",
                  name=server.get_name(), failure=f,
                  level=log.UNUSUAL, parent=lp, umid="zUKdCw")
-
-

--- a/src/allmydata/immutable/offloaded.py
+++ b/src/allmydata/immutable/offloaded.py
@@ -54,7 +54,7 @@ class CHKCheckerAndUEBFetcher(object):
     def _get_all_shareholders(self, storage_index):
         dl = []
         for s in self._peer_getter(storage_index):
-            d = s.get_rref().callRemote("get_buckets", storage_index)
+            d = s.get_storage_server().get_buckets(storage_index)
             d.addCallbacks(self._got_response, self._got_error,
                            callbackArgs=(s,))
             dl.append(d)

--- a/src/allmydata/immutable/upload.py
+++ b/src/allmydata/immutable/upload.py
@@ -261,20 +261,21 @@ class ServerTracker(object):
         return self._server.get_name()
 
     def query(self, sharenums):
-        rref = self._server.get_rref()
-        d = rref.callRemote("allocate_buckets",
-                            self.storage_index,
-                            self.renew_secret,
-                            self.cancel_secret,
-                            sharenums,
-                            self.allocated_size,
-                            canary=Referenceable())
+        storage_server = self._server.get_storage_server()
+        d = storage_server.allocate_buckets(
+            self.storage_index,
+            self.renew_secret,
+            self.cancel_secret,
+            sharenums,
+            self.allocated_size,
+            canary=Referenceable(),
+        )
         d.addCallback(self._buckets_allocated)
         return d
 
     def ask_about_existing_shares(self):
-        rref = self._server.get_rref()
-        return rref.callRemote("get_buckets", self.storage_index)
+        storage_server = self._server.get_storage_server()
+        return storage_server.get_buckets(self.storage_index)
 
     def _buckets_allocated(self, alreadygot_and_buckets):
         #log.msg("%s._got_reply(%s)" % (self, (alreadygot, buckets)))
@@ -415,7 +416,7 @@ class Tahoe2ServerSelector(log.PrefixingLogMixin):
         # field) from getting large shares (for files larger than about
         # 12GiB). See #439 for details.
         def _get_maxsize(server):
-            v0 = server.get_rref().version
+            v0 = server.get_version()
             v1 = v0["http://allmydata.org/tahoe/protocols/storage/v1"]
             return v1["maximum-immutable-share-size"]
 

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -538,7 +538,9 @@ class IServer(IDisplayableServer):
         pass
 
     def get_rref():
-        """Once a server is connected, I return a RemoteReference.
+        """Obsolete.  Use ``get_storage_server`` instead.
+
+        Once a server is connected, I return a RemoteReference.
         Before a server is connected for the first time, I return None.
 
         Note that the rref I return will start producing DeadReferenceErrors

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -291,6 +291,81 @@ class RIStorageServer(RemoteInterface):
         """
 
 
+class IStorageServer(Interface):
+    """
+    An object capable of storing shares for a storage client.
+    """
+    def get_version():
+        """
+        :see: ``RIStorageServer.get_version``
+        """
+
+    def allocate_buckets(
+            storage_index,
+            renew_secret,
+            cancel_secret,
+            sharenums,
+            allocated_size,
+            canary,
+    ):
+        """
+        :see: ``RIStorageServer.allocate_buckets``
+        """
+
+    def add_lease(
+            storage_index,
+            renew_secret,
+            cancel_secret,
+    ):
+        """
+        :see: ``RIStorageServer.add_lease``
+        """
+
+    def renew_lease(
+            storage_index,
+            renew_secret,
+    ):
+        """
+        :see: ``RIStorageServer.renew_lease``
+        """
+
+    def get_buckets(
+            storage_index,
+    ):
+        """
+        :see: ``RIStorageServer.get_buckets``
+        """
+
+    def slot_readv(
+            storage_index,
+            shares,
+            readv,
+    ):
+        """
+        :see: ``RIStorageServer.slot_readv``
+        """
+
+    def slot_testv_and_readv_and_writev(
+            storage_index,
+            secrets,
+            tw_vectors,
+            r_vector,
+    ):
+        """
+        :see: ``RIStorageServer.slot_testv_readv_and_writev``
+        """
+
+    def advise_corrupt_share(
+            share_type,
+            storage_index,
+            shnum,
+            reason,
+    ):
+        """
+        :see: ``RIStorageServer.advise_corrupt_share``
+        """
+
+
 class IStorageBucketWriter(Interface):
     """
     Objects of this kind live on the client side.
@@ -469,6 +544,17 @@ class IServer(IDisplayableServer):
         Note that the rref I return will start producing DeadReferenceErrors
         once the connection is lost.
         """
+
+    def get_storage_server():
+        """
+        Once a server is connected, I return an ``IStorageServer``.
+        Before a server is connected for the first time, I return None.
+
+        Note that the ``IStorageServer`` I return will start producing
+        DeadReferenceErrors once the connection is lost.
+        """
+
+
 
 
 class IMutableSlotWriter(Interface):
@@ -2935,4 +3021,3 @@ class IConnectionStatus(Interface):
         connection hint and the handler it is using) to the status string
         (pending, connected, refused, or other errors).
         """)
-

--- a/src/allmydata/mutable/layout.py
+++ b/src/allmydata/mutable/layout.py
@@ -230,7 +230,7 @@ class SDMFSlotWriteProxy(object):
     """
     def __init__(self,
                  shnum,
-                 rref, # a remote reference to a storage server
+                 storage_server, # an IStorageServer
                  storage_index,
                  secrets, # (write_enabler, renew_secret, cancel_secret)
                  seqnum, # the sequence number of the mutable file
@@ -239,7 +239,7 @@ class SDMFSlotWriteProxy(object):
                  segment_size,
                  data_length): # the length of the original file
         self.shnum = shnum
-        self._rref = rref
+        self._storage_server = storage_server
         self._storage_index = storage_index
         self._secrets = secrets
         self._seqnum = seqnum
@@ -541,12 +541,13 @@ class SDMFSlotWriteProxy(object):
 
         tw_vectors = {}
         tw_vectors[self.shnum] = (self._testvs, datavs, None)
-        return self._rref.callRemote("slot_testv_and_readv_and_writev",
-                                     self._storage_index,
-                                     self._secrets,
-                                     tw_vectors,
-                                     # TODO is it useful to read something?
-                                     self._readvs)
+        return self._storage_server.slot_testv_and_readv_and_writev(
+            self._storage_index,
+            self._secrets,
+            tw_vectors,
+            # TODO is it useful to read something?
+            self._readvs,
+        )
 
 
 MDMFHEADER = ">BQ32sBBQQ QQQQQQQQ"
@@ -729,7 +730,7 @@ class MDMFSlotWriteProxy(object):
     # disruption.
     def __init__(self,
                  shnum,
-                 rref, # a remote reference to a storage server
+                 storage_server, # a remote reference to a storage server
                  storage_index,
                  secrets, # (write_enabler, renew_secret, cancel_secret)
                  seqnum, # the sequence number of the mutable file
@@ -738,7 +739,7 @@ class MDMFSlotWriteProxy(object):
                  segment_size,
                  data_length): # the length of the original file
         self.shnum = shnum
-        self._rref = rref
+        self._storage_server = storage_server
         self._storage_index = storage_index
         self._seqnum = seqnum
         self._required_shares = required_shares
@@ -1159,11 +1160,12 @@ class MDMFSlotWriteProxy(object):
                 self._testvs = [(0, len(new_checkstring), "eq", new_checkstring)]
             on_success = _first_write
         tw_vectors[self.shnum] = (self._testvs, datavs, None)
-        d = self._rref.callRemote("slot_testv_and_readv_and_writev",
-                                  self._storage_index,
-                                  self._secrets,
-                                  tw_vectors,
-                                  self._readv)
+        d = self._storage_server.slot_testv_and_readv_and_writev(
+            self._storage_index,
+            self._secrets,
+            tw_vectors,
+            self._readv,
+        )
         def _result(results):
             if isinstance(results, failure.Failure) or not results[0]:
                 # Do nothing; the write was unsuccessful.
@@ -1189,13 +1191,13 @@ class MDMFSlotReadProxy(object):
     it is valid) to eliminate some of the need to fetch it from servers.
     """
     def __init__(self,
-                 rref,
+                 storage_server,
                  storage_index,
                  shnum,
                  data="",
                  data_is_everything=False):
         # Start the initialization process.
-        self._rref = rref
+        self._storage_server = storage_server
         self._storage_index = storage_index
         self.shnum = shnum
 
@@ -1752,10 +1754,11 @@ class MDMFSlotReadProxy(object):
             results = {self.shnum: results}
             return defer.succeed(results)
         else:
-            return self._rref.callRemote("slot_readv",
-                                         self._storage_index,
-                                         [self.shnum],
-                                         readvs)
+            return self._storage_server.slot_readv(
+                self._storage_index,
+                [self.shnum],
+                readvs,
+            )
 
 
     def is_sdmf(self):

--- a/src/allmydata/mutable/publish.py
+++ b/src/allmydata/mutable/publish.py
@@ -269,7 +269,7 @@ class Publish(object):
             secrets = (write_enabler, renew_secret, cancel_secret)
 
             writer = writer_class(shnum,
-                                  server.get_rref(),
+                                  server.get_storage_server(),
                                   self._storage_index,
                                   secrets,
                                   self._new_seqnum,
@@ -471,7 +471,7 @@ class Publish(object):
             secrets = (write_enabler, renew_secret, cancel_secret)
 
             writer =  writer_class(shnum,
-                                   server.get_rref(),
+                                   server.get_storage_server(),
                                    self._storage_index,
                                    secrets,
                                    self._new_seqnum,

--- a/src/allmydata/mutable/retrieve.py
+++ b/src/allmydata/mutable/retrieve.py
@@ -309,7 +309,7 @@ class Retrieve(object):
             if key in self.servermap.proxies:
                 reader = self.servermap.proxies[key]
             else:
-                reader = MDMFSlotReadProxy(server.get_rref(),
+                reader = MDMFSlotReadProxy(server.get_storage_server(),
                                            self._storage_index, shnum, None)
             reader.server = server
             self.readers[shnum] = reader
@@ -906,9 +906,13 @@ class Retrieve(object):
 
 
     def notify_server_corruption(self, server, shnum, reason):
-        rref = server.get_rref()
-        rref.callRemoteOnly("advise_corrupt_share",
-                            "mutable", self._storage_index, shnum, reason)
+        storage_server = server.get_storage_server()
+        storage_server.advise_corrupt_share(
+            "mutable",
+            self._storage_index,
+            shnum,
+            reason,
+        )
 
 
     def _try_to_validate_privkey(self, enc_privkey, reader, server):

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -428,10 +428,10 @@ class NativeStorageServer(service.MultiService):
         return self._rref
 
     def get_storage_server(self):
+        """
+        See ``IServer.get_storage_server``.
+        """
         if self._rref is None:
-            # Somewhat questionable to create a third state (never connected,
-            # connected, disconnected) but it mirrors the get_rref behavior so
-            # we'll keep it for now.
             return None
         # Pass in an accessor for our _rref attribute.  The value of the
         # attribute may change over time as connections are lost and

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -437,7 +437,7 @@ class NativeStorageServer(service.MultiService):
         # attribute may change over time as connections are lost and
         # re-established.  The _StorageServer should always be able to get the
         # most up-to-date value.
-        return _StorageServer(get_rref=lambda: self._rref)
+        return _StorageServer(get_rref=self.get_rref)
 
     def _lost(self):
         log.msg(format="lost connection to %(name)s", name=self.get_name(),

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -111,7 +111,7 @@ class StorageFarmBroker(service.MultiService):
     # these two are used in unit tests
     def test_add_rref(self, serverid, rref, ann):
         s = NativeStorageServer(serverid, ann.copy(), self._tub_maker, {})
-        s.rref = rref
+        s._rref = rref
         s._is_connected = True
         self.servers[serverid] = s
 
@@ -315,7 +315,7 @@ class NativeStorageServer(service.MultiService):
         self.last_connect_time = None
         self.last_loss_time = None
         self.remote_host = None
-        self.rref = None
+        self._rref = None
         self._is_connected = False
         self._reconnector = None
         self._trigger_cb = None
@@ -344,8 +344,8 @@ class NativeStorageServer(service.MultiService):
     def get_permutation_seed(self):
         return self._permutation_seed
     def get_version(self):
-        if self.rref:
-            return self.rref.version
+        if self._rref:
+            return self._rref.version
         return None
     def get_name(self): # keep methodname short
         # TODO: decide who adds [] in the short description. It should
@@ -367,8 +367,8 @@ class NativeStorageServer(service.MultiService):
 
     def get_connection_status(self):
         last_received = None
-        if self.rref:
-            last_received = self.rref.getDataLastReceivedAt()
+        if self._rref:
+            last_received = self._rref.getDataLastReceivedAt()
         return connection_status.from_foolscap_reconnector(self._reconnector,
                                                            last_received)
 
@@ -414,18 +414,18 @@ class NativeStorageServer(service.MultiService):
 
         self.last_connect_time = time.time()
         self.remote_host = rref.getLocationHints()
-        self.rref = rref
+        self._rref = rref
         self._is_connected = True
         rref.notifyOnDisconnect(self._lost)
 
     def get_rref(self):
-        return self.rref
+        return self._rref
 
     def _lost(self):
         log.msg(format="lost connection to %(name)s", name=self.get_name(),
                 facility="tahoe.storage_broker", umid="zbRllw")
         self.last_loss_time = time.time()
-        # self.rref is now stale: all callRemote()s will get a
+        # self._rref is now stale: all callRemote()s will get a
         # DeadReferenceError. We leave the stale reference in place so that
         # uploader/downloader code (which received this IServer through
         # get_connected_servers() or get_servers_for_psi()) can continue to

--- a/src/allmydata/test/mutable/test_filenode.py
+++ b/src/allmydata/test/mutable/test_filenode.py
@@ -11,7 +11,11 @@ from allmydata.mutable.publish import MutableData
 from ..test_download import PausingConsumer, PausingAndStoppingConsumer, \
      StoppingConsumer, ImmediatelyStoppingConsumer
 from .. import common_util as testutil
-from .util import FakeStorage, make_nodemaker
+from .util import (
+    FakeStorage,
+    make_nodemaker_with_peers,
+    make_peer,
+)
 
 class Filenode(unittest.TestCase, testutil.ShouldFailMixin):
     # this used to be in Publish, but we removed the limit. Some of
@@ -19,8 +23,15 @@ class Filenode(unittest.TestCase, testutil.ShouldFailMixin):
     # larger than the limit.
     OLD_MAX_SEGMENT_SIZE = 3500000
     def setUp(self):
-        self._storage = s = FakeStorage()
-        self.nodemaker = make_nodemaker(s)
+        self._storage = FakeStorage()
+        self._peers = list(
+            make_peer(self._storage, n)
+            for n
+            # 10 is the default for N.  We're trying to make enough servers
+            # here so that each only gets one share.
+            in range(10)
+        )
+        self.nodemaker = make_nodemaker_with_peers(self._peers)
 
     def test_create(self):
         d = self.nodemaker.create_mutable_file()
@@ -352,16 +363,20 @@ class Filenode(unittest.TestCase, testutil.ShouldFailMixin):
 
 
     def test_mdmf_write_count(self):
-        # Publishing an MDMF file should only cause one write for each
-        # share that is to be published. Otherwise, we introduce
-        # undesirable semantics that are a regression from SDMF
+        """
+        Publishing an MDMF file causes exactly one write for each share that is to
+        be published. Otherwise, we introduce undesirable semantics that are a
+        regression from SDMF.
+        """
         upload = MutableData("MDMF" * 100000) # about 400 KiB
         d = self.nodemaker.create_mutable_file(upload,
                                                version=MDMF_VERSION)
         def _check_server_write_counts(ignored):
             sb = self.nodemaker.storage_broker
-            for server in sb.servers.itervalues():
-                self.failUnlessEqual(server.get_rref().queries, 1)
+            for peer in self._peers:
+                # There were enough servers for each to only get a single
+                # share.
+                self.assertEqual(peer.storage_server.queries, 1)
         d.addCallback(_check_server_write_counts)
         return d
 

--- a/src/allmydata/test/mutable/test_filenode.py
+++ b/src/allmydata/test/mutable/test_filenode.py
@@ -372,7 +372,6 @@ class Filenode(unittest.TestCase, testutil.ShouldFailMixin):
         d = self.nodemaker.create_mutable_file(upload,
                                                version=MDMF_VERSION)
         def _check_server_write_counts(ignored):
-            sb = self.nodemaker.storage_broker
             for peer in self._peers:
                 # There were enough servers for each to only get a single
                 # share.

--- a/src/allmydata/test/no_network.py
+++ b/src/allmydata/test/no_network.py
@@ -32,6 +32,9 @@ from allmydata.util import fileutil, idlib, hashutil
 from allmydata.util.hashutil import permute_server_hash
 from allmydata.util.fileutil import abspath_expanduser_unicode
 from allmydata.interfaces import IStorageBroker, IServer
+from allmydata.storage_client import (
+    _StorageServer,
+)
 from .common import (
     TEST_RSA_KEY_SIZE,
     SameProcessStreamEndpointAssigner,
@@ -166,6 +169,10 @@ class NoNetworkServer(object):
         return "nickname"
     def get_rref(self):
         return self.rref
+    def get_storage_server(self):
+        if self.rref is None:
+            return None
+        return _StorageServer(lambda: self.rref)
     def get_version(self):
         return self.rref.version
 

--- a/src/allmydata/test/test_download.py
+++ b/src/allmydata/test/test_download.py
@@ -601,8 +601,8 @@ class DownloadTest(_Base, unittest.TestCase):
         # that they're old and can't handle reads that overrun the length of
         # the share. This exercises a different code path.
         for s in self.c0.storage_broker.get_connected_servers():
-            rref = s.get_rref()
-            v1 = rref.version["http://allmydata.org/tahoe/protocols/storage/v1"]
+            v = s.get_version()
+            v1 = v["http://allmydata.org/tahoe/protocols/storage/v1"]
             v1["tolerates-immutable-read-overrun"] = False
 
         n = self.c0.create_node_from_uri(immutable_uri)
@@ -1178,8 +1178,8 @@ class DownloadV2(_Base, unittest.TestCase):
         # that they're old and can't handle reads that overrun the length of
         # the share. This exercises a different code path.
         for s in self.c0.storage_broker.get_connected_servers():
-            rref = s.get_rref()
-            v1 = rref.version["http://allmydata.org/tahoe/protocols/storage/v1"]
+            v = s.get_version()
+            v1 = v["http://allmydata.org/tahoe/protocols/storage/v1"]
             v1["tolerates-immutable-read-overrun"] = False
 
         # upload a file
@@ -1198,8 +1198,8 @@ class DownloadV2(_Base, unittest.TestCase):
         self.c0 = self.g.clients[0]
 
         for s in self.c0.storage_broker.get_connected_servers():
-            rref = s.get_rref()
-            v1 = rref.version["http://allmydata.org/tahoe/protocols/storage/v1"]
+            v = s.get_version()
+            v1 = v["http://allmydata.org/tahoe/protocols/storage/v1"]
             v1["tolerates-immutable-read-overrun"] = False
 
         # upload a file

--- a/src/allmydata/test/test_immutable.py
+++ b/src/allmydata/test/test_immutable.py
@@ -16,6 +16,9 @@ from allmydata.interfaces import NotEnoughSharesError
 from allmydata.immutable.upload import Data
 from allmydata.immutable.downloader import finder
 
+from .no_network import (
+    NoNetworkServer,
+)
 
 class MockShareHashTree(object):
     def needed_hashes(self):
@@ -106,19 +109,6 @@ class TestShareFinder(unittest.TestCase):
                 eventually(_give_buckets_and_hunger_again)
                 return d
 
-        class MockIServer(object):
-            def __init__(self, serverid, rref):
-                self.serverid = serverid
-                self.rref = rref
-            def get_serverid(self):
-                return self.serverid
-            def get_rref(self):
-                return self.rref
-            def get_name(self):
-                return "name-%s" % self.serverid
-            def get_version(self):
-                return self.rref.version
-
         class MockStorageBroker(object):
             def __init__(self, servers):
                 self.servers = servers
@@ -136,9 +126,9 @@ class TestShareFinder(unittest.TestCase):
         mockserver1 = MockServer({1: MockBuckets(), 2: MockBuckets()})
         mockserver2 = MockServer({})
         mockserver3 = MockServer({3: MockBuckets()})
-        servers = [ MockIServer("ms1", mockserver1),
-                    MockIServer("ms2", mockserver2),
-                    MockIServer("ms3", mockserver3), ]
+        servers = [ NoNetworkServer("ms1", mockserver1),
+                    NoNetworkServer("ms2", mockserver2),
+                    NoNetworkServer("ms3", mockserver3), ]
         mockstoragebroker = MockStorageBroker(servers)
         mockdownloadstatus = MockDownloadStatus()
         mocknode = MockNode(check_reneging=True, check_fetch_failed=True)

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -2511,9 +2511,9 @@ class Connections(SystemTestMixin, unittest.TestCase):
             self.failUnlessEqual(len(nonclients), 1)
 
             self.s1 = nonclients[0]  # s1 is the server, not c0
-            self.s1_rref = self.s1.get_rref()
-            self.failIfEqual(self.s1_rref, None)
-            self.failUnless(self.s1.is_connected())
+            self.s1_storage_server = self.s1.get_storage_server()
+            self.assertIsNot(self.s1_storage_server, None)
+            self.assertTrue(self.s1.is_connected())
         d.addCallback(_start)
 
         # now shut down the server
@@ -2524,9 +2524,9 @@ class Connections(SystemTestMixin, unittest.TestCase):
         d.addCallback(lambda ign: self.poll(_poll))
 
         def _down(ign):
-            self.failIf(self.s1.is_connected())
-            rref = self.s1.get_rref()
-            self.failUnless(rref)
-            self.failUnlessIdentical(rref, self.s1_rref)
+            self.assertFalse(self.s1.is_connected())
+            storage_server = self.s1.get_storage_server()
+            self.assertIsNot(storage_server, None)
+            self.assertEqual(storage_server, self.s1_storage_server)
         d.addCallback(_down)
         return d


### PR DESCRIPTION
Fixes: ticket:3048

I didn't manage to completely eliminate `get_rref` but the only callers that remain are in the test suite and are violating the `RemoteReference` interface anyway.  I think this is still a good step forward.  The test code that still uses `get_rref` will probably all need to be massively rewritten when we switch away from Foolscap, anyway.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/618)
<!-- Reviewable:end -->
