### PR TITLE
refactor 3031

### DIFF
--- a/docs/debian.rst
+++ b/docs/debian.rst
@@ -1,8 +1,8 @@
 ﻿.. -*- coding: utf-8-with-signature -*-
 
-=========================
-Debian and Ubuntu Support
-=========================
+===========================
+ Debian and Ubuntu Support
+===========================
 
 1.  `Overview`_
 2.  `Dependency Packages`_
@@ -39,7 +39,7 @@ virtualenv.
 
 The ``.deb`` packages, of course, rely solely upon other ``.deb`` packages.
 For reference, here is a list of the debian package names that provide Tahoe's
-dependencies as of the 1.9 release:
+dependencies as of the 1.14.0 release:
 
 * python
 * python-zfec
@@ -48,6 +48,7 @@ dependencies as of the 1.9 release:
 * python-twisted
 * python-nevow
 * python-mock
+* python-cryptography
 * python-simplejson
 * python-setuptools
 * python-support (for Debian-specific install-time tools)

--- a/docs/frontends/CLI.rst
+++ b/docs/frontends/CLI.rst
@@ -44,7 +44,7 @@ arguments. "``tahoe --help``" might also provide something useful.
 Running "``tahoe --version``" will display a list of version strings, starting
 with the "allmydata" module (which contains the majority of the Tahoe-LAFS
 functionality) and including versions for a number of dependent libraries,
-like Twisted, Foolscap, and zfec. "``tahoe --version-and-path``"
+like Twisted, Foolscap, cryptography, and zfec. "``tahoe --version-and-path``"
 will also show the path from which each library was imported.
 
 On Unix systems, the shell expands filename wildcards (``'*'`` and ``'?'``)

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -12,7 +12,7 @@ from twisted.python.failure import Failure
 
 import allmydata
 from allmydata.crypto.ed25519 import SigningKey
-from allmydata.crypto.rsa import PrivateKey
+from allmydata.crypto import rsa
 from allmydata.storage.server import StorageServer
 from allmydata import storage_client
 from allmydata.immutable.upload import Uploader
@@ -156,8 +156,7 @@ class KeyGenerator:
         keysize = keysize or self.default_keysize
         # RSA key generation for a 2048 bit key takes between 0.8 and 3.2
         # secs
-        signer = PrivateKey.generate(keysize)
-        verifier = signer.public_key()
+        signer, verifier = rsa.create_signing_keypair(keysize)
         return defer.succeed( (verifier, signer) )
 
 class Terminator(service.Service):

--- a/src/allmydata/crypto/aes.py
+++ b/src/allmydata/crypto/aes.py
@@ -1,4 +1,3 @@
-import os
 import six
 
 from cryptography.hazmat.backends import default_backend

--- a/src/allmydata/crypto/rsa.py
+++ b/src/allmydata/crypto/rsa.py
@@ -8,110 +8,153 @@ from cryptography.hazmat.primitives.serialization import load_der_private_key, l
 from allmydata.crypto import BadSignature
 
 
-class RsaMixin(object):
+"""
+This is the value that was used by `pycryptopp`, and we must continue to use it for
+both backwards compatibility and interoperability.
 
-    '''
-    This is the value that was used by `pycryptopp`, and we must continue to use it for
-    both backwards compatibility and interoperability.
-
-    The docs for `cryptography` suggest to use the constant defined at
-    `cryptography.hazmat.primitives.asymmetric.padding.PSS.MAX_LENGTH`, but this causes old
-    signatures to fail to validate.
-    '''
-    RSA_PSS_SALT_LENGTH = 32
+The docs for `cryptography` suggest to use the constant defined at
+`cryptography.hazmat.primitives.asymmetric.padding.PSS.MAX_LENGTH`, but this causes old
+signatures to fail to validate.
+"""
+RSA_PSS_SALT_LENGTH = 32
 
 
-class PrivateKey(RsaMixin):
+def create_verifying_key_from_string(public_key_der):
+    """
+    Create an RSA verifying key from a previously serialized public key.
 
-    def __init__(self, priv_key):
-        self._priv_key = priv_key
+    :returns: public key
+    """
+    pub_key = load_der_public_key(
+        public_key_der,
+        backend=default_backend(),
+    )
+    return pub_key
 
-    @classmethod
-    def generate(cls, key_size):
-        priv_key = rsa.generate_private_key(
-            public_exponent=65537,  # serisously don't change this value
-            key_size=key_size,
-            backend=default_backend()
-        )
-        return cls(priv_key)
 
-    @classmethod
-    def parse_string(cls, priv_key_str):
-        priv_key = load_der_private_key(
-            priv_key_str,
-            password=None,
-            backend=default_backend(),
-        )
-        return cls(priv_key)
+def create_signing_keypair(key_size):
+    """
+    Create a new RSA signing keypair from scratch. Can be used with
+    `sign_data` function.
 
-    def public_key(self):
-        return PublicKey(self._priv_key.public_key())
+    :param int key_size: length of key in bits
 
-    def serialize(self):
-        return self._priv_key.private_bytes(
-            encoding=Encoding.DER,
-            format=PrivateFormat.PKCS8,
-            encryption_algorithm=NoEncryption(),
-        )
+    :returns: 2-tuple of (private_key, public_key)
+    """
+    priv_key = rsa.generate_private_key(
+        public_exponent=65537,  # serisously don't change this value
+        key_size=key_size,
+        backend=default_backend()
+    )
+    return priv_key, priv_key.public_key()
 
-    def sign(self, data):
-        return self._priv_key.sign(
+
+def create_signing_keypair_from_string(private_key_der):
+    """
+    Create an RSA signing key from a previously serialized private key.
+
+    :returns: 2-tuple of (private_key, public_key)
+    """
+    priv_key = load_der_private_key(
+        private_key_der,
+        password=None,
+        backend=default_backend(),
+    )
+    return priv_key, priv_key.public_key()
+
+
+def der_string_from_signing_key(private_key):
+    """
+    Serializes a given RSA private key to a DER string
+    """
+    _validate_private_key(private_key)
+    return private_key.private_bytes(
+        encoding=Encoding.DER,
+        format=PrivateFormat.PKCS8,
+        encryption_algorithm=NoEncryption(),
+    )
+
+
+def der_string_from_verifying_key(public_key):
+    """
+    Serializes a given RSA private key to a DER string
+    """
+    _validate_public_key(public_key)
+    return public_key.public_bytes(
+        encoding=Encoding.DER,
+        format=PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def create_verifying_key_from_string(public_key_der):
+    """
+    Create an RSA signing key from a previously serialized public key
+    """
+    pub_key = load_der_public_key(
+        public_key_der,
+        backend=default_backend(),
+    )
+    return pub_key
+
+
+def sign_data(private_key, data):
+    """
+    :param private_key: the private part of a keypair returned from
+        `create_signing_keypair_from_string` or `create_signing_keypair`
+
+    :param bytes data: the bytes to sign
+
+    :returns: bytes which are a signature of the bytes given as `data`.
+    """
+    _validate_private_key(private_key)
+    return private_key.sign(
+        data,
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=RSA_PSS_SALT_LENGTH,
+        ),
+        hashes.SHA256(),
+    )
+
+def verify_signature(public_key, alleged_signature, data):
+    """
+    :param public_key: a verifying key, returned from `create_verifying_key_from_string` or `create_verifying_key_from_private_key`
+
+    :param bytes alleged_signature: the bytes of the alleged signature
+
+    :param bytes data: the data which was allegedly signed
+    """
+    try:
+        public_key.verify(
+            alleged_signature,
             data,
             padding.PSS(
                 mgf=padding.MGF1(hashes.SHA256()),
-                salt_length=self.RSA_PSS_SALT_LENGTH,
+                salt_length=RSA_PSS_SALT_LENGTH,
             ),
             hashes.SHA256(),
         )
-
-    def __eq__(self, other):
-        if isinstance(other, type(self)):
-            return self.serialize() == other.serialize()
-        else:
-            return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    except InvalidSignature:
+        raise BadSignature
 
 
-class PublicKey(RsaMixin):
-
-    def __init__(self, pub_key):
-        self._pub_key = pub_key
-
-    @classmethod
-    def parse_string(cls, pub_key_str):
-        pub_key = load_der_public_key(
-            pub_key_str,
-            backend=default_backend(),
-        )
-        return cls(pub_key)
-
-    def serialize(self):
-        return self._pub_key.public_bytes(
-            encoding=Encoding.DER,
-            format=PublicFormat.SubjectPublicKeyInfo,
+def _validate_public_key(public_key):
+    """
+    Internal helper. Checks that `public_key` is a valid cryptography
+    object
+    """
+    if not isinstance(public_key, rsa.RSAPublicKey):
+        raise ValueError(
+            "public_key not an RSAPublicKey"
         )
 
-    def verify(self, signature, data):
-        try:
-            self._pub_key.verify(
-                signature,
-                data,
-                padding.PSS(
-                    mgf=padding.MGF1(hashes.SHA256()),
-                    salt_length=self.RSA_PSS_SALT_LENGTH,
-                ),
-                hashes.SHA256(),
-            )
-        except InvalidSignature:
-            raise BadSignature
 
-    def __eq__(self, other):
-        if isinstance(other, type(self)):
-            return self.serialize() == other.serialize()
-        else:
-            return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
+def _validate_private_key(private_key):
+    """
+    Internal helper. Checks that `public_key` is a valid cryptography
+    object
+    """
+    if not isinstance(private_key, rsa.RSAPrivateKey):
+        raise ValueError(
+            "private_key not an RSAPrivateKey"
+        )

--- a/src/allmydata/crypto/rsa.py
+++ b/src/allmydata/crypto/rsa.py
@@ -19,19 +19,6 @@ signatures to fail to validate.
 RSA_PSS_SALT_LENGTH = 32
 
 
-def create_verifying_key_from_string(public_key_der):
-    """
-    Create an RSA verifying key from a previously serialized public key.
-
-    :returns: public key
-    """
-    pub_key = load_der_public_key(
-        public_key_der,
-        backend=default_backend(),
-    )
-    return pub_key
-
-
 def create_signing_keypair(key_size):
     """
     Create a new RSA signing keypair from scratch. Can be used with
@@ -88,7 +75,7 @@ def der_string_from_verifying_key(public_key):
 
 def create_verifying_key_from_string(public_key_der):
     """
-    Create an RSA signing key from a previously serialized public key
+    Create an RSA verifying key from a previously serialized public key
     """
     pub_key = load_der_public_key(
         public_key_der,

--- a/src/allmydata/immutable/downloader/fetcher.py
+++ b/src/allmydata/immutable/downloader/fetcher.py
@@ -7,7 +7,7 @@ from allmydata.util.dictutil import DictOfSets
 from common import OVERDUE, COMPLETE, CORRUPT, DEAD, BADSEGNUM, \
      BadSegmentNumberError
 
-class SegmentFetcher:
+class SegmentFetcher(object):
     """I am responsible for acquiring blocks for a single segment. I will use
     the Share instances passed to my add_shares() method to locate, retrieve,
     and validate those blocks. I expect my parent node to call my

--- a/src/allmydata/mutable/checker.py
+++ b/src/allmydata/mutable/checker.py
@@ -8,7 +8,7 @@ from allmydata.mutable.common import MODE_CHECK, MODE_WRITE, CorruptShareError
 from allmydata.mutable.servermap import ServerMap, ServermapUpdater
 from allmydata.mutable.retrieve import Retrieve # for verifying
 
-class MutableChecker:
+class MutableChecker(object):
     SERVERMAP_MODE = MODE_CHECK
 
     def __init__(self, node, storage_broker, history, monitor):

--- a/src/allmydata/mutable/filenode.py
+++ b/src/allmydata/mutable/filenode.py
@@ -5,6 +5,7 @@ from twisted.internet import defer, reactor
 from foolscap.api import eventually
 
 from allmydata.crypto.aes import AES
+from allmydata.crypto import rsa
 from allmydata.interfaces import IMutableFileNode, ICheckable, ICheckResults, \
      NotEnoughSharesError, MDMF_VERSION, SDMF_VERSION, IMutableUploadable, \
      IMutableFileVersion, IWriteable
@@ -128,8 +129,8 @@ class MutableFileNode(object):
         """
         (pubkey, privkey) = keypair
         self._pubkey, self._privkey = pubkey, privkey
-        pubkey_s = self._pubkey.serialize()
-        privkey_s = self._privkey.serialize()
+        pubkey_s = rsa.der_string_from_verifying_key(self._pubkey)
+        privkey_s = rsa.der_string_from_signing_key(self._privkey)
         self._writekey = hashutil.ssk_writekey_hash(privkey_s)
         self._encprivkey = self._encrypt_privkey(self._writekey, privkey_s)
         self._fingerprint = hashutil.ssk_pubkey_fingerprint_hash(pubkey_s)

--- a/src/allmydata/mutable/filenode.py
+++ b/src/allmydata/mutable/filenode.py
@@ -23,7 +23,7 @@ from allmydata.mutable.checker import MutableChecker, MutableCheckAndRepairer
 from allmydata.mutable.repairer import Repairer
 
 
-class BackoffAgent:
+class BackoffAgent(object):
     # these parameters are copied from foolscap.reconnector, which gets them
     # from twisted.internet.protocol.ReconnectingClientFactory
     initialDelay = 1.0

--- a/src/allmydata/mutable/publish.py
+++ b/src/allmydata/mutable/publish.py
@@ -6,6 +6,7 @@ from twisted.internet import defer
 from twisted.python import failure
 
 from allmydata.crypto.aes import AES
+from allmydata.crypto import rsa
 from allmydata.interfaces import IPublishStatus, SDMF_VERSION, MDMF_VERSION, \
                                  IMutableUploadable
 from allmydata.util import base32, hashutil, mathutil, log
@@ -849,7 +850,7 @@ class Publish(object):
         started = time.time()
         self._status.set_status("Signing prefix")
         signable = self._get_some_writer().get_signable()
-        self.signature = self._privkey.sign(signable)
+        self.signature = rsa.sign_data(self._privkey, signable)
 
         for (shnum, writers) in self.writers.iteritems():
             for writer in writers:
@@ -864,7 +865,7 @@ class Publish(object):
         self._status.set_status("Pushing shares")
         self._started_pushing = started
         ds = []
-        verification_key = self._pubkey.serialize()
+        verification_key = rsa.der_string_from_verifying_key(self._pubkey)
 
         for (shnum, writers) in self.writers.copy().iteritems():
             for writer in writers:

--- a/src/allmydata/mutable/publish.py
+++ b/src/allmydata/mutable/publish.py
@@ -100,7 +100,7 @@ class PublishStatus(object):
 class LoopLimitExceededError(Exception):
     pass
 
-class Publish:
+class Publish(object):
     """I represent a single act of publishing the mutable file to the grid. I
     will only publish my data if the servermap I am using still represents
     the current state of the world.

--- a/src/allmydata/mutable/repairer.py
+++ b/src/allmydata/mutable/repairer.py
@@ -24,7 +24,7 @@ class RepairRequiresWritecapError(Exception):
 class MustForceRepairError(Exception):
     pass
 
-class Repairer:
+class Repairer(object):
     def __init__(self, node, check_results, storage_broker, history, monitor):
         self.node = node
         self.check_results = ICheckResults(check_results)

--- a/src/allmydata/mutable/retrieve.py
+++ b/src/allmydata/mutable/retrieve.py
@@ -9,7 +9,7 @@ from foolscap.api import eventually, fireEventually, DeadReferenceError, \
      RemoteException
 
 from allmydata.crypto.aes import AES
-from allmydata.crypto.rsa import PrivateKey
+from allmydata.crypto import rsa
 from allmydata.interfaces import IRetrieveStatus, NotEnoughSharesError, \
      DownloadStopped, MDMF_VERSION, SDMF_VERSION
 from allmydata.util.assertutil import _assert, precondition
@@ -931,7 +931,7 @@ class Retrieve(object):
         # it's good
         self.log("got valid privkey from shnum %d on reader %s" %
                  (reader.shnum, reader))
-        privkey = PrivateKey.parse_string(alleged_privkey_s)
+        privkey, _ = rsa.create_signing_keypair_from_string(alleged_privkey_s)
         self._node._populate_encprivkey(enc_privkey)
         self._node._populate_privkey(privkey)
         self._need_privkey = False

--- a/src/allmydata/mutable/retrieve.py
+++ b/src/allmydata/mutable/retrieve.py
@@ -89,7 +89,7 @@ class RetrieveStatus(object):
         serverid = server.get_serverid()
         self._problems[serverid] = f
 
-class Marker:
+class Marker(object):
     pass
 
 @implementer(IPushProducer)

--- a/src/allmydata/mutable/servermap.py
+++ b/src/allmydata/mutable/servermap.py
@@ -9,7 +9,7 @@ from twisted.python import failure
 from foolscap.api import DeadReferenceError, RemoteException, eventually, \
                          fireEventually
 from allmydata.crypto import BadSignature
-from allmydata.crypto.rsa import PublicKey, PrivateKey
+from allmydata.crypto import rsa
 from allmydata.util import base32, hashutil, log, deferredutil
 from allmydata.util.dictutil import DictOfSets
 from allmydata.storage.server import si_b2a
@@ -838,7 +838,7 @@ class ServermapUpdater(object):
             # against the public key before keeping track of it.
             assert self._node.get_pubkey()
             try:
-                self._node.get_pubkey().verify(signature[1], prefix)
+                rsa.verify_signature(self._node.get_pubkey(), signature[1], prefix)
             except BadSignature:
                 raise CorruptShareError(server, shnum,
                                         "signature is invalid")
@@ -909,7 +909,7 @@ class ServermapUpdater(object):
                                                               update_data)
 
     def _deserialize_pubkey(self, pubkey_s):
-        verifier = PublicKey.parse_string(pubkey_s)
+        verifier = rsa.create_verifying_key_from_string(pubkey_s)
         return verifier
 
     def _try_to_validate_privkey(self, enc_privkey, server, shnum, lp):
@@ -930,7 +930,7 @@ class ServermapUpdater(object):
         self.log("got valid privkey from shnum %d on serverid %s" %
                  (shnum, server.get_name()),
                  parent=lp)
-        privkey = PrivateKey.parse_string(alleged_privkey_s)
+        privkey, _ = rsa.create_signing_keypair_from_string(alleged_privkey_s)
         self._node._populate_encprivkey(enc_privkey)
         self._node._populate_privkey(privkey)
         self._need_privkey = False

--- a/src/allmydata/mutable/servermap.py
+++ b/src/allmydata/mutable/servermap.py
@@ -81,7 +81,7 @@ class UpdateStatus(object):
     def set_finished(self, when):
         self.finished = when
 
-class ServerMap:
+class ServerMap(object):
     """I record the placement of mutable shares.
 
     This object records which shares (of various versions) are located on
@@ -379,7 +379,7 @@ class ServerMap:
         self.update_data.setdefault(shnum , []).append((verinfo, data))
 
 
-class ServermapUpdater:
+class ServermapUpdater(object):
     def __init__(self, filenode, storage_broker, monitor, servermap,
                  mode=MODE_READ, add_lease=False, update_range=None):
         """I update a servermap, locating a sufficient number of useful

--- a/src/allmydata/scripts/admin.py
+++ b/src/allmydata/scripts/admin.py
@@ -38,7 +38,7 @@ generate-keypair, derive the public key and print it to stdout.
 
 def derive_pubkey(options):
     out = options.stdout
-    from allmydata.crypto.ed25519 import SigningKey 
+    from allmydata.crypto.ed25519 import SigningKey
     privkey_vs = options.privkey
     priv_key = SigningKey.parse_encoded_key(privkey_vs)
     print("private:", priv_key.encoded_key(), file=out)

--- a/src/allmydata/test/mutable/test_problems.py
+++ b/src/allmydata/test/mutable/test_problems.py
@@ -5,6 +5,7 @@ from twisted.trial import unittest
 from twisted.internet import defer
 from foolscap.logging import log
 from allmydata import uri
+from allmydata.crypto import rsa
 from allmydata.interfaces import NotEnoughSharesError, SDMF_VERSION, MDMF_VERSION
 from allmydata.util import fileutil
 from allmydata.util.hashutil import ssk_writekey_hash, ssk_pubkey_fingerprint_hash
@@ -211,8 +212,8 @@ class Problems(GridTestMixin, unittest.TestCase, testutil.ShouldFailMixin):
         def _got_key(keypair):
             (pubkey, privkey) = keypair
             nm.key_generator = SameKeyGenerator(pubkey, privkey)
-            pubkey_s = pubkey.serialize()
-            privkey_s = privkey.serialize()
+            pubkey_s = rsa.der_string_from_verifying_key(pubkey)
+            privkey_s = rsa.der_string_from_signing_key(privkey)
             u = uri.WriteableSSKFileURI(ssk_writekey_hash(privkey_s),
                                         ssk_pubkey_fingerprint_hash(pubkey_s))
             self._storage_index = u.get_storage_index()

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -15,7 +15,6 @@ from twisted.python.filepath import FilePath
 from foolscap.api import Tub, Referenceable, fireEventually, flushEventualQueue
 from twisted.application import service
 from allmydata import crypto
-from allmydata.crypto import ed25519
 from allmydata.crypto.ed25519 import SigningKey
 from allmydata.interfaces import InsufficientVersionError
 from allmydata.introducer.client import IntroducerClient


### PR DESCRIPTION
This refactors the RSA code to be more "helper functions in Tahoe, using the actual cryptography objects" as I suggested in the review. This still has approximately the same "crypto code" out-and-about, but instead of having wrapper classes that ape the old pycryptopp API, it uses helper-functions.

If this looks better, I can do the ed25519 stuff as well (and/or change some of the function/helper names etc). Personally, I think this is better because:

 - it hides the "actual" objects; all Tahoe code uses is `crypto.rsa.*` functions
 - it's more explicit (i.s. `PrivateKey.parse` tells me nothing, whereas `rsa.create_keypair_from_string` tells me it's loading an rsa keypair and similarly `PrivateKey.generate(2048)` versus `rsa.create_signing_keypair(2048)`)
 - moves more code to "functional" style

There are a few other cleanups here: the derive-from-`object` stuff that got removed is put back, and the docs are updated to include `cryptography`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/620)
<!-- Reviewable:end -->
