### PR TITLE
Use twisted.web.template in web/storage.py

### DIFF
--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -4210,9 +4210,9 @@ class WebStatus(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
 
     def test_util(self):
         w = StorageStatusElement(None, None)
-        self.failUnlessEqual(w.render_space(None, None), "?")
-        self.failUnlessEqual(w.render_space(None, 10e6), "10000000")
-        self.failUnlessEqual(w.render_abbrev_space(None, None), "?")
-        self.failUnlessEqual(w.render_abbrev_space(None, 10e6), "10.00 MB")
+        self.failUnlessEqual(w.render_space(None), "?")
+        self.failUnlessEqual(w.render_space(10e6), "10000000")
+        self.failUnlessEqual(w.render_abbrev_space(None), "?")
+        self.failUnlessEqual(w.render_abbrev_space(10e6), "10.00 MB")
         self.failUnlessEqual(remove_prefix("foo.bar", "foo."), "bar")
         self.failUnlessEqual(remove_prefix("foo.bar", "baz."), None)

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -2975,6 +2975,8 @@ def remove_tags(s):
 
 def renderSynchronously(ss):
     """
+    Return fully rendered HTML document.
+
     :param _StorageStatus ss: a StorageStatus instance.
     """
     elem = StorageStatusElement(ss._storage, ss._nickname)
@@ -2982,10 +2984,20 @@ def renderSynchronously(ss):
     return unittest.TestCase().successResultOf(deferred)
 
 def renderDeferred(ss):
+    """
+    Return a `Deferred` HTML renderer.
+
+    :param _StorageStatus ss: a StorageStatus instance.
+    """
     elem = StorageStatusElement(ss._storage, ss._nickname)
     return flattenString(None, elem)
 
 class JSONRequest(Request):
+    """
+    A Request with t=json argument added to it.
+
+    This is useful to invoke a Resouce.render_JSON() method.
+    """
     implements(IRequest)
 
     def __init__(self, **kwargs):
@@ -2994,6 +3006,11 @@ class JSONRequest(Request):
         self.fields = {}
 
 def renderJSON(resource):
+    """Exercise resouce.render_JSON()
+
+    :param _MultiFormatResource resouce: A `twisted.web.resouce.Resource`
+        that contains a render_JSON() method.
+    """
     return resource.render(JSONRequest())
 
 class MyBucketCountingCrawler(BucketCountingCrawler):

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -30,8 +30,11 @@ from allmydata.interfaces import BadWriteEnablerError
 from allmydata.test.common import LoggingServiceParent, ShouldFailMixin
 from allmydata.test.common_web import WebRenderingMixin
 from allmydata.test.no_network import NoNetworkServer
-from allmydata.web.storage import StorageStatus, StorageStatusElement, \
+from allmydata.web.storage import (
+    StorageStatus,
+    StorageStatusElement,
     remove_prefix
+)
 from allmydata.storage_client import (
     _StorageServer,
 )

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -29,7 +29,6 @@ from allmydata.mutable.layout import MDMFSlotWriteProxy, MDMFSlotReadProxy, \
                                      SHARE_HASH_CHAIN_SIZE
 from allmydata.interfaces import BadWriteEnablerError
 from allmydata.test.common import LoggingServiceParent, ShouldFailMixin
-from allmydata.test.common_web import WebRenderingMixin
 from nevow.testutil import FakeRequest
 from allmydata.test.no_network import NoNetworkServer
 from allmydata.web.storage import (
@@ -3185,7 +3184,7 @@ class InstrumentedStorageServer(StorageServer):
 class No_ST_BLOCKS_StorageServer(StorageServer):
     LeaseCheckerClass = No_ST_BLOCKS_LeaseCheckingCrawler
 
-class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
+class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin):
 
     def setUp(self):
         self.s = service.MultiService()
@@ -4087,7 +4086,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
         d = renderDeferred(page, args={"t": ["json"]})
         return d
 
-class WebStatus(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
+class WebStatus(unittest.TestCase, pollmixin.PollMixin):
 
     def setUp(self):
         self.s = service.MultiService()

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -11,9 +11,8 @@ from twisted.web.template import flattenString
 # web/common.py, we can use `twisted.web.iweb.IRequest` here.
 from nevow.inevow import IRequest
 
-# from twisted.web.server import Request
-from twisted.web.test.test_web import DummyRequest
-from zope.interface import implements
+from twisted.web.test.requesthelper import DummyRequest
+from zope.interface import implementer
 
 from foolscap.api import fireEventually
 import itertools
@@ -2990,14 +2989,13 @@ def renderDeferred(ss):
     elem = StorageStatusElement(ss._storage, ss._nickname)
     return flattenString(None, elem)
 
+@implementer(IRequest)
 class JSONRequest(DummyRequest):
     """
     A Request with t=json argument added to it.
 
     This is useful to invoke a Resouce.render_JSON() method.
     """
-    implements(IRequest)
-
     def __init__(self, **kwargs):
         DummyRequest.__init__(self, b"/", **kwargs)
         self.args = {"t": ["json"]}

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -30,7 +30,8 @@ from allmydata.interfaces import BadWriteEnablerError
 from allmydata.test.common import LoggingServiceParent, ShouldFailMixin
 from allmydata.test.common_web import WebRenderingMixin
 from allmydata.test.no_network import NoNetworkServer
-from allmydata.web.storage import StorageStatus, remove_prefix
+from allmydata.web.storage import StorageStatus, StorageStatusElement, \
+    remove_prefix
 from allmydata.storage_client import (
     _StorageServer,
 )
@@ -4208,7 +4209,7 @@ class WebStatus(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
         self.failUnlessIn("Reserved space: - 10.00 MB (10000000)", s)
 
     def test_util(self):
-        w = StorageStatus(None)
+        w = StorageStatusElement(None, None)
         self.failUnlessEqual(w.render_space(None, None), "?")
         self.failUnlessEqual(w.render_space(None, 10e6), "10000000")
         self.failUnlessEqual(w.render_abbrev_space(None, None), "?")

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -11,7 +11,8 @@ from twisted.web.template import flattenString
 # web/common.py, we can use `twisted.web.iweb.IRequest` here.
 from nevow.inevow import IRequest
 
-from twisted.web.test.requesthelper import DummyRequest
+from twisted.web.server import Request
+from twisted.web.test.requesthelper import DummyChannel
 from zope.interface import implementer
 
 from foolscap.api import fireEventually
@@ -2989,24 +2990,20 @@ def renderDeferred(ss):
     elem = StorageStatusElement(ss._storage, ss._nickname)
     return flattenString(None, elem)
 
-@implementer(IRequest)
-class JSONRequest(DummyRequest):
-    """
-    A Request with t=json argument added to it.
-
-    This is useful to invoke a Resouce.render_JSON() method.
-    """
-    def __init__(self, **kwargs):
-        DummyRequest.__init__(self, b"/", **kwargs)
-        self.args = {"t": ["json"]}
-        self.fields = {}
-
 def renderJSON(resource):
-    """Exercise resouce.render_JSON()
+    """Render a JSON from the given resource."""
 
-    :param _MultiFormatResource resouce: A `twisted.web.resouce.Resource`
-        that contains a render_JSON() method.
-    """
+    @implementer(IRequest)
+    class JSONRequest(Request):
+        """
+        A Request with t=json argument added to it.  This is useful to
+        invoke a Resouce.render_JSON() method.
+        """
+        def __init__(self):
+            Request.__init__(self, DummyChannel())
+            self.args = {"t": ["json"]}
+            self.fields = {}
+
     return resource.render(JSONRequest())
 
 class MyBucketCountingCrawler(BucketCountingCrawler):

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -11,8 +11,8 @@ from twisted.web.template import flattenString
 # web/common.py, we can use `twisted.web.iweb.IRequest` here.
 from nevow.inevow import IRequest
 
-from twisted.web.server import Request
-from twisted.web.test.test_web import DummyChannel
+# from twisted.web.server import Request
+from twisted.web.test.test_web import DummyRequest
 from zope.interface import implements
 
 from foolscap.api import fireEventually
@@ -2990,7 +2990,7 @@ def renderDeferred(ss):
     elem = StorageStatusElement(ss._storage, ss._nickname)
     return flattenString(None, elem)
 
-class JSONRequest(Request):
+class JSONRequest(DummyRequest):
     """
     A Request with t=json argument added to it.
 
@@ -2999,7 +2999,7 @@ class JSONRequest(Request):
     implements(IRequest)
 
     def __init__(self, **kwargs):
-        Request.__init__(self, DummyChannel(), **kwargs)
+        DummyRequest.__init__(self, b"/", **kwargs)
         self.args = {"t": ["json"]}
         self.fields = {}
 

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -2979,9 +2979,7 @@ def renderSynchronously(ss):
 
     :param _StorageStatus ss: a StorageStatus instance.
     """
-    elem = StorageStatusElement(ss._storage, ss._nickname)
-    deferred = flattenString(None, elem)
-    return unittest.TestCase().successResultOf(deferred)
+    return unittest.TestCase().successResultOf(renderDeferred(ss))
 
 def renderDeferred(ss):
     """

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -5,6 +5,16 @@ from twisted.trial import unittest
 from twisted.internet import defer
 from twisted.application import service
 from twisted.web.template import flattenString
+
+# We need to use `nevow.inevow.IRequest` for now for compatibility
+# with the code in web/common.py.  Once nevow bits are gone from
+# web/common.py, we can use `twisted.web.iweb.IRequest` here.
+from nevow.inevow import IRequest
+
+from twisted.web.server import Request
+from twisted.web.test.test_web import DummyChannel
+from zope.interface import implements
+
 from foolscap.api import fireEventually
 import itertools
 from allmydata import interfaces
@@ -29,7 +39,6 @@ from allmydata.mutable.layout import MDMFSlotWriteProxy, MDMFSlotReadProxy, \
                                      SHARE_HASH_CHAIN_SIZE
 from allmydata.interfaces import BadWriteEnablerError
 from allmydata.test.common import LoggingServiceParent, ShouldFailMixin
-from nevow.testutil import FakeRequest
 from allmydata.test.no_network import NoNetworkServer
 from allmydata.web.storage import (
     StorageStatus,
@@ -2972,28 +2981,20 @@ def renderSynchronously(ss):
     deferred = flattenString(None, elem)
     return unittest.TestCase().successResultOf(deferred)
 
-def renderDeferred(resource, **kwargs):
-    """
-    Use this to exercise an overridden MultiFormatResource.render(),
-    usually for output=json or render_GET.  It returns a Deferred.
+def renderDeferred(ss):
+    elem = StorageStatusElement(ss._storage, ss._nickname)
+    return flattenString(None, elem)
 
-    :param _MultiFormatResource resource: an HTTP resource to be rendered.
+class JSONRequest(Request):
+    implements(IRequest)
 
-    """
-    # We should be using twisted.web's DummyRequest here instead of
-    # nevow's FakeRequest, but right now it is a bit of a problem: see
-    # web/common.py.  MultiFormatResource.render() makes a get_arg()
-    # call, which does a IRequest(ctx_or_req).  IRequest can handle
-    # FakeRequest, but it can't handle DummyRequest.
-    req = FakeRequest(**kwargs)
-    req.fields = None
-    d = defer.maybeDeferred(resource.render, req)
-    def _done(res):
-        if isinstance(res, str):
-            return res + req.v
-        return req.v
-    d.addCallback(_done)
-    return d
+    def __init__(self, **kwargs):
+        Request.__init__(self, DummyChannel(), **kwargs)
+        self.args = {"t": ["json"]}
+        self.fields = {}
+
+def renderJSON(resource):
+    return resource.render(JSONRequest())
 
 class MyBucketCountingCrawler(BucketCountingCrawler):
     def finished_prefix(self, cycle, prefix):
@@ -4083,7 +4084,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin):
         return d
 
     def render_json(self, page):
-        d = renderDeferred(page, args={"t": ["json"]})
+        d = renderJSON(page)
         return d
 
 class WebStatus(unittest.TestCase, pollmixin.PollMixin):
@@ -4127,7 +4128,7 @@ class WebStatus(unittest.TestCase, pollmixin.PollMixin):
         return d
 
     def render_json(self, page):
-        d = renderDeferred(page, args={"t": ["json"]})
+        d = renderJSON(page)
         return d
 
     def test_status_no_disk_stats(self):

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -3399,7 +3399,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin):
                               "(2 mutable / 2 immutable),", s)
             self.failUnlessIn("but expiration was not enabled", s)
         d.addCallback(_check_html)
-        d.addCallback(lambda ign: self.render_json(webstatus))
+        d.addCallback(lambda ign: renderJSON(webstatus))
         def _check_json(raw):
             data = json.loads(raw)
             self.failUnlessIn("lease-checker", data)
@@ -4036,7 +4036,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin):
             self.failUnlessEqual(so_far["corrupt-shares"], [(first_b32, 0)])
         d.addCallback(_after_first_bucket)
 
-        d.addCallback(lambda ign: self.render_json(w))
+        d.addCallback(lambda ign: renderJSON(w))
         def _check_json(raw):
             data = json.loads(raw)
             # grr. json turns all dict keys into strings.
@@ -4063,7 +4063,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin):
             self.failUnlessEqual(rec["examined-shares"], 3)
             self.failUnlessEqual(last["corrupt-shares"], [(first_b32, 0)])
         d.addCallback(_after_first_cycle)
-        d.addCallback(lambda ign: self.render_json(w))
+        d.addCallback(lambda ign: renderJSON(w))
         def _check_json_history(raw):
             data = json.loads(raw)
             last = data["lease-checker"]["history"]["0"]
@@ -4083,9 +4083,6 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin):
         d.addBoth(_cleanup)
         return d
 
-    def render_json(self, page):
-        d = renderJSON(page)
-        return d
 
 class WebStatus(unittest.TestCase, pollmixin.PollMixin):
 
@@ -4116,7 +4113,7 @@ class WebStatus(unittest.TestCase, pollmixin.PollMixin):
             self.failUnlessIn("Accepting new shares: Yes", s)
             self.failUnlessIn("Reserved space: - 0 B (0)", s)
         d.addCallback(_check_html)
-        d.addCallback(lambda ign: self.render_json(w))
+        d.addCallback(lambda ign: renderJSON(w))
         def _check_json(raw):
             data = json.loads(raw)
             s = data["stats"]
@@ -4127,9 +4124,6 @@ class WebStatus(unittest.TestCase, pollmixin.PollMixin):
         d.addCallback(_check_json)
         return d
 
-    def render_json(self, page):
-        d = renderJSON(page)
-        return d
 
     def test_status_no_disk_stats(self):
         def call_get_disk_stats(whichdir, reserved_space=0):

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -30,6 +30,7 @@ from allmydata.mutable.layout import MDMFSlotWriteProxy, MDMFSlotReadProxy, \
 from allmydata.interfaces import BadWriteEnablerError
 from allmydata.test.common import LoggingServiceParent, ShouldFailMixin
 from allmydata.test.common_web import WebRenderingMixin
+from nevow.testutil import FakeRequest
 from allmydata.test.no_network import NoNetworkServer
 from allmydata.web.storage import (
     StorageStatus,
@@ -2972,6 +2973,29 @@ def renderSynchronously(ss):
     deferred = flattenString(None, elem)
     return unittest.TestCase().successResultOf(deferred)
 
+def renderDeferred(resource, **kwargs):
+    """
+    Use this to exercise an overridden MultiFormatResource.render(),
+    usually for output=json or render_GET.  It returns a Deferred.
+
+    :param _MultiFormatResource resource: an HTTP resource to be rendered.
+
+    """
+    # We should be using twisted.web's DummyRequest here instead of
+    # nevow's FakeRequest, but right now it is a bit of a problem: see
+    # web/common.py.  MultiFormatResource.render() makes a get_arg()
+    # call, which does a IRequest(ctx_or_req).  IRequest can handle
+    # FakeRequest, but it can't handle DummyRequest.
+    req = FakeRequest(**kwargs)
+    req.fields = None
+    d = defer.maybeDeferred(resource.render, req)
+    def _done(res):
+        if isinstance(res, str):
+            return res + req.v
+        return req.v
+    d.addCallback(_done)
+    return d
+
 class MyBucketCountingCrawler(BucketCountingCrawler):
     def finished_prefix(self, cycle, prefix):
         BucketCountingCrawler.finished_prefix(self, cycle, prefix)
@@ -3291,7 +3315,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             self.failIfEqual(sr2["configured-diskbytes"], None)
             self.failIfEqual(sr2["original-sharebytes"], None)
         d.addCallback(_after_first_bucket)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html_in_cycle(html):
             s = remove_tags(html)
             self.failUnlessIn("So far, this cycle has examined "
@@ -3366,7 +3390,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             self.failUnlessEqual(count_leases(mutable_si_2), 1)
             self.failUnlessEqual(count_leases(mutable_si_3), 2)
         d.addCallback(_after_first_cycle)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html(html):
             s = remove_tags(html)
             self.failUnlessIn("recovered: 0 shares, 0 buckets "
@@ -3466,7 +3490,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
                 d2.addCallback(_after_first_bucket)
                 return d2
         d.addCallback(_after_first_bucket)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html_in_cycle(html):
             s = remove_tags(html)
             # the first bucket encountered gets deleted, and its prefix
@@ -3525,7 +3549,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             self.failUnless(rec["configured-diskbytes"] >= 0,
                             rec["configured-diskbytes"])
         d.addCallback(_after_first_cycle)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html(html):
             s = remove_tags(html)
             self.failUnlessIn("Expiration Enabled: expired leases will be removed", s)
@@ -3610,7 +3634,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
                 d2.addCallback(_after_first_bucket)
                 return d2
         d.addCallback(_after_first_bucket)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html_in_cycle(html):
             s = remove_tags(html)
             # the first bucket encountered gets deleted, and its prefix
@@ -3671,7 +3695,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             self.failUnless(rec["configured-diskbytes"] >= 0,
                             rec["configured-diskbytes"])
         d.addCallback(_after_first_cycle)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html(html):
             s = remove_tags(html)
             self.failUnlessIn("Expiration Enabled:"
@@ -3733,7 +3757,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             self.failUnlessEqual(count_shares(mutable_si_3), 1)
             self.failUnlessEqual(count_leases(mutable_si_3), 2)
         d.addCallback(_after_first_cycle)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html(html):
             s = remove_tags(html)
             self.failUnlessIn("The following sharetypes will be expired: immutable.", s)
@@ -3790,7 +3814,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             self.failUnlessEqual(count_shares(mutable_si_2), 0)
             self.failUnlessEqual(count_shares(mutable_si_3), 0)
         d.addCallback(_after_first_cycle)
-        d.addCallback(lambda ign: self.render1(webstatus))
+        d.addCallback(lambda ign: renderDeferred(webstatus))
         def _check_html(html):
             s = remove_tags(html)
             self.failUnlessIn("The following sharetypes will be expired: mutable.", s)
@@ -4021,7 +4045,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             # it also turns all tuples into lists
             self.failUnlessEqual(corrupt_shares, [[first_b32, 0]])
         d.addCallback(_check_json)
-        d.addCallback(lambda ign: self.render1(w))
+        d.addCallback(lambda ign: renderDeferred(w))
         def _check_html(html):
             s = remove_tags(html)
             self.failUnlessIn("Corrupt shares: SI %s shnum 0" % first_b32, s)
@@ -4046,7 +4070,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
             corrupt_shares = last["corrupt-shares"]
             self.failUnlessEqual(corrupt_shares, [[first_b32, 0]])
         d.addCallback(_check_json_history)
-        d.addCallback(lambda ign: self.render1(w))
+        d.addCallback(lambda ign: renderDeferred(w))
         def _check_html_history(html):
             s = remove_tags(html)
             self.failUnlessIn("Corrupt shares: SI %s shnum 0" % first_b32, s)
@@ -4060,7 +4084,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
         return d
 
     def render_json(self, page):
-        d = self.render1(page, args={"t": ["json"]})
+        d = renderDeferred(page, args={"t": ["json"]})
         return d
 
 class WebStatus(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
@@ -4083,7 +4107,7 @@ class WebStatus(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
         ss = StorageServer(basedir, nodeid)
         ss.setServiceParent(self.s)
         w = StorageStatus(ss, "nickname")
-        d = self.render1(w)
+        d = renderDeferred(w)
         def _check_html(html):
             self.failUnlessIn("<h1>Storage Server Status</h1>", html)
             s = remove_tags(html)
@@ -4104,7 +4128,7 @@ class WebStatus(unittest.TestCase, pollmixin.PollMixin, WebRenderingMixin):
         return d
 
     def render_json(self, page):
-        d = self.render1(page, args={"t": ["json"]})
+        d = renderDeferred(page, args={"t": ["json"]})
         return d
 
     def test_status_no_disk_stats(self):

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -2968,7 +2968,7 @@ def renderSynchronously(ss):
     """
     :param _StorageStatus ss: a StorageStatus instance.
     """
-    elem = StorageStatusElement(ss.storage, ss.nickname)
+    elem = StorageStatusElement(ss._storage, ss._nickname)
     deferred = flattenString(None, elem)
     return unittest.TestCase().successResultOf(deferred)
 

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -2969,9 +2969,8 @@ def renderSynchronously(ss):
     :param _StorageStatus ss: a StorageStatus instance.
     """
     elem = StorageStatusElement(ss.storage, ss.nickname)
-    result = []
-    flattenString(None, elem).addCallback(result.append)
-    return result[0]
+    deferred = flattenString(None, elem)
+    return unittest.TestCase().successResultOf(deferred)
 
 class MyBucketCountingCrawler(BucketCountingCrawler):
     def finished_prefix(self, cycle, prefix):

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -963,8 +963,9 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
     def test_storage(self):
         d = self.GET("/storage")
         def _check(res):
-            self.failUnlessIn('Storage Server Status', res)
-            self.failUnlessIn(FAVICON_MARKUP, res)
+            soup = BeautifulSoup(res, 'html5lib')
+            assert_soup_has_text(self, soup, 'Storage Server Status')
+            assert_soup_has_favicon(self, soup)
             res_u = res.decode('utf-8')
             self.failUnlessIn(u'<li>Server Nickname: <span class="nickname mine">fake_nickname \u263A</span></li>', res_u)
         d.addCallback(_check)

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -38,11 +38,11 @@ class StorageStatusElement(Element):
 
     @renderer
     def nickname(self, req, tag):
-        return self._nickname
+        return tag(self._nickname)
 
     @renderer
     def nodeid(self, req, tag):
-        return idlib.nodeid_b2a(self._storage.my_nodeid)
+        return tag(idlib.nodeid_b2a(self._storage.my_nodeid))
 
     def _get_storage_stat(self, key):
         """Get storage server statistics.
@@ -110,20 +110,20 @@ class StorageStatusElement(Element):
     @renderer
     def accepting_immutable_shares(self, req, tag):
         accepting = self._get_storage_stat("storage_server.accepting_immutable_shares")
-        return {True: "Yes", False: "No"}[bool(accepting)]
+        return tag({True: "Yes", False: "No"}[bool(accepting)])
 
     @renderer
     def last_complete_bucket_count(self, req, tag):
         s = self._storage.bucket_counter.get_state()
         count = s.get("last-complete-bucket-count")
         if count is None:
-            return "Not computed yet"
-        return str(count)
+            return tag("Not computed yet")
+        return tag(str(count))
 
     @renderer
     def count_crawler_status(self, req, tag):
         p = self._storage.bucket_counter.get_progress()
-        return self.format_crawler_progress(p)
+        return tag(self.format_crawler_progress(p))
 
     def format_crawler_progress(self, p):
         cycletime = p["estimated-time-per-cycle"]

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -48,6 +48,30 @@ class StorageStatusElement(Element):
         return idlib.nodeid_b2a(self.storage.my_nodeid)
 
     def _get_storage_stat(self, key):
+        """Get storage server statistics.
+
+        Storage Server keeps a dict that contains various usage and
+        latency statistics.  The dict looks like this:
+
+          {
+            'storage_server.accepting_immutable_shares': 1,
+            'storage_server.allocated': 0,
+            'storage_server.disk_avail': 106539192320,
+            'storage_server.disk_free_for_nonroot': 106539192320,
+            'storage_server.disk_free_for_root': 154415284224,
+            'storage_server.disk_total': 941088460800,
+            'storage_server.disk_used': 786673176576,
+            'storage_server.latencies.add-lease.01_0_percentile': None,
+            'storage_server.latencies.add-lease.10_0_percentile': None,
+            ...
+          }
+
+        ``StorageServer.get_stats()`` returns the above dict.  Storage
+        status page uses a subset of the items in the dict, concerning
+        disk usage.
+
+        :param str key: storage server statistic we want to know.
+        """
         if not self.storage:
             return None
         return self.storage.get_stats().get(key)

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -212,7 +212,7 @@ class StorageStatusElement(Element):
 
         p = T.ul()
         def add(*pieces):
-            p[T.li[pieces]]
+            p(T.li(pieces))
 
         def maybe(d):
             if d is None:
@@ -248,9 +248,9 @@ class StorageStatusElement(Element):
 
         if so_far["corrupt-shares"]:
             add("Corrupt shares:",
-                T.ul[ [T.li[ ["SI %s shnum %d" % corrupt_share
+                T.ul( (T.li( ["SI %s shnum %d" % corrupt_share
                               for corrupt_share in so_far["corrupt-shares"] ]
-                             ]]])
+                             ))))
         return tag("Current cycle:", p)
 
     @renderer
@@ -284,9 +284,9 @@ class StorageStatusElement(Element):
 
         if last["corrupt-shares"]:
             add("Corrupt shares:",
-                T.ul[ [T.li[ ["SI %s shnum %d" % corrupt_share
+                T.ul( (T.li( ["SI %s shnum %d" % corrupt_share
                               for corrupt_share in last["corrupt-shares"] ]
-                             ]]])
+                             ))))
 
         return tag(p)
 

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -6,8 +6,7 @@ from twisted.web.template import (
     XMLFile,
     tags as T,
     renderer,
-    renderElement,
-    flattenString
+    renderElement
 )
 from allmydata.web.common import (
     abbreviate_time,
@@ -370,13 +369,6 @@ class StorageStatus(MultiFormatResource):
              "lease-checker-progress": self.storage.lease_checker.get_progress(),
              }
         return json.dumps(d, indent=1) + "\n"
-
-    def renderSynchronously(self):
-        # to appease the test suite.
-        elem = StorageStatusElement(self.storage, self.nickname)
-        result = []
-        flattenString(None, elem).addCallback(result.append)
-        return result[0]
 
     # to appease the test suite
     def renderHTTP(self, ctx=None):

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -310,7 +310,7 @@ class StorageStatus(MultiFormatResource):
         elem = StorageStatusElement(self.storage, self.nickname)
         result = []
         flattenString(None, elem).addCallback(result.append)
-        return result
+        return result[0]
 
     def renderHTTP(self, ctx=None):
         # to appease the test suite.

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -2,7 +2,7 @@
 import time, json
 from twisted.python.filepath import FilePath
 from twisted.web.template import tags as T, \
-    renderer, Element, renderElement, XMLFile
+    renderer, Element, renderElement, XMLFile, flattenString
 from allmydata.web.common import (
     abbreviate_time,
     MultiFormatResource

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -318,19 +318,3 @@ class StorageStatus(MultiFormatResource):
              "lease-checker-progress": self._storage.lease_checker.get_progress(),
              }
         return json.dumps(d, indent=1) + "\n"
-
-    # to appease the test suite
-    def renderHTTP(self, ctx=None):
-        """Send HTML or JSON formatted data, based on request.
-
-        This function contains a bit of nevow-ism, but since this is
-        only called from the test suite, the nevow-ism should go away
-        as we update things.
-
-        :param _nevow.context.WovenContext ctx: context is passed on
-            from the test suite.  We get a request out of this
-            context, and use the request to render a result.
-
-        """
-        from nevow.inevow import IRequest
-        return self.render(IRequest(ctx))

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -82,64 +82,30 @@ class StorageStatusElement(Element):
         return u"%d" % size
 
     @renderer
-    def disk_total(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_total")
-        return tag(self.render_space(val))
+    def storage_stats(self, req, tag):
+        # Render storage status table that appears near the top of the page.
+        total = self._get_storage_stat("storage_server.disk_total")
+        used = self._get_storage_stat("storage_server.disk_used")
+        free_root = self._get_storage_stat("storage_server.disk_free_for_root")
+        free_nonroot = self._get_storage_stat("storage_server.disk_free_for_nonroot")
+        reserved = self._get_storage_stat("storage_server.reserved_space")
+        available = self._get_storage_stat("storage_server.disk_avail")
 
-    @renderer
-    def disk_total_abbrev(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_total")
-        return tag(self.render_abbrev_space(val))
-
-    @renderer
-    def disk_used(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_used")
-        return tag(self.render_space(val))
-
-    @renderer
-    def disk_used_abbrev(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_used")
-        return tag(self.render_abbrev_space(val))
-
-    @renderer
-    def disk_free_for_root(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_free_for_root")
-        return tag(self.render_space(val))
-
-    @renderer
-    def disk_free_for_root_abbrev(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_free_for_root")
-        return tag(self.render_abbrev_space(val))
-
-    @renderer
-    def disk_free_for_nonroot(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_free_for_nonroot")
-        return tag(self.render_space(val))
-
-    @renderer
-    def disk_free_for_nonroot_abbrev(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_free_for_nonroot")
-        return tag(self.render_abbrev_space(val))
-
-    @renderer
-    def reserved_space(self, req, tag):
-        val = self._get_storage_stat("storage_server.reserved_space")
-        return tag(self.render_space(val))
-
-    @renderer
-    def reserved_space_abbrev(self, req, tag):
-        val = self._get_storage_stat("storage_server.reserved_space")
-        return tag(self.render_abbrev_space(val))
-
-    @renderer
-    def disk_avail(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_avail")
-        return tag(self.render_space(val))
-
-    @renderer
-    def disk_avail_abbrev(self, req, tag):
-        val = self._get_storage_stat("storage_server.disk_avail")
-        return tag(self.render_abbrev_space(val))
+        tag.fillSlots(
+            disk_total = self.render_space(total),
+            disk_total_abbrev = self.render_abbrev_space(total),
+            disk_used = self.render_space(used),
+            disk_used_abbrev = self.render_abbrev_space(used),
+            disk_free_for_root = self.render_space(free_root),
+            disk_free_for_root_abbrev = self.render_abbrev_space(free_root),
+            disk_free_for_nonroot = self.render_space(free_nonroot),
+            disk_free_for_nonroot_abbrev = self.render_abbrev_space(free_nonroot),
+            reserved_space = self.render_space(reserved),
+            reserved_space_abbrev = self.render_abbrev_space(reserved),
+            disk_avail = self.render_space(available),
+            disk_avail_abbrev = self.render_abbrev_space(available)
+        )
+        return tag
 
     @renderer
     def accepting_immutable_shares(self, req, tag):

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -73,13 +73,13 @@ class StorageStatusElement(Element):
 
     def render_abbrev_space(self, size):
         if size is None:
-            return "?"
+            return u"?"
         return abbreviate_space(size)
 
     def render_space(self, size):
         if size is None:
-            return "?"
-        return "%d" % size
+            return u"?"
+        return u"%d" % size
 
     @renderer
     def disk_total(self, req, tag):

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -43,7 +43,7 @@ class StorageStatusElement(Element):
 
     @renderer
     def nodeid(self, req, tag):
-        if not self.storage:
+        if self.storage is None:
             return tag("No storage server running.")
         return idlib.nodeid_b2a(self.storage.my_nodeid)
 

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -319,7 +319,8 @@ class StorageStatusElement(Element):
 
         return tag(p)
 
-    def format_recovered(self, sr, a):
+    @staticmethod
+    def format_recovered(sr, a):
         def maybe(d):
             if d is None:
                 return "?"

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -378,6 +378,18 @@ class StorageStatus(MultiFormatResource):
         flattenString(None, elem).addCallback(result.append)
         return result[0]
 
+    # to appease the test suite
     def renderHTTP(self, ctx=None):
-        # to appease the test suite.
-        self.renderSynchronously()
+        """Send HTML or JSON formatted data, based on request.
+
+        This function contains a bit of nevow-ism, but since this is
+        only called from the test suite, the nevow-ism should go away
+        as we update things.
+
+        :param _nevow.context.WovenContext ctx: context is passed on
+            from the test suite.  We get a request out of this
+            context, and use the request to render a result.
+
+        """
+        from nevow.inevow import IRequest
+        return self.render(IRequest(ctx))

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -42,8 +42,6 @@ class StorageStatusElement(Element):
 
     @renderer
     def nodeid(self, req, tag):
-        if self.storage is None:
-            return tag("No storage server running.")
         return idlib.nodeid_b2a(self.storage.my_nodeid)
 
     def _get_storage_stat(self, key):
@@ -71,8 +69,6 @@ class StorageStatusElement(Element):
 
         :param str key: storage server statistic we want to know.
         """
-        if not self.storage:
-            return None
         return self.storage.get_stats().get(key)
 
     def render_abbrev_space(self, size):
@@ -152,8 +148,6 @@ class StorageStatusElement(Element):
 
     @renderer
     def last_complete_bucket_count(self, req, tag):
-        if not self.storage:
-            return tag("No storage server running.")
         s = self.storage.bucket_counter.get_state()
         count = s.get("last-complete-bucket-count")
         if count is None:
@@ -162,8 +156,6 @@ class StorageStatusElement(Element):
 
     @renderer
     def count_crawler_status(self, req, tag):
-        if not self.storage:
-            return tag("No storage server running.")
         p = self.storage.bucket_counter.get_progress()
         return self.format_crawler_progress(p)
 
@@ -200,8 +192,6 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_expiration_enabled(self, req, tag):
-        if not self.storage:
-            return tag("No storage server running.")
         lc = self.storage.lease_checker
         if lc.expiration_enabled:
             return tag("Enabled: expired leases will be removed")
@@ -210,8 +200,6 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_expiration_mode(self, req, tag):
-        if not self.storage:
-            return tag("No storage server running.")
         lc = self.storage.lease_checker
         if lc.mode == "age":
             if lc.override_lease_duration is None:
@@ -235,16 +223,12 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_current_cycle_progress(self, req, tag):
-        if not self.storage:
-            return tag("No storage server running.")
         lc = self.storage.lease_checker
         p = lc.get_progress()
         return tag(self.format_crawler_progress(p))
 
     @renderer
     def lease_current_cycle_results(self, req, tag):
-        if not self.storage:
-            return tag("No storage server running.")
         lc = self.storage.lease_checker
         p = lc.get_progress()
         if not p["cycle-in-progress"]:
@@ -302,8 +286,6 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_last_cycle_results(self, req, tag):
-        if not self.storage:
-            return tag("No storage server running.")
         lc = self.storage.lease_checker
         h = lc.get_state()["history"]
         if not h:

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -50,6 +50,16 @@ class StorageStatusElement(Element):
             return tag("?")
         return tag(abbreviate_space(val))
 
+    def render_abbrev_space(self, ctx, size):
+        if size is None:
+            return "?"
+        return abbreviate_space(size)
+
+    def render_space(self, ctx, size):
+        if size is None:
+            return "?"
+        return "%d" % size
+
     @renderer
     def disk_total(self, req, tag):
         return self.str(tag, self.get_stat("storage_server.disk_total"))

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -50,12 +50,12 @@ class StorageStatusElement(Element):
             return tag("?")
         return tag(abbreviate_space(val))
 
-    def render_abbrev_space(self, ctx, size):
+    def render_abbrev_space(self, size):
         if size is None:
             return "?"
         return abbreviate_space(size)
 
-    def render_space(self, ctx, size):
+    def render_space(self, size):
         if size is None:
             return "?"
         return "%d" % size

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -47,7 +47,7 @@ class StorageStatusElement(Element):
             return tag("No storage server running.")
         return idlib.nodeid_b2a(self.storage.my_nodeid)
 
-    def get_stat(self, key):
+    def _get_storage_stat(self, key):
         if not self.storage:
             return None
         return self.storage.get_stats().get(key)
@@ -64,67 +64,67 @@ class StorageStatusElement(Element):
 
     @renderer
     def disk_total(self, req, tag):
-        val = self.get_stat("storage_server.disk_total")
+        val = self._get_storage_stat("storage_server.disk_total")
         return tag(self.render_space(val))
 
     @renderer
     def disk_total_abbrev(self, req, tag):
-        val = self.get_stat("storage_server.disk_total")
+        val = self._get_storage_stat("storage_server.disk_total")
         return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_used(self, req, tag):
-        val = self.get_stat("storage_server.disk_used")
+        val = self._get_storage_stat("storage_server.disk_used")
         return tag(self.render_space(val))
 
     @renderer
     def disk_used_abbrev(self, req, tag):
-        val = self.get_stat("storage_server.disk_used")
+        val = self._get_storage_stat("storage_server.disk_used")
         return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_free_for_root(self, req, tag):
-        val = self.get_stat("storage_server.disk_free_for_root")
+        val = self._get_storage_stat("storage_server.disk_free_for_root")
         return tag(self.render_space(val))
 
     @renderer
     def disk_free_for_root_abbrev(self, req, tag):
-        val = self.get_stat("storage_server.disk_free_for_root")
+        val = self._get_storage_stat("storage_server.disk_free_for_root")
         return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_free_for_nonroot(self, req, tag):
-        val = self.get_stat("storage_server.disk_free_for_nonroot")
+        val = self._get_storage_stat("storage_server.disk_free_for_nonroot")
         return tag(self.render_space(val))
 
     @renderer
     def disk_free_for_nonroot_abbrev(self, req, tag):
-        val = self.get_stat("storage_server.disk_free_for_nonroot")
+        val = self._get_storage_stat("storage_server.disk_free_for_nonroot")
         return tag(self.render_abbrev_space(val))
 
     @renderer
     def reserved_space(self, req, tag):
-        val = self.get_stat("storage_server.reserved_space")
+        val = self._get_storage_stat("storage_server.reserved_space")
         return tag(self.render_space(val))
 
     @renderer
     def reserved_space_abbrev(self, req, tag):
-        val = self.get_stat("storage_server.reserved_space")
+        val = self._get_storage_stat("storage_server.reserved_space")
         return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_avail(self, req, tag):
-        val = self.get_stat("storage_server.disk_avail")
+        val = self._get_storage_stat("storage_server.disk_avail")
         return tag(self.render_space(val))
 
     @renderer
     def disk_avail_abbrev(self, req, tag):
-        val = self.get_stat("storage_server.disk_avail")
+        val = self._get_storage_stat("storage_server.disk_avail")
         return tag(self.render_abbrev_space(val))
 
     @renderer
     def accepting_immutable_shares(self, req, tag):
-        accepting = self.get_stat("storage_server.accepting_immutable_shares")
+        accepting = self._get_storage_stat("storage_server.accepting_immutable_shares")
         return {True: "Yes", False: "No"}[bool(accepting)]
 
     @renderer

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -1,7 +1,8 @@
 
 import time, json
 from twisted.python.filepath import FilePath
-from twisted.web.template import tags as T, renderer, Element, renderElement, XMLFile
+from twisted.web.template import tags as T, \
+    renderer, Element, renderElement, XMLFile
 from allmydata.web.common import (
     abbreviate_time,
     MultiFormatResource
@@ -303,3 +304,14 @@ class StorageStatus(MultiFormatResource):
              "lease-checker-progress": self.storage.lease_checker.get_progress(),
              }
         return json.dumps(d, indent=1) + "\n"
+
+    def renderSynchronously(self):
+        # to appease the test suite.
+        elem = StorageStatusElement(self.storage, self.nickname)
+        result = []
+        flattenString(None, elem).addCallback(result.append)
+        return result
+
+    def renderHTTP(self, ctx=None):
+        # to appease the test suite.
+        self.renderSynchronously()

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -40,16 +40,6 @@ class StorageStatusElement(Element):
             return None
         return self.storage.get_stats().get(key)
 
-    def str(self, tag, val):
-        if val is None:
-            return tag("?")
-        return tag(str(val))
-
-    def abbr(self, tag, val):
-        if val is None:
-            return tag("?")
-        return tag(abbreviate_space(val))
-
     def render_abbrev_space(self, size):
         if size is None:
             return "?"
@@ -62,51 +52,63 @@ class StorageStatusElement(Element):
 
     @renderer
     def disk_total(self, req, tag):
-        return self.str(tag, self.get_stat("storage_server.disk_total"))
+        val = self.get_stat("storage_server.disk_total")
+        return tag(self.render_space(val))
 
     @renderer
     def disk_total_abbrev(self, req, tag):
-        return self.abbr(tag, self.get_stat("storage_server.disk_total"))
+        val = self.get_stat("storage_server.disk_total")
+        return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_used(self, req, tag):
-        return self.str(tag, self.get_stat("storage_server.disk_used"))
+        val = self.get_stat("storage_server.disk_used")
+        return tag(self.render_space(val))
 
     @renderer
     def disk_used_abbrev(self, req, tag):
-        return self.abbr(tag, self.get_stat("storage_server.disk_used"))
+        val = self.get_stat("storage_server.disk_used")
+        return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_free_for_root(self, req, tag):
-        return self.str(tag, self.get_stat("storage_server.disk_free_for_root"))
+        val = self.get_stat("storage_server.disk_free_for_root")
+        return tag(self.render_space(val))
 
     @renderer
     def disk_free_for_root_abbrev(self, req, tag):
-        return self.abbr(tag, self.get_stat("storage_server.disk_free_for_root"))
+        val = self.get_stat("storage_server.disk_free_for_root")
+        return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_free_for_nonroot(self, req, tag):
-        return self.str(tag, self.get_stat("storage_server.disk_free_for_nonroot"))
+        val = self.get_stat("storage_server.disk_free_for_nonroot")
+        return tag(self.render_space(val))
 
     @renderer
     def disk_free_for_nonroot_abbrev(self, req, tag):
-        return self.abbr(tag, self.get_stat("storage_server.disk_free_for_nonroot"))
+        val = self.get_stat("storage_server.disk_free_for_nonroot")
+        return tag(self.render_abbrev_space(val))
 
     @renderer
     def reserved_space(self, req, tag):
-        return self.str(tag, self.get_stat("storage_server.reserved_space"))
+        val = self.get_stat("storage_server.reserved_space")
+        return tag(self.render_space(val))
 
     @renderer
     def reserved_space_abbrev(self, req, tag):
-        return self.abbr(tag, self.get_stat("storage_server.reserved_space"))
+        val = self.get_stat("storage_server.reserved_space")
+        return tag(self.render_abbrev_space(val))
 
     @renderer
     def disk_avail(self, req, tag):
-        return self.str(tag, self.get_stat("storage_server.disk_avail"))
+        val = self.get_stat("storage_server.disk_avail")
+        return tag(self.render_space(val))
 
     @renderer
     def disk_avail_abbrev(self, req, tag):
-        return self.abbr(tag, self.get_stat("storage_server.disk_avail"))
+        val = self.get_stat("storage_server.disk_avail")
+        return tag(self.render_abbrev_space(val))
 
     @renderer
     def accepting_immutable_shares(self, req, tag):

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -31,9 +31,13 @@ class StorageStatusElement(Element):
 
     @renderer
     def nodeid(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         return idlib.nodeid_b2a(self.storage.my_nodeid)
 
     def get_stat(self, key):
+        if not self.storage:
+            return None
         return self.storage.get_stats().get(key)
 
     def str(self, tag, val):
@@ -101,6 +105,8 @@ class StorageStatusElement(Element):
 
     @renderer
     def last_complete_bucket_count(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         s = self.storage.bucket_counter.get_state()
         count = s.get("last-complete-bucket-count")
         if count is None:
@@ -109,6 +115,8 @@ class StorageStatusElement(Element):
 
     @renderer
     def count_crawler_status(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         p = self.storage.bucket_counter.get_progress()
         return self.format_crawler_progress(p)
 
@@ -145,6 +153,8 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_expiration_enabled(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         lc = self.storage.lease_checker
         if lc.expiration_enabled:
             return tag("Enabled: expired leases will be removed")
@@ -153,6 +163,8 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_expiration_mode(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         lc = self.storage.lease_checker
         if lc.mode == "age":
             if lc.override_lease_duration is None:
@@ -176,12 +188,16 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_current_cycle_progress(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         lc = self.storage.lease_checker
         p = lc.get_progress()
         return tag(self.format_crawler_progress(p))
 
     @renderer
     def lease_current_cycle_results(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         lc = self.storage.lease_checker
         p = lc.get_progress()
         if not p["cycle-in-progress"]:
@@ -239,6 +255,8 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_last_cycle_results(self, req, tag):
+        if not self.storage:
+            return tag("No storage server running.")
         lc = self.storage.lease_checker
         h = lc.get_state()["history"]
         if not h:

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -1,8 +1,14 @@
 
 import time, json
 from twisted.python.filepath import FilePath
-from twisted.web.template import tags as T, \
-    renderer, Element, renderElement, XMLFile, flattenString
+from twisted.web.template import (
+    Element,
+    XMLFile,
+    tags as T,
+    renderer,
+    renderElement,
+    flattenString
+)
 from allmydata.web.common import (
     abbreviate_time,
     MultiFormatResource

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -161,7 +161,7 @@ class StorageStatusElement(Element):
     def storage_running(self, req, tag):
         if self.storage:
             return tag
-        return tag("No Storage Server Running")
+        return T.h1("No Storage Server Running")
 
     @renderer
     def lease_expiration_enabled(self, req, tag):

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -33,16 +33,16 @@ class StorageStatusElement(Element):
         :param string nickname: friendly name for storage.
         """
         super(StorageStatusElement, self).__init__()
-        self.storage = storage
-        self.nick = nickname
+        self._storage = storage
+        self._nickname = nickname
 
     @renderer
     def nickname(self, req, tag):
-        return self.nick
+        return self._nickname
 
     @renderer
     def nodeid(self, req, tag):
-        return idlib.nodeid_b2a(self.storage.my_nodeid)
+        return idlib.nodeid_b2a(self._storage.my_nodeid)
 
     def _get_storage_stat(self, key):
         """Get storage server statistics.
@@ -69,7 +69,7 @@ class StorageStatusElement(Element):
 
         :param str key: storage server statistic we want to know.
         """
-        return self.storage.get_stats().get(key)
+        return self._storage.get_stats().get(key)
 
     def render_abbrev_space(self, size):
         if size is None:
@@ -114,7 +114,7 @@ class StorageStatusElement(Element):
 
     @renderer
     def last_complete_bucket_count(self, req, tag):
-        s = self.storage.bucket_counter.get_state()
+        s = self._storage.bucket_counter.get_state()
         count = s.get("last-complete-bucket-count")
         if count is None:
             return "Not computed yet"
@@ -122,7 +122,7 @@ class StorageStatusElement(Element):
 
     @renderer
     def count_crawler_status(self, req, tag):
-        p = self.storage.bucket_counter.get_progress()
+        p = self._storage.bucket_counter.get_progress()
         return self.format_crawler_progress(p)
 
     def format_crawler_progress(self, p):
@@ -152,13 +152,13 @@ class StorageStatusElement(Element):
 
     @renderer
     def storage_running(self, req, tag):
-        if self.storage:
+        if self._storage:
             return tag
         return T.h1("No Storage Server Running")
 
     @renderer
     def lease_expiration_enabled(self, req, tag):
-        lc = self.storage.lease_checker
+        lc = self._storage.lease_checker
         if lc.expiration_enabled:
             return tag("Enabled: expired leases will be removed")
         else:
@@ -166,7 +166,7 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_expiration_mode(self, req, tag):
-        lc = self.storage.lease_checker
+        lc = self._storage.lease_checker
         if lc.mode == "age":
             if lc.override_lease_duration is None:
                 tag("Leases will expire naturally, probably 31 days after "
@@ -189,13 +189,13 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_current_cycle_progress(self, req, tag):
-        lc = self.storage.lease_checker
+        lc = self._storage.lease_checker
         p = lc.get_progress()
         return tag(self.format_crawler_progress(p))
 
     @renderer
     def lease_current_cycle_results(self, req, tag):
-        lc = self.storage.lease_checker
+        lc = self._storage.lease_checker
         p = lc.get_progress()
         if not p["cycle-in-progress"]:
             return ""
@@ -252,7 +252,7 @@ class StorageStatusElement(Element):
 
     @renderer
     def lease_last_cycle_results(self, req, tag):
-        lc = self.storage.lease_checker
+        lc = self._storage.lease_checker
         h = lc.get_state()["history"]
         if not h:
             return ""
@@ -304,18 +304,18 @@ class StorageStatusElement(Element):
 class StorageStatus(MultiFormatResource):
     def __init__(self, storage, nickname=""):
         super(StorageStatus, self).__init__()
-        self.storage = storage
-        self.nickname = nickname
+        self._storage = storage
+        self._nickname = nickname
 
     def render_HTML(self, req):
-        return renderElement(req, StorageStatusElement(self.storage, self.nickname))
+        return renderElement(req, StorageStatusElement(self._storage, self._nickname))
 
     def render_JSON(self, req):
         req.setHeader("content-type", "text/plain")
-        d = {"stats": self.storage.get_stats(),
-             "bucket-counter": self.storage.bucket_counter.get_state(),
-             "lease-checker": self.storage.lease_checker.get_state(),
-             "lease-checker-progress": self.storage.lease_checker.get_progress(),
+        d = {"stats": self._storage.get_stats(),
+             "bucket-counter": self._storage.bucket_counter.get_state(),
+             "lease-checker": self._storage.lease_checker.get_state(),
+             "lease-checker-progress": self._storage.lease_checker.get_progress(),
              }
         return json.dumps(d, indent=1) + "\n"
 

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -24,9 +24,15 @@ def remove_prefix(s, prefix):
 
 
 class StorageStatusElement(Element):
+    """Class to render a storage status page."""
+
     loader = XMLFile(FilePath(__file__).sibling("storage_status.xhtml"))
 
-    def __init__(self, storage, nickname):
+    def __init__(self, storage, nickname=""):
+        """
+        :param _StorageServer storage: data about storage.
+        :param string nickname: friendly name for storage.
+        """
         super(StorageStatusElement, self).__init__()
         self.storage = storage
         self.nick = nickname

--- a/src/allmydata/web/storage_status.xhtml
+++ b/src/allmydata/web/storage_status.xhtml
@@ -57,7 +57,7 @@
   <ul>
     <li>Server Nickname: <span class="nickname mine"><t:transparent t:render="nickname" /></span></li>
     <li>Server Nodeid: <span class="nodeid mine data-chars"> <t:transparent t:render="nodeid" /></span></li>
-    <li t:data="stats">Accepting new shares:
+    <li>Accepting new shares:
       <span t:render="accepting_immutable_shares" /></li>
     <li>Total buckets:
        <span t:render="last_complete_bucket_count" />

--- a/src/allmydata/web/storage_status.xhtml
+++ b/src/allmydata/web/storage_status.xhtml
@@ -1,4 +1,4 @@
-<html xmlns:n="http://nevow.com/ns/nevow/0.1">
+<html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
   <head>
     <title>Tahoe-LAFS - Storage Server Status</title>
     <link href="/tahoe.css" rel="stylesheet" type="text/css"/>
@@ -7,19 +7,19 @@
   </head>
 <body>
 
-<div n:render="storage_running">
+<div t:render="storage_running">
 
   <h1>Storage Server Status</h1>
 
-  <table n:data="stats">
+  <table class="storage_status">
     <tr><td>Total disk space:</td>
-        <td><span n:render="abbrev_space" n:data="disk_total" /></td>
-        <td>(<span n:render="space" n:data="disk_total" />)</td>
+        <td><span t:render="disk_total_abbrev" /></td>
+        <td>(<span t:render="disk_total" />)</td>
         <td />
       </tr>
     <tr><td>Disk space used:</td>
-        <td>- <span n:render="abbrev_space" n:data="disk_used" /></td>
-        <td>(<span n:render="space" n:data="disk_used" />)</td>
+        <td>- <span t:render="disk_used_abbrev" /></td>
+        <td>(<span t:render="disk_used" />)</td>
         <td />
       </tr>
     <tr><td />
@@ -28,18 +28,18 @@
         <td />
       </tr>
     <tr><td>Disk space free (root):</td>
-        <td><span n:render="abbrev_space" n:data="disk_free_for_root"/></td>
-        <td>(<span n:render="space" n:data="disk_free_for_root"/>)</td>
+        <td><span t:render="disk_free_for_root_abbrev"/></td>
+        <td>(<span t:render="disk_free_for_root"/>)</td>
         <td>[see 1]</td>
         </tr>
     <tr><td>Disk space free (non-root):</td>
-        <td><span n:render="abbrev_space" n:data="disk_free_for_nonroot" /></td>
-        <td>(<span n:render="space" n:data="disk_free_for_nonroot" />)</td>
+        <td><span t:render="disk_free_for_nonroot_abbrev" /></td>
+        <td>(<span t:render="disk_free_for_nonroot" />)</td>
         <td>[see 2]</td>
         </tr>
     <tr><td>Reserved space:</td>
-        <td>- <span n:render="abbrev_space" n:data="reserved_space" /></td>
-        <td>(<span n:render="space" n:data="reserved_space" />)</td>
+        <td>- <span t:render="reserved_space_abbrev" /></td>
+        <td>(<span t:render="reserved_space" />)</td>
         <td />
       </tr>
     <tr><td />
@@ -48,23 +48,31 @@
         <td />
       </tr>
     <tr><td>Space Available to Tahoe:</td>
-        <td><span n:render="abbrev_space" n:data="disk_avail" /></td>
-        <td>(<span n:render="space" n:data="disk_avail" />)</td>
+        <td><span t:render="disk_avail_abbrev" /></td>
+        <td>(<span t:render="disk_avail" />)</td>
         <td />
       </tr>
   </table>
 
   <ul>
-    <li>Server Nickname: <span class="nickname mine" n:render="data" n:data="nickname" /></li>
-    <li>Server Nodeid: <span class="nodeid mine data-chars" n:render="string" n:data="nodeid" /></li>
-    <li n:data="stats">Accepting new shares:
-     <span n:render="bool" n:data="accepting_immutable_shares" /></li>
+    <li>Server Nickname:
+      <span class="nickname mine">
+        <span t:render="nickname" />
+      </span>
+    </li>
+    <li>Server Nodeid:
+      <span class="nodeid mine data-chars">
+        <span t:render="nodeid" />
+      </span>
+    </li>
+    <li t:data="stats">Accepting new shares:
+      <span t:render="accepting_immutable_shares" /></li>
     <li>Total buckets:
-       <span n:render="string" n:data="last_complete_bucket_count" />
+       <span t:render="last_complete_bucket_count" />
        (the number of files and directories for which this server is holding
         a share)
       <ul>
-        <li n:render="count_crawler_status" />
+        <li><span t:render="count_crawler_status" /></li>
       </ul>
     </li>
   </ul>
@@ -72,11 +80,11 @@
   <h2>Lease Expiration Crawler</h2>
 
   <ul>
-    <li>Expiration <span n:render="lease_expiration_enabled" /></li>
-    <li n:render="lease_expiration_mode" />
-    <li n:render="lease_current_cycle_progress" />
-    <li n:render="lease_current_cycle_results" />
-    <li n:render="lease_last_cycle_results" />
+    <li>Expiration <span t:render="lease_expiration_enabled" /></li>
+    <li t:render="lease_expiration_mode" />
+    <li t:render="lease_current_cycle_progress" />
+    <li t:render="lease_current_cycle_results" />
+    <li t:render="lease_last_cycle_results" />
   </ul>
 
   <hr />

--- a/src/allmydata/web/storage_status.xhtml
+++ b/src/allmydata/web/storage_status.xhtml
@@ -13,13 +13,13 @@
 
   <table class="storage_status">
     <tr><td>Total disk space:</td>
-        <td><span t:render="disk_total_abbrev" /></td>
-        <td>(<span t:render="disk_total" />)</td>
+        <td><t:transparent t:render="disk_total_abbrev" /></td>
+        <td>(<t:transparent t:render="disk_total" />)</td>
         <td />
       </tr>
     <tr><td>Disk space used:</td>
-        <td>- <span t:render="disk_used_abbrev" /></td>
-        <td>(<span t:render="disk_used" />)</td>
+        <td>- <t:transparent t:render="disk_used_abbrev" /></td>
+        <td>(<t:transparent t:render="disk_used" />)</td>
         <td />
       </tr>
     <tr><td />
@@ -28,18 +28,18 @@
         <td />
       </tr>
     <tr><td>Disk space free (root):</td>
-        <td><span t:render="disk_free_for_root_abbrev"/></td>
-        <td>(<span t:render="disk_free_for_root"/>)</td>
+        <td><t:transparent t:render="disk_free_for_root_abbrev"/></td>
+        <td>(<t:transparent t:render="disk_free_for_root"/>)</td>
         <td>[see 1]</td>
         </tr>
     <tr><td>Disk space free (non-root):</td>
-        <td><span t:render="disk_free_for_nonroot_abbrev" /></td>
-        <td>(<span t:render="disk_free_for_nonroot" />)</td>
+        <td><t:transparent t:render="disk_free_for_nonroot_abbrev" /></td>
+        <td>(<t:transparent t:render="disk_free_for_nonroot" />)</td>
         <td>[see 2]</td>
         </tr>
     <tr><td>Reserved space:</td>
-        <td>- <span t:render="reserved_space_abbrev" /></td>
-        <td>(<span t:render="reserved_space" />)</td>
+        <td>- <t:transparent t:render="reserved_space_abbrev" /></td>
+        <td>(<t:transparent t:render="reserved_space" />)</td>
         <td />
       </tr>
     <tr><td />
@@ -48,8 +48,8 @@
         <td />
       </tr>
     <tr><td>Space Available to Tahoe:</td>
-        <td><span t:render="disk_avail_abbrev" /></td>
-        <td>(<span t:render="disk_avail" />)</td>
+        <td><t:transparent t:render="disk_avail_abbrev" /></td>
+        <td>(<t:transparent t:render="disk_avail" />)</td>
         <td />
       </tr>
   </table>

--- a/src/allmydata/web/storage_status.xhtml
+++ b/src/allmydata/web/storage_status.xhtml
@@ -11,15 +11,15 @@
 
   <h1>Storage Server Status</h1>
 
-  <table class="storage_status">
+  <table class="storage_status" t:render="storage_stats">
     <tr><td>Total disk space:</td>
-        <td><t:transparent t:render="disk_total_abbrev" /></td>
-        <td>(<t:transparent t:render="disk_total" />)</td>
+        <td><t:slot name="disk_total_abbrev" /></td>
+        <td>(<t:slot name="disk_total" />)</td>
         <td />
       </tr>
     <tr><td>Disk space used:</td>
-        <td>- <t:transparent t:render="disk_used_abbrev" /></td>
-        <td>(<t:transparent t:render="disk_used" />)</td>
+        <td>- <t:slot name="disk_used_abbrev" /></td>
+        <td>(<t:slot name="disk_used" />)</td>
         <td />
       </tr>
     <tr><td />
@@ -28,18 +28,18 @@
         <td />
       </tr>
     <tr><td>Disk space free (root):</td>
-        <td><t:transparent t:render="disk_free_for_root_abbrev"/></td>
-        <td>(<t:transparent t:render="disk_free_for_root"/>)</td>
+        <td><t:slot name="disk_free_for_root_abbrev"/></td>
+        <td>(<t:slot name="disk_free_for_root"/>)</td>
         <td>[see 1]</td>
         </tr>
     <tr><td>Disk space free (non-root):</td>
-        <td><t:transparent t:render="disk_free_for_nonroot_abbrev" /></td>
-        <td>(<t:transparent t:render="disk_free_for_nonroot" />)</td>
+        <td><t:slot name="disk_free_for_nonroot_abbrev" /></td>
+        <td>(<t:slot name="disk_free_for_nonroot" />)</td>
         <td>[see 2]</td>
         </tr>
     <tr><td>Reserved space:</td>
-        <td>- <t:transparent t:render="reserved_space_abbrev" /></td>
-        <td>(<t:transparent t:render="reserved_space" />)</td>
+        <td>- <t:slot name="reserved_space_abbrev" /></td>
+        <td>(<t:slot name="reserved_space" />)</td>
         <td />
       </tr>
     <tr><td />
@@ -48,8 +48,8 @@
         <td />
       </tr>
     <tr><td>Space Available to Tahoe:</td>
-        <td><t:transparent t:render="disk_avail_abbrev" /></td>
-        <td>(<t:transparent t:render="disk_avail" />)</td>
+        <td><t:slot name="disk_avail_abbrev" /></td>
+        <td>(<t:slot name="disk_avail" />)</td>
         <td />
       </tr>
   </table>

--- a/src/allmydata/web/storage_status.xhtml
+++ b/src/allmydata/web/storage_status.xhtml
@@ -55,16 +55,8 @@
   </table>
 
   <ul>
-    <li>Server Nickname:
-      <span class="nickname mine">
-        <t:transparent t:render="nickname" />
-      </span>
-    </li>
-    <li>Server Nodeid:
-      <span class="nodeid mine data-chars">
-        <t:transparent t:render="nodeid" />
-      </span>
-    </li>
+    <li>Server Nickname: <span class="nickname mine"><t:transparent t:render="nickname" /></span></li>
+    <li>Server Nodeid: <span class="nodeid mine data-chars"> <t:transparent t:render="nodeid" /></span></li>
     <li t:data="stats">Accepting new shares:
       <span t:render="accepting_immutable_shares" /></li>
     <li>Total buckets:

--- a/src/allmydata/web/storage_status.xhtml
+++ b/src/allmydata/web/storage_status.xhtml
@@ -57,12 +57,12 @@
   <ul>
     <li>Server Nickname:
       <span class="nickname mine">
-        <span t:render="nickname" />
+        <t:transparent t:render="nickname" />
       </span>
     </li>
     <li>Server Nodeid:
       <span class="nodeid mine data-chars">
-        <span t:render="nodeid" />
+        <t:transparent t:render="nodeid" />
       </span>
     </li>
     <li t:data="stats">Accepting new shares:


### PR DESCRIPTION
This is a stab on https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3247.  Please see the attached screenshots of the rendered pages, before and after: they look more or less same, to my untrained eyes. :-)

This is work in progress.  I wanted to get some feedback:

- I am not sure one large commit like this is a good idea.  I could split this into multiple smaller commits, although that would be a rather annoying thing to do. :-)
- I could not figure out `twisted.web.template`'s equivalent of `nevow`'s way of filling a table using data from a dictionary.  So table is now filled with a bunch of individual `@renderer` methods.
- Tests are failing, because there's no `renderSynchronously()` and `renderHTTP()` in the new `StorageStatus` class.  How do I proceed here?
- `StorageStatus.render_JSON()` should perhaps do `req.setHeader("content-type", "application/json")` instead of `req.setHeader("content-type", "text/plain")`?

Before:

![storage-before](https://user-images.githubusercontent.com/23618/73743644-0dd66700-471d-11ea-9c6e-f3fa1d2822ac.png)

After:

![storage-after](https://user-images.githubusercontent.com/23618/73743665-162ea200-471d-11ea-8af3-2464b0529d0c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/690)
<!-- Reviewable:end -->
