### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
         uses: actions/upload-artifact@v1
         if: failure()
         with:
-          name: eliot.log
-          path: eliot.log
+          name: integration.eliot.json
+          path: integration.eliot.json
 
   packaging:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       # Get vcpython27 on Windows + Python 2.7, to build zfec
       # extension.  See https://chocolatey.org/packages/vcpython27 and
       # https://github.com/crazy-max/ghaction-chocolatey
-      - name: Install MSVC 9.0 for Python 2.7 on Windows
+      - name: [Windows] Install MSVC 9.0 for Python 2.7
         if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
         uses: crazy-max/ghaction-chocolatey@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,10 @@ jobs:
           name: eliot.log
           path: eliot.log
 
-      # Set Codecov token inside Project Settings > Secrets as
-      # CODECOV_TOKEN.
       - name: Upload coverage report
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: abf679b6-e2e6-4b33-b7b5-6cfbd41ee691
           file: coverage.xml
 
   integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Run "tox -e coverage"
         run: tox -e coverage
 
-      - name: Run "tox -e pyinstaller"
-        run: tox -e pyinstaller
-
       - name: Upload eliot.log in case of failure
         uses: actions/upload-artifact@v1
         if: failure()
@@ -144,3 +141,47 @@ jobs:
           name: eliot.log
           path: eliot.log
 
+  packaging:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+        python-version:
+          - 2.7
+
+    steps:
+
+      # Get vcpython27 on Windows + Python 2.7, to build zfec
+      # extension.  See https://chocolatey.org/packages/vcpython27 and
+      # https://github.com/crazy-max/ghaction-chocolatey
+      - name: [Windows] Install MSVC 9.0 for Python 2.7
+        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install vcpython27
+
+      - name: Check out Tahoe-LAFS sources
+        uses: actions/checkout@v2
+
+      - name: Fetch all history for all tags and branches
+        run: git fetch --prune --unshallow
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade codecov tox setuptools
+          pip list
+
+      - name: Display tool versions
+        run: python misc/build_helpers/show-tool-versions.py
+
+      - name: Run "tox -e pyinstaller"
+        run: tox -e pyinstaller

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         os:
           - macos-latest
           - windows-latest
-          - ubuntu-latest
         python-version:
           - 2.7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,14 @@ jobs:
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py
 
-      # # codechecks throws type error; disable for now.
-      # - name: Run "tox -e codechecks"
-      #   run: tox -e codechecks
+      # Codechecks errors out when running Towncrier within GitHub
+      # Actions.  See this issue:
+      # https://github.com/hawkowl/towncrier/issues/175.
+      #
+      # Run codechecks anyway, and continue on error, for now.
+      - name: Run "tox -e codechecks"
+        run: tox -e codechecks
+        continue-on-error: true
 
       - name: Run "tox -e py27"
         if: matrix.python-version == '2.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
+  schedule:
+    # Daily at 3:21
+    - cron: '21 3 * * *'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+        python-version:
+          - 2.7
+
+    steps:
+
+      # Get vcpython27 on Windows + Python 2.7, to build zfec
+      # extension.  See https://chocolatey.org/packages/vcpython27 and
+      # https://github.com/crazy-max/ghaction-chocolatey
+      - name: Install MSVC 9.0 for Python 2.7 on Windows
+        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install vcpython27
+
+      - name: Check out Tahoe-LAFS sources
+        uses: actions/checkout@v2
+
+      - name: Fetch all history for all tags and branches
+        run: git fetch --prune --unshallow
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade codecov tox setuptools
+          pip list
+
+      - name: Display tool versions
+        run: python misc/build_helpers/show-tool-versions.py
+
+      # # codechecks throws type error; disable for now.
+      # - name: Run "tox -e codechecks"
+      #   run: tox -e codechecks
+
+      - name: Run "tox -e py27"
+        if: matrix.python-version == '2.7'
+        run: tox -e py27
+
+      - name: Run "tox -e coverage"
+        run: tox -e coverage
+
+      - name: Run "tox -e pyinstaller"
+        run: tox -e pyinstaller
+
+      - name: Upload eliot.log in case of failure
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: eliot.log
+          path: eliot.log
+
+      # Set Codecov token inside Project Settings > Secrets as
+      # CODECOV_TOKEN.
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
   release:
     types: [published]
-  schedule:
-    # Daily at 3:21
-    - cron: '21 3 * * *'
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
   pull_request:
-  release:
-    types: [published]
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       # Get vcpython27 on Windows + Python 2.7, to build zfec
       # extension.  See https://chocolatey.org/packages/vcpython27 and
       # https://github.com/crazy-max/ghaction-chocolatey
-      - name: [Windows] Install MSVC 9.0 for Python 2.7
+      - name: Install MSVC 9.0 for Python 2.7 [Windows]
         if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
         uses: crazy-max/ghaction-chocolatey@v1
         with:
@@ -92,15 +92,15 @@ jobs:
 
     steps:
 
-      - name: [Ubuntu] Install Tor
+      - name: Install Tor [Ubuntu]
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install tor
 
-      - name: [macOS] Install Tor
+      - name: Install Tor [macOS]
         if: matrix.os == 'macos-latest'
         run: brew install tor
 
-      - name: [Windows] Install Tor
+      - name: Install Tor [Windows]
         if: matrix.os == 'windows-latest'
         uses: crazy-max/ghaction-chocolatey@v1
         with:
@@ -158,7 +158,7 @@ jobs:
       # Get vcpython27 on Windows + Python 2.7, to build zfec
       # extension.  See https://chocolatey.org/packages/vcpython27 and
       # https://github.com/crazy-max/ghaction-chocolatey
-      - name: [Windows] Install MSVC 9.0 for Python 2.7
+      - name: Install MSVC 9.0 for Python 2.7 [Windows]
         if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
         uses: crazy-max/ghaction-chocolatey@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,6 @@ jobs:
         run: tox -e codechecks
         continue-on-error: true
 
-      - name: Run "tox -e py27"
-        if: matrix.python-version == '2.7'
-        run: tox -e py27
-
       - name: Run "tox -e coverage"
         run: tox -e coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,6 @@ jobs:
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py
 
-      # Codechecks errors out when running Towncrier within GitHub
-      # Actions.  See this issue:
-      # https://github.com/hawkowl/towncrier/issues/175.
-      #
-      # Run codechecks anyway, and continue on error, for now.
-      - name: Run "tox -e codechecks"
-        run: tox -e codechecks
-        continue-on-error: true
-
       - name: Run "tox -e coverage"
         run: tox -e coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
     - cron: '21 3 * * *'
 
 jobs:
-  test:
+
+  coverage:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,65 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.xml
+
+  integration:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+        python-version:
+          - 2.7
+
+    steps:
+
+      - name: [Ubuntu] Install Tor
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install tor
+
+      - name: [macOS] Install Tor
+        if: matrix.os == 'macos-latest'
+        run: brew install tor
+
+      - name: [Windows] Install Tor
+        if: matrix.os == 'windows-latest'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install tor
+
+      - name: Install MSVC 9.0 for Python 2.7 [Windows]
+        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install vcpython27
+
+      - name: Check out Tahoe-LAFS sources
+        uses: actions/checkout@v2
+
+      - name: Fetch all history for all tags and branches
+        run: git fetch --prune --unshallow
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade tox
+          pip list
+
+      - name: Display tool versions
+        run: python misc/build_helpers/show-tool-versions.py
+
+      - name: Run "tox -e integration"
+        run: tox -e integration
+
+      - name: Upload eliot.log in case of failure
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: eliot.log
+          path: eliot.log
+


### PR DESCRIPTION
Related to ticket [3277](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3277).  That ticket is about moving Windows CI to GitHub Actions, but we also get macOS and Ubuntu CI (almost) for free.  An example of this instance of Actions in action is [here](https://github.com/sajith/tahoe-lafs/runs/459370027).

There are a couple of caveats.  Running `tox -e codechecks` fails with an error (see below), on all three platforms, so that is disabled for now.  

```
codechecks run-test: commands[5] | python -m towncrier.check --pyproject towncrier.pyproject.toml
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/2.7.17/x64/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/Users/runner/hostedtoolcache/Python/2.7.17/x64/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/towncrier/check.py", line 98, in <module>
    _main()
  File "/Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/towncrier/check.py", line 31, in _main
    return __main(compare_with, directory, pyproject)
  File "/Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/lib/python2.7/site-packages/towncrier/check.py", line 44, in __main
    .decode(getattr(sys.stdout, "encoding", "utf8"))
TypeError: decode() argument 1 must be string, not None
ERROR: InvocationError for command /Users/runner/runners/2.165.2/work/tahoe-lafs/tahoe-lafs/.tox/codechecks/bin/python -m towncrier.check --pyproject towncrier.pyproject.toml (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   codechecks: commands failed
##[error]Process completed with exit code 1.
```
Looks like the default encoding is set to `None`.   What's the right thing to do here?  Get the encoding to change (by setting a locale maybe?)?  Or handle the `None` case in towncrier to call `.decode('utf8')`?

Second caveat is that uploading to coverage test results to codecov.io fails occasionally with a timeout.  (See codecov/codecov-action#54, codecov/codecov-action#56.)  Since this is already done elsewhere, we could perhaps omit this step in GitHub Actions CI?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/696)
<!-- Reviewable:end -->
