### PR TITLE
Remove nevow from allmydata.web.root.IncidentReporter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     #   `pip install tahoe-lafs[sftp]` would not install requirements
     #   specified by Twisted[conch].  Since this would be the *whole point* of
     #   an sftp extra in Tahoe-LAFS, there is no point in having one.
-    "Twisted[tls,conch] >= 18.4.0, < 20.0.0",
+    "Twisted[tls,conch] >= 18.4.0",
 
     # We need Nevow >= 0.11.1 which can be installed using pip.
     "Nevow >= 0.11.1",

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     #   `pip install tahoe-lafs[sftp]` would not install requirements
     #   specified by Twisted[conch].  Since this would be the *whole point* of
     #   an sftp extra in Tahoe-LAFS, there is no point in having one.
-    "Twisted[tls,conch] >= 18.4.0",
+    "Twisted[tls,conch] >= 18.4.0, < 20.0.0",
 
     # We need Nevow >= 0.11.1 which can be installed using pip.
     "Nevow >= 0.11.1",

--- a/src/allmydata/web/root.py
+++ b/src/allmydata/web/root.py
@@ -28,7 +28,7 @@ from allmydata.web.common import (
     WebError,
     get_arg,
     MultiFormatPage,
-    RenderMixin,
+    MultiFormatResource,
     get_format,
     get_mutable_type,
     render_time_delta,
@@ -169,14 +169,15 @@ class FileHandler(rend.Page):
         raise WebError("/file must be followed by a file-cap and a name",
                        http.NOT_FOUND)
 
-class IncidentReporter(RenderMixin, rend.Page):
-    def render_POST(self, ctx):
-        req = IRequest(ctx)
+class IncidentReporter(MultiFormatResource):
+    """Handler for /report_incident POST request"""
+
+    def render(self, req):
         log.msg(format="User reports incident through web page: %(details)s",
                 details=get_arg(req, "details", ""),
                 level=log.WEIRD, umid="LkD9Pw")
-        req.setHeader("content-type", "text/plain")
-        return "An incident report has been saved to logs/incidents/ in the node directory."
+        req.setHeader("content-type", "text/plain; charset=UTF-8")
+        return b"An incident report has been saved to logs/incidents/ in the node directory."
 
 SPACE = u"\u00A0"*2
 

--- a/src/allmydata/web/root.py
+++ b/src/allmydata/web/root.py
@@ -173,6 +173,9 @@ class IncidentReporter(MultiFormatResource):
     """Handler for /report_incident POST request"""
 
     def render(self, req):
+        if req.method != "POST":
+            raise WebError("/report_incident can only be used with POST")
+
         log.msg(format="User reports incident through web page: %(details)s",
                 details=get_arg(req, "details", ""),
                 level=log.WEIRD, umid="LkD9Pw")


### PR DESCRIPTION
This change calls for an explanation:

- `RenderMixin` doesn't seem to be adding anything here, so it is gone.

- The web browser was unhappy without a charset in the response (Firefox 74 was anyway), so `content-type` header also gets a `charset=UTF-8`.

- Returning a Unicode string made nevow appserver unhappy, so it is just a `str`.  The precise error message was:

```
	Traceback (most recent call last):
	  File "tahoe-lafs/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 654, in _runCallbacks
	    current.result = callback(current.result, *args, **kw)
	  File "tahoe-lafs/venv/local/lib/python2.7/site-packages/nevow/appserver.py", line 264, in gotPageContext
	    self._cbFinishRender, pageContext
	  File "tahoe-lafs/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 322, in addCallback
	    callbackKeywords=kw)
	  File "tahoe-lafs/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 311, in addCallbacks
	    self._runCallbacks()
	--- <exception caught here> ---
	  File "tahoe-lafs/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 654, in _runCallbacks
	    current.result = callback(current.result, *args, **kw)
	  File "tahoe-lafs/venv/local/lib/python2.7/site-packages/nevow/appserver.py", line 303, in _cbFinishRender
	    res = inevow.IResource(html)
	exceptions.TypeError: ('Could not adapt', u'An incident report has been saved to logs/incidents/ in the node directory.', <InterfaceClass nevow.inevow.IResource>)
```

Fixes: ticket:3294

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/699)
<!-- Reviewable:end -->
