### PR TITLE
Add "autobahn" to "package_imports"

### DIFF
--- a/src/allmydata/_auto_deps.py
+++ b/src/allmydata/_auto_deps.py
@@ -139,6 +139,7 @@ package_imports = [
     ('setuptools',       'setuptools'),
     ('eliot',            'eliot'),
     ('attrs',            'attr'),
+    ('autobahn',         'autobahn'),
 ]
 
 # Dependencies for which we don't know how to get a version number at run-time.


### PR DESCRIPTION
This fixes PyInstaller-generated "frozen" binaries which, without
this, fail to run with "allmydata.PackagingError: no version info
for autobahn"

fixes: ticket:3229

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/634)
<!-- Reviewable:end -->
