### PR TITLE
Port introweb to use twisted.web.template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -341,6 +341,8 @@ setup(name="tahoe-lafs", # also set in __init__.py
               "towncrier",
               "testtools",
               "fixtures",
+              "beautifulsoup4",
+              "html5lib",
           ],
           "tor": [
               "foolscap[tor] >= 0.12.5",

--- a/src/allmydata/test/web/common.py
+++ b/src/allmydata/test/web/common.py
@@ -9,12 +9,21 @@ FAVICON_MARKUP = '<link href="/icon.png" rel="shortcut icon" />'
 
 
 def assert_soup_has_favicon(testcase, soup):
+    """
+    Using a ``TestCase`` object ``testcase``, assert that the passed in
+    ``BeautifulSoup`` object ``soup`` contains the tahoe favicon link.
+    """
     links = soup.find_all(u'link', rel=u'shortcut icon')
     testcase.assert_(
         any(t[u'href'] == u'/icon.png' for t in links), soup)
 
 
 def assert_soup_has_text(testcase, soup, text):
+    """
+    Using a ``TestCase`` object ``testcase``, assert that the passed in
+    ``BeautifulSoup`` object ``soup`` contains the passed in ``text`` anywhere
+    as a text node.
+    """
     testcase.assert_(
         soup.find_all(string=re.compile(re.escape(text))),
         soup)

--- a/src/allmydata/test/web/common.py
+++ b/src/allmydata/test/web/common.py
@@ -1,6 +1,18 @@
 
+import re
+
 unknown_rwcap = u"lafs://from_the_future_rw_\u263A".encode('utf-8')
 unknown_rocap = u"ro.lafs://readonly_from_the_future_ro_\u263A".encode('utf-8')
 unknown_immcap = u"imm.lafs://immutable_from_the_future_imm_\u263A".encode('utf-8')
 
 FAVICON_MARKUP = '<link href="/icon.png" rel="shortcut icon" />'
+
+def assert_soup_has_favicon(testcase, soup):
+    links = soup.find_all('link', rel='shortcut icon')
+    testcase.assert_(
+        any(t['href'] == '/icon.png' for t in links), soup)
+
+def assert_soup_has_text(testcase, soup, text):
+    testcase.assert_(
+        soup.find_all(string=re.compile(re.escape(text))),
+        soup)

--- a/src/allmydata/test/web/common.py
+++ b/src/allmydata/test/web/common.py
@@ -7,10 +7,12 @@ unknown_immcap = u"imm.lafs://immutable_from_the_future_imm_\u263A".encode('utf-
 
 FAVICON_MARKUP = '<link href="/icon.png" rel="shortcut icon" />'
 
+
 def assert_soup_has_favicon(testcase, soup):
-    links = soup.find_all('link', rel='shortcut icon')
+    links = soup.find_all(u'link', rel=u'shortcut icon')
     testcase.assert_(
-        any(t['href'] == '/icon.png' for t in links), soup)
+        any(t[u'href'] == u'/icon.png' for t in links), soup)
+
 
 def assert_soup_has_text(testcase, soup, text):
     testcase.assert_(

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -1,3 +1,5 @@
+import re
+from bs4 import BeautifulSoup
 from os.path import join
 from twisted.trial import unittest
 from twisted.internet import reactor
@@ -6,7 +8,8 @@ from twisted.internet import defer
 from allmydata.introducer import create_introducer
 from allmydata import node
 from .common import (
-    FAVICON_MARKUP,
+    assert_soup_has_favicon,
+    assert_soup_has_text,
 )
 from ..common import (
     SameProcessStreamEndpointAssigner,
@@ -47,7 +50,8 @@ class IntroducerWeb(unittest.TestCase):
 
         url = "http://localhost:%d/" % self.ws.getPortnum()
         res = yield do_http("get", url)
-        self.failUnlessIn('Welcome to the Tahoe-LAFS Introducer', res)
-        self.failUnlessIn(FAVICON_MARKUP, res)
-        self.failUnlessIn('Page rendered at', res)
-        self.failUnlessIn('Tahoe-LAFS code imported from:', res)
+        soup = BeautifulSoup(res, 'html5lib')
+        assert_soup_has_text(self, soup, 'Welcome to the Tahoe-LAFS Introducer')
+        assert_soup_has_favicon(self, soup)
+        assert_soup_has_text(self, soup, 'Page rendered at')
+        assert_soup_has_text(self, soup, 'Tahoe-LAFS code imported from:')

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -15,6 +15,7 @@ from ..common import (
 )
 from ..common_web import do_http
 
+
 class IntroducerWeb(unittest.TestCase):
     def setUp(self):
         self.node = None
@@ -50,7 +51,7 @@ class IntroducerWeb(unittest.TestCase):
         url = "http://localhost:%d/" % self.ws.getPortnum()
         res = yield do_http("get", url)
         soup = BeautifulSoup(res, 'html5lib')
-        assert_soup_has_text(self, soup, 'Welcome to the Tahoe-LAFS Introducer')
+        assert_soup_has_text(self, soup, u'Welcome to the Tahoe-LAFS Introducer')
         assert_soup_has_favicon(self, soup)
-        assert_soup_has_text(self, soup, 'Page rendered at')
-        assert_soup_has_text(self, soup, 'Tahoe-LAFS code imported from:')
+        assert_soup_has_text(self, soup, u'Page rendered at')
+        assert_soup_has_text(self, soup, u'Tahoe-LAFS code imported from:')

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -1,4 +1,3 @@
-import re
 from bs4 import BeautifulSoup
 from os.path import join
 from twisted.trial import unittest

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -460,7 +460,6 @@ class MultiFormatPage(Page):
             return lambda ctx: renderer(IRequest(ctx))
 
 
-
 class MultiFormatResource(resource.Resource, object):
     """
     ``MultiFormatResource`` is a ``resource.Resource`` that can be rendered in
@@ -490,7 +489,6 @@ class MultiFormatResource(resource.Resource, object):
         renderer = self._get_renderer(t)
         return renderer(req)
 
-
     def _get_renderer(self, fmt):
         """
         Get the renderer for the indicated format.
@@ -516,7 +514,6 @@ class MultiFormatResource(resource.Resource, object):
             renderer = self.render_HTML
 
         return renderer
-
 
 
 class SlotsSequenceElement(template.Element):
@@ -548,10 +545,9 @@ class SlotsSequenceElement(template.Element):
     @template.renderer
     def empty(self, request, tag):
         if len(self.seq) > 0:
-            return ''
+            return u''
         else:
             return tag
-
 
 
 class TokenOnlyWebApi(resource.Resource, object):

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -2,7 +2,7 @@
 import time
 import json
 
-from twisted.web import http, server, resource
+from twisted.web import http, server, resource, template
 from twisted.python import log
 from twisted.python.failure import Failure
 from zope.interface import Interface
@@ -458,6 +458,32 @@ class MultiFormatPage(Page):
             if renderer is None:
                 return super(MultiFormatPage, self).renderHTTP
             return lambda ctx: renderer(IRequest(ctx))
+
+
+
+class SlotsSequenceElement(template.Element):
+    def __init__(self, tag, seq):
+        self.loader = template.TagLoader(tag)
+        self.seq = seq
+
+    @template.renderer
+    def header(self, request, tag):
+        if len(self.seq) > 0:
+            return tag
+        else:
+            return ''
+
+    @template.renderer
+    def item(self, request, tag):
+        for item in self.seq:
+            yield tag().fillSlots(**item)
+    @template.renderer
+
+    def empty(self, request, tag):
+        if len(self.seq) > 0:
+            return ''
+        else:
+            return tag
 
 
 

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -467,13 +467,6 @@ class SlotsSequenceElement(template.Element):
         self.seq = seq
 
     @template.renderer
-    def header(self, request, tag):
-        if len(self.seq) > 0:
-            return tag
-        else:
-            return ''
-
-    @template.renderer
     def item(self, request, tag):
         for item in self.seq:
             yield tag().fillSlots(**item)

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -493,9 +493,9 @@ class MultiFormatResource(resource.Resource, object):
         """
         Get the renderer for the indicated format.
 
-        :param str fmt: The format.  If a method with a prefix of
-            ``render_`` and a suffix of this format (upper-cased) is found, it
-            will be used.
+        :param str fmt: The format.  If a method with a prefix of ``render_``
+            and a suffix of this format (upper-cased) is found, it will be
+            used.
 
         :return: A callable which takes a twisted.web Request and renders a
             response.
@@ -518,19 +518,11 @@ class MultiFormatResource(resource.Resource, object):
 
 class SlotsSequenceElement(template.Element):
     """
-    ``SlotsSequenceElement` is a minimal port of nevow's sequence renderer
-    for twisted.web.template.
+    ``SlotsSequenceElement` is a minimal port of nevow's sequence renderer for
+    twisted.web.template.
 
-    Tags passed in to be templated will have two renderers available:
-
-    - The ``item`` renderer will have its tag cloned for each item in the
-      sequence provided, and its slots filled from the sequence item. Each
-      item must be dict-like enough for ``tag.fillSlots(**item)``. Each cloned
-      tag will be siblings with no separator beween them.
-
-    - The ``empty`` renderer will either return its tag unmodified if the
-      provided sequence has no items, or return the empty string if there are
-      any items.
+    Tags passed in to be templated will have two renderers available: ``item``
+    and ``tag``.
     """
 
     def __init__(self, tag, seq):
@@ -539,11 +531,26 @@ class SlotsSequenceElement(template.Element):
 
     @template.renderer
     def item(self, request, tag):
+        """
+        A template renderer for each sequence item.
+
+        ``tag`` will be cloned for each item in the sequence provided, and its
+        slots filled from the sequence item. Each item must be dict-like enough
+        for ``tag.fillSlots(**item)``. Each cloned tag will be siblings with no
+        separator beween them.
+        """
         for item in self.seq:
             yield tag.clone(deep=False).fillSlots(**item)
 
     @template.renderer
     def empty(self, request, tag):
+        """
+        A template renderer for empty sequences.
+
+        This renderer will either return ``tag`` unmodified if the provided
+        sequence has no items, or return the empty string if there are any
+        items.
+        """
         if len(self.seq) > 0:
             return u''
         else:

--- a/src/allmydata/web/introducer.xhtml
+++ b/src/allmydata/web/introducer.xhtml
@@ -1,4 +1,4 @@
-<html xmlns:n="http://nevow.com/ns/nevow/0.1"><head>
+<html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1"><head>
   <title>Tahoe-LAFS - Introducer Status</title>
   <link href="/tahoe.css" rel="stylesheet" type="text/css"/>
   <link href="/icon.png" rel="shortcut icon" />
@@ -10,23 +10,23 @@
 <div class="section" id="this-client">
   <h2>This Introducer</h2>
 
-  <table class="node-info table-headings-left">
-    <tr><th>My nodeid:</th> <td class="nodeid mine data-chars" n:render="string" n:data="my_nodeid" /></tr>
-    <tr><th>My versions:</th> <td n:render="string" n:data="version" /></tr>
-    <tr><th>Tahoe-LAFS code imported from:</th> <td n:render="data" n:data="import_path" /></tr>
+  <table class="node-info table-headings-left" t:render="node_data">
+    <tr><th>My nodeid:</th> <td class="nodeid mine data-chars"><t:slot name="my_nodeid" /></td></tr>
+    <tr><th>My versions:</th> <td><t:slot name="version" /></td></tr>
+    <tr><th>Tahoe-LAFS code imported from:</th> <td><t:slot name="import_path" /></td></tr>
   </table>
 </div>
 
-<div>Announcement Summary: <span n:render="announcement_summary" /></div>
-<div>Subscription Summary: <span n:render="client_summary" /></div>
+<div>Announcement Summary: <span t:render="announcement_summary" /></div>
+<div>Subscription Summary: <span t:render="client_summary" /></div>
 
 <br />
 
 
 <div class="section">
 <h2>Service Announcements</h2>
-<table class="services table-headings-top" n:render="sequence" n:data="services">
-  <tr n:pattern="header">
+<table class="services table-headings-top" t:render="services">
+  <tr t:render="header">
     <th class="nickname-and-peerid">
       <div class="service-nickname">Nickname</div>
       <div class="nodeid data-chars">ServerID</div></th>
@@ -34,23 +34,23 @@
     <th>Version</th>
     <th>Service Name</th>
   </tr>
-  <tr n:pattern="item" n:render="service_row">
+  <tr t:render="item">
     <td class="nickname-and-peerid">
-      <div class="nickname"><n:slot name="nickname"/></div>
-      <div class="nodeid data-chars"><n:slot name="serverid"/></div></td>
-    <td class="service-announced"><n:attr name="title"><n:slot name="connection-hints"/></n:attr><n:slot name="announced"/></td>
-    <td class="service-version"><n:slot name="version"/></td>
-    <td class="service-service-name"><n:slot name="service_name"/></td>
+      <div class="nickname"><t:slot name="nickname"/></div>
+      <div class="nodeid data-chars"><t:slot name="serverid"/></div></td>
+    <td class="service-announced"><t:attr name="title"><t:slot name="connection-hints"/></t:attr><t:slot name="announced"/></td>
+    <td class="service-version"><t:slot name="version"/></td>
+    <td class="service-service-name"><t:slot name="service_name"/></td>
   </tr>
-  <tr n:pattern="empty"><td>no peers!</td></tr>
+  <tr t:render="empty"><td>no peers!</td></tr>
 </table>
 </div>
 
 
 <div>
 <h2>Subscribed Clients</h2>
-<table class="services table-headings-top" n:render="sequence" n:data="subscribers">
-  <tr n:pattern="header">
+<table class="services table-headings-top" t:render="subscribers">
+  <tr t:render="header">
     <th class="nickname-and-peerid">
       <div class="service-nickname">Nickname</div>
       <div class="nodeid data-chars">Tub ID</div></th>
@@ -59,20 +59,20 @@
     <th>Version</th>
     <th>Subscribed To</th>
   </tr>
-  <tr n:pattern="item" n:render="subscriber_row">
+  <tr t:render="item">
     <td class="nickname-and-peerid">
-      <div class="nickname"><n:slot name="nickname"/></div>
-      <div class="nodeid data-chars"><n:slot name="tubid"/></div></td>
-    <td><n:slot name="connected"/></td>
-    <td class="service-since"><n:slot name="since"/></td>
-    <td class="service-version"><n:slot name="version"/></td>
-    <td class="service-service-name"><n:slot name="service_name"/></td>
+      <div class="nickname"><t:slot name="nickname"/></div>
+      <div class="nodeid data-chars"><t:slot name="tubid"/></div></td>
+    <td><t:slot name="connected"/></td>
+    <td class="service-since"><t:slot name="since"/></td>
+    <td class="service-version"><t:slot name="version"/></td>
+    <td class="service-service-name"><t:slot name="service_name"/></td>
   </tr>
-  <tr n:pattern="empty"><td>no subscribers!</td></tr>
+  <tr t:render="empty"><td>no subscribers!</td></tr>
 </table>
 </div>
 
-<p class="minutia">Page rendered at <span n:render="data" n:data="rendered_at" /></p>
+<p class="minutia" t:render="node_data">Page rendered at <span><t:slot name="rendered_at" /></span></p>
 
   </body>
 </html>

--- a/src/allmydata/web/introducer.xhtml
+++ b/src/allmydata/web/introducer.xhtml
@@ -26,7 +26,7 @@
 <div class="section">
 <h2>Service Announcements</h2>
 <table class="services table-headings-top" t:render="services">
-  <tr t:render="header">
+  <tr>
     <th class="nickname-and-peerid">
       <div class="service-nickname">Nickname</div>
       <div class="nodeid data-chars">ServerID</div></th>
@@ -50,7 +50,7 @@
 <div>
 <h2>Subscribed Clients</h2>
 <table class="services table-headings-top" t:render="subscribers">
-  <tr t:render="header">
+  <tr>
     <th class="nickname-and-peerid">
       <div class="service-nickname">Nickname</div>
       <div class="nodeid data-chars">Tub ID</div></th>

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -75,16 +75,6 @@ class IntroducerRootElement(Element):
     def node_data(self, req, tag):
         return tag.fillSlots(**self.node_data_dict)
 
-    # FIXME: This code is duplicated in root.py and introweb.py.
-    def data_rendered_at(self, ctx, data):
-        return render_time(time.time())
-    def data_version(self, ctx, data):
-        return get_package_versions_string()
-    def data_import_path(self, ctx, data):
-        return str(allmydata).replace("/", "/ ")
-    def data_my_nodeid(self, ctx, data):
-        return idlib.nodeid_b2a(self.introducer_node.nodeid)
-
     @renderer
     def announcement_summary(self, req, data):
         services = {}

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -13,16 +13,14 @@ from allmydata.util import idlib
 from allmydata.web.common import (
     getxmlfile,
     render_time,
-    MultiFormatPage,
+    MultiFormatResource,
     SlotsSequenceElement,
 )
 
 
-class IntroducerRoot(resource.Resource):
+class IntroducerRoot(MultiFormatResource):
     def __init__(self, introducer_node):
-        resource.Resource.__init__(self)
-        # probably should fix this.. Resource isn't new-style in py2
-        #super(IntroducerRoot, self).__init__()
+        super(IntroducerRoot, self).__init__()
         self.introducer_node = introducer_node
         self.introducer_service = introducer_node.getServiceNamed("introducer")
         # necessary as a root Resource
@@ -31,8 +29,8 @@ class IntroducerRoot(resource.Resource):
         for filen in os.listdir(static_dir):
             self.putChild(filen, nevow_File(os.path.join(static_dir, filen)))
 
-    def render(self, request):
-        return renderElement(request, IntroducerRootElement(
+    def render_HTML(self, req):
+        return renderElement(req, IntroducerRootElement(
             self.introducer_node, self.introducer_service))
 
     def render_JSON(self, req):

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -1,7 +1,7 @@
 
 import time, os
 from pkg_resources import resource_filename
-from twisted.web.template import Element, renderer, renderElement, XMLFile
+from twisted.web.template import Element, XMLFile, renderElement, renderer
 from twisted.python.filepath import FilePath
 from twisted.web import resource, static
 import allmydata
@@ -9,7 +9,6 @@ import json
 from allmydata.version_checks import get_package_versions_string
 from allmydata.util import idlib
 from allmydata.web.common import (
-    getxmlfile,
     render_time,
     MultiFormatResource,
     SlotsSequenceElement,
@@ -17,12 +16,13 @@ from allmydata.web.common import (
 
 
 class IntroducerRoot(MultiFormatResource):
+
     def __init__(self, introducer_node):
         super(IntroducerRoot, self).__init__()
         self.introducer_node = introducer_node
         self.introducer_service = introducer_node.getServiceNamed("introducer")
         # necessary as a root Resource
-        self.putChild('', self)
+        self.putChild("", self)
         static_dir = resource_filename("allmydata.web", "static")
         for filen in os.listdir(static_dir):
             self.putChild(filen, static.File(os.path.join(static_dir, filen)))
@@ -61,10 +61,10 @@ class IntroducerRootElement(Element):
         self.introducer_node = introducer_node
         self.introducer_service = introducer_service
         self.node_data_dict = {
-            'my_nodeid': idlib.nodeid_b2a(self.introducer_node.nodeid),
-            'version': get_package_versions_string(),
-            'import_path': str(allmydata).replace("/", "/ "),  # XXX kludge for wrapping
-            'rendered_at': render_time(time.time()),
+            "my_nodeid": idlib.nodeid_b2a(self.introducer_node.nodeid),
+            "version": get_package_versions_string(),
+            "import_path": str(allmydata).replace("/", "/ "),  # XXX kludge for wrapping
+            "rendered_at": render_time(time.time()),
         }
 
     @renderer
@@ -72,7 +72,7 @@ class IntroducerRootElement(Element):
         return tag.fillSlots(**self.node_data_dict)
 
     @renderer
-    def announcement_summary(self, req, data):
+    def announcement_summary(self, req, tag):
         services = {}
         for ad in self.introducer_service.get_announcements():
             if ad.service_name not in services:
@@ -84,7 +84,7 @@ class IntroducerRootElement(Element):
                           for service_name in service_names])
 
     @renderer
-    def client_summary(self, req, data):
+    def client_summary(self, req, tag):
         counts = {}
         for s in self.introducer_service.get_subscribers():
             if s.service_name not in counts:
@@ -110,7 +110,7 @@ class IntroducerRootElement(Element):
         return SlotsSequenceElement(tag, services)
 
     @renderer
-    def subscribers(self, ctx, tag):
+    def subscribers(self, req, tag):
         subscribers = [{
             "nickname": s.nickname,
             "tubid": s.tubid,

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -1,11 +1,9 @@
 
 import time, os
-from nevow import rend
-from nevow.static import File as nevow_File
-from nevow.util import resource_filename
+from pkg_resources import resource_filename
 from twisted.web.template import Element, renderer, renderElement, XMLFile
 from twisted.python.filepath import FilePath
-from twisted.web import resource
+from twisted.web import resource, static
 import allmydata
 import json
 from allmydata.version_checks import get_package_versions_string
@@ -27,7 +25,7 @@ class IntroducerRoot(MultiFormatResource):
         self.putChild('', self)
         static_dir = resource_filename("allmydata.web", "static")
         for filen in os.listdir(static_dir):
-            self.putChild(filen, nevow_File(os.path.join(static_dir, filen)))
+            self.putChild(filen, static.File(os.path.join(static_dir, filen)))
 
     def render_HTML(self, req):
         return renderElement(req, IntroducerRootElement(

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -3,7 +3,7 @@ import time, os
 from pkg_resources import resource_filename
 from twisted.web.template import Element, XMLFile, renderElement, renderer
 from twisted.python.filepath import FilePath
-from twisted.web import resource, static
+from twisted.web import static
 import allmydata
 import json
 from allmydata.version_checks import get_package_versions_string

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -16,6 +16,12 @@ from allmydata.web.common import (
 
 
 class IntroducerRoot(MultiFormatResource):
+    """
+    A ``Resource`` intended as the root resource for introducers.
+
+    :param _IntroducerNode introducer_node: The introducer node to template
+        information about.
+    """
 
     def __init__(self, introducer_node):
         super(IntroducerRoot, self).__init__()
@@ -27,11 +33,24 @@ class IntroducerRoot(MultiFormatResource):
         for filen in os.listdir(static_dir):
             self.putChild(filen, static.File(os.path.join(static_dir, filen)))
 
+    def _create_element(self):
+        """
+        Create a ``IntroducerRootElement`` which can be flattened into an HTML
+        response.
+        """
+        return IntroducerRootElement(
+            self.introducer_node, self.introducer_service)
+
     def render_HTML(self, req):
-        return renderElement(req, IntroducerRootElement(
-            self.introducer_node, self.introducer_service))
+        """
+        Render an HTML template describing this introducer node.
+        """
+        return renderElement(req, self._create_element())
 
     def render_JSON(self, req):
+        """
+        Render JSON describing this introducer node.
+        """
         res = {}
 
         counts = {}

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -72,6 +72,14 @@ class IntroducerRoot(MultiFormatResource):
 
 
 class IntroducerRootElement(Element):
+    """
+    An ``Element`` HTML template which can be flattened to describe this
+    introducer node.
+
+    :param _IntroducerNode introducer_node: The introducer node to describe.
+    :param IntroducerService introducer_service: The introducer service created
+        by the node.
+    """
 
     loader = XMLFile(FilePath(__file__).sibling("introducer.xhtml"))
 

--- a/src/allmydata/web/introweb.py
+++ b/src/allmydata/web/introweb.py
@@ -39,7 +39,7 @@ class IntroducerRoot(MultiFormatResource):
             if s.service_name not in counts:
                 counts[s.service_name] = 0
             counts[s.service_name] += 1
-        res["subscription_summary"] = counts
+        res[u"subscription_summary"] = counts
 
         announcement_summary = {}
         for ad in self.introducer_service.get_announcements():
@@ -47,9 +47,9 @@ class IntroducerRoot(MultiFormatResource):
             if service_name not in announcement_summary:
                 announcement_summary[service_name] = 0
             announcement_summary[service_name] += 1
-        res["announcement_summary"] = announcement_summary
+        res[u"announcement_summary"] = announcement_summary
 
-        return json.dumps(res, indent=1) + "\n"
+        return json.dumps(res, indent=1) + b"\n"
 
 
 class IntroducerRootElement(Element):
@@ -80,8 +80,8 @@ class IntroducerRootElement(Element):
             services[ad.service_name] += 1
         service_names = services.keys()
         service_names.sort()
-        return ", ".join(["%s: %d" % (service_name, services[service_name])
-                          for service_name in service_names])
+        return u", ".join(u"{}: {}".format(service_name, services[service_name])
+                          for service_name in service_names)
 
     @renderer
     def client_summary(self, req, tag):
@@ -90,8 +90,8 @@ class IntroducerRootElement(Element):
             if s.service_name not in counts:
                 counts[s.service_name] = 0
             counts[s.service_name] += 1
-        return ", ".join([ "%s: %d" % (name, counts[name])
-                           for name in sorted(counts.keys()) ] )
+        return u", ".join(u"{}: {}".format(name, counts[name])
+                          for name in sorted(counts.keys()))
 
     @renderer
     def services(self, req, tag):
@@ -101,8 +101,8 @@ class IntroducerRootElement(Element):
             "serverid": ad.serverid,
             "nickname": ad.nickname,
             "connection-hints":
-                "connection hints: " + " ".join(ad.connection_hints),
-            "connected": "?",
+                u"connection hints: " + u" ".join(ad.connection_hints),
+            "connected": u"?",
             "announced": render_time(ad.when),
             "version": ad.version,
             "service_name": ad.service_name,


### PR DESCRIPTION
A small/proof of concept port to show that not much has to change to use twt instead of nevow.

The tests failed without also switching to use an actual html parser. The attributes were scrambled around compared to what the substring test expected, so something more involved was necessary. I know `html5lib` is/will be used in the tests in the near future, so this seems fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/649)
<!-- Reviewable:end -->
