### PR TITLE
Attempt to inherit the base dependencies in the pyinstaller env

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,7 +69,7 @@ after_test:
     %PYTHON%\python.exe setup.py bdist_wheel
     %PYTHON%\python.exe -m pip wheel -w dist .
   - |
-    %PYTHON%\python.exe -m pip install codecov coverage
+    %PYTHON%\python.exe -m pip install codecov "coverage ~= 4.5"
     %PYTHON%\python.exe -m coverage xml -o coverage.xml -i
     %PYTHON%\python.exe -m codecov -X search -X gcov -f coverage.xml
 

--- a/tox.ini
+++ b/tox.ini
@@ -171,6 +171,7 @@ commands =
 install_command = python -m pip install --no-use-pep517 {opts} {packages}
 extras =
 deps =
+    {[testenv]deps}
     packaging
     pyinstaller
 # Setting PYTHONHASHSEED to a known value assists with reproducible builds.


### PR DESCRIPTION
Fixes: ticket:3276

This also adds another pin for `coverage` in the appveyor configuration.  This duplicates the CircleCI fix from ticket:3267 / #670 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/687)
<!-- Reviewable:end -->
