### PR TITLE
Pin a known working foolscap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ install_requires = [
     #   and allocate_tcp_port
     # * foolscap >= 0.12.5 has ConnectionInfo and ReconnectionInfo
     # * foolscap >= 0.12.6 has an i2p.sam_endpoint() that takes kwargs
-    "foolscap >= 0.12.6",
+    # * foolscap 0.13.2 drops i2p support completely
+    "foolscap == 0.13.1",
 
     # * cryptography 2.6 introduced some ed25519 APIs we rely on.  Note that
     #   Twisted[conch] also depends on cryptography and Twisted[tls]


### PR DESCRIPTION
Fixes: ticket:3272

I chose to fix this by pinning the older, working Foolscap version.  No doubt this will need to be changed in the course of any Python 3 porting work but this at least gives us the opportunity to make one final I2P-supporting release of Tahoe-LAFS, if we wish.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/675)
<!-- Reviewable:end -->
