### PR TITLE
Use 2.7-buster Docker image for pypy

### DIFF
--- a/.circleci/Dockerfile.pypy
+++ b/.circleci/Dockerfile.pypy
@@ -1,4 +1,4 @@
-FROM pypy:2.7-7.1.1-jessie
+FROM pypy:2.7-buster
 
 ENV WHEELHOUSE_PATH /tmp/wheelhouse
 ENV VIRTUALENV_PATH /tmp/venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ workflows:
 
       - "nixos-19.09"
 
-      # Test against PyPy 2.7/7.1.1
-      - "pypy2.7-7.1"
+      # Test against PyPy 2.7
+      - "pypy2.7-buster"
 
       # Other assorted tasks and configurations
       - "lint"
@@ -69,7 +69,7 @@ workflows:
       - "build-image-fedora-29"
       - "build-image-centos-8"
       - "build-image-slackware-14.2"
-      - "build-image-pypy-2.7-7.1.1-jessie"
+      - "build-image-pypy-2.7-buster"
 
 
 jobs:
@@ -198,10 +198,10 @@ jobs:
         user: "nobody"
 
 
-  pypy2.7-7.1:
+  pypy2.7-buster:
     <<: *DEBIAN
     docker:
-      - image: "tahoelafsci/pypy:2.7-7.1.1-jessie"
+      - image: "tahoelafsci/pypy:2.7-buster"
         user: "nobody"
 
     environment:
@@ -513,9 +513,9 @@ jobs:
       TAG: "14.2"
 
 
-  build-image-pypy-2.7-7.1.1-jessie:
+  build-image-pypy-2.7-buster:
     <<: *BUILD_IMAGE
 
     environment:
       DISTRO: "pypy"
-      TAG: "2.7-7.1.1-jessie"
+      TAG: "2.7-buster"


### PR DESCRIPTION
This should fix the failing PyPy CI job, such as [this](https://app.circleci.com/pipelines/github/tahoe-lafs/tahoe-lafs/60/workflows/21e74705-18c8-4af4-8326-5c8f3cf345ff/jobs/18760) one.

Related to [3299](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3299).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/706)
<!-- Reviewable:end -->
