### PR TITLE
Avoid failing CI when dependencies trigger deprecation warnings

### DIFF
--- a/misc/build_helpers/run-deprecations.py
+++ b/misc/build_helpers/run-deprecations.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import sys, os, io
+import sys, os, io, re
 from twisted.internet import reactor, protocol, task, defer
 from twisted.python.procutils import which
 from twisted.python import usage
@@ -12,6 +12,7 @@ from twisted.python import usage
 class Options(usage.Options):
     optParameters = [
         ["warnings", None, None, "file to write warnings into at end of test run"],
+        ["package", None, None, "Python package to which to restrict warning collection"]
         ]
 
     def parseArgs(self, command, *args):
@@ -19,7 +20,7 @@ class Options(usage.Options):
         self["args"] = list(args)
 
     description = """Run as:
-PYTHONWARNINGS=default::DeprecationWarning python run-deprecations.py [--warnings=STDERRFILE]  COMMAND ARGS..
+PYTHONWARNINGS=default::DeprecationWarning python run-deprecations.py [--warnings=STDERRFILE] [--package=PYTHONPACKAGE ] COMMAND ARGS..
 """
 
 class RunPP(protocol.ProcessProtocol):
@@ -33,6 +34,26 @@ class RunPP(protocol.ProcessProtocol):
         signal = reason.value.signal
         rc = reason.value.exitCode
         self.d.callback((signal, rc))
+
+
+def make_matcher(options):
+    # A deprecation warning line looks something like this:
+    #
+    # somepath/foo/bar/baz.py:43: DeprecationWarning: Foo is deprecated, try bar instead.
+    #
+    # Sadly there is no guarantee warnings begin at the beginning of a line
+    # since they are written to output without coordination with whatever
+    # other Python code is running in the process.
+    pattern = r".*\.py[oc]?:\d+:" # (Pending)?DeprecationWarning: .*"
+    if options["package"]:
+        pattern = r".*/{}/".format(
+            re.escape(options["package"]),
+        ) + pattern
+    expression = re.compile(pattern)
+    def match(line):
+        return expression.match(line) is not None
+    return match
+
 
 @defer.inlineCallbacks
 def run_command(main):
@@ -63,6 +84,8 @@ def run_command(main):
     reactor.spawnProcess(pp, exe, [exe] + config["args"], env=None)
     (signal, rc) = yield pp.d
 
+    match = make_matcher(config)
+
     # maintain ordering, but ignore duplicates (for some reason, either the
     # 'warnings' module or twisted.python.deprecate isn't quashing them)
     already = set()
@@ -75,12 +98,12 @@ def run_command(main):
 
     pp.stdout.seek(0)
     for line in pp.stdout.readlines():
-        if "DeprecationWarning" in line:
+        if match(line):
             add(line) # includes newline
 
     pp.stderr.seek(0)
     for line in pp.stderr.readlines():
-        if "DeprecationWarning" in line:
+        if match(line):
             add(line)
 
     if warnings:

--- a/misc/build_helpers/run-deprecations.py
+++ b/misc/build_helpers/run-deprecations.py
@@ -37,13 +37,21 @@ class RunPP(protocol.ProcessProtocol):
 
 
 def make_matcher(options):
-    # A deprecation warning line looks something like this:
-    #
-    # somepath/foo/bar/baz.py:43: DeprecationWarning: Foo is deprecated, try bar instead.
-    #
-    # Sadly there is no guarantee warnings begin at the beginning of a line
-    # since they are written to output without coordination with whatever
-    # other Python code is running in the process.
+    """
+    Make a function that matches a line with a relevant deprecation.
+
+    A deprecation warning line looks something like this::
+
+      somepath/foo/bar/baz.py:43: DeprecationWarning: Foo is deprecated, try bar instead.
+
+    Sadly there is no guarantee warnings begin at the beginning of a line
+    since they are written to output without coordination with whatever other
+    Python code is running in the process.
+
+    :return: A one-argument callable that accepts a string and returns
+        ``True`` if it contains an interesting warning and ``False``
+        otherwise.
+    """
     pattern = r".*\.py[oc]?:\d+:" # (Pending)?DeprecationWarning: .*"
     if options["package"]:
         pattern = r".*/{}/".format(

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ commands =
 setenv =
          PYTHONWARNINGS=default::DeprecationWarning
 commands =
-         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
+         python misc/build_helpers/run-deprecations.py --package allmydata --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
 
 [testenv:upcoming-deprecations]
 setenv =
@@ -109,7 +109,7 @@ deps =
      git+https://github.com/warner/foolscap
 commands =
          flogtool --version
-         python misc/build_helpers/run-deprecations.py --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
+         python misc/build_helpers/run-deprecations.py --package allmydata --warnings={env:TAHOE_LAFS_WARNINGS_LOG:_trial_temp/deprecation-warnings.log} trial {env:TAHOE_LAFS_TRIAL_ARGS:--rterrors} {posargs:allmydata}
 
 [testenv:checkmemory]
 commands =


### PR DESCRIPTION
Fixes: ticket:3232

Since the idea of the deprecations CI jobs is to tell us when Tahoe-LAFS is using deprecated APIs and should be fixed, we don't need to see deprecation warnings triggered by other projects.

The approach here is possible error prone because of the nature of the Python warnings system.  We can only filter based on the information in the warning but the pointer to the code that "caused" a warning is somewhat iffy.  It depends on the warning originator correctly figuring out things about stack levels.  Hopefully they do ... but it's certainly not always the case.

Still, perhaps this is a better trade-off to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/638)
<!-- Reviewable:end -->
