### PR TITLE
[WIP] Tell trial to run the test suite in two processes

### DIFF
--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -51,7 +51,7 @@ fi
 # Send the output directly to a file because transporting the binary subunit2
 # via tox and then scraping it out is hideous and failure prone.
 export SUBUNITREPORTER_OUTPUT_PATH="${SUBUNIT2}"
-export TAHOE_LAFS_TRIAL_ARGS="--reporter=subunitv2-file --rterrors"
+export TAHOE_LAFS_TRIAL_ARGS="-j2 --reporter=subunitv2-file --rterrors"
 export PIP_NO_INDEX="1"
 
 ${BOOTSTRAP_VENV}/bin/tox \


### PR DESCRIPTION
CircleCI build environment has 2 vCPUs by default.
Maybe this will be faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/624)
<!-- Reviewable:end -->
