### PR TITLE
Render helper status page using twisted.web.template

### DIFF
--- a/src/allmydata/web/helper.xhtml
+++ b/src/allmydata/web/helper.xhtml
@@ -6,22 +6,29 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   </head>
   <body>
-    <h1>Helper Status</h1>
-    <h2>Immutable Uploads</h2>
-    <ul t:data="helper_stats">
-      <li>Active: <span t:render="active_uploads" /></li>
-      <li>--</li>
-      <li>Bytes Fetched: <span t:render="upload_bytes_fetched" /></li>
-      <li>Incoming: <span t:render="incoming" /></li>
-      <li>Encoding: <span t:render="encoding" /></li>
-      <li>Bytes Encoded: <span t:render="upload_bytes_encoded" /></li>
-      <li>--</li>
-      <li>Total Requests: <span t:render="upload_requests" /></li>
-      <ul>
-        <li>Already Present: <span t:render="upload_already_present" /></li>
-        <li>Need Upload: <span t:render="upload_need_upload" /></li>
+
+    <div t:render="helper_running">
+      <h1>Helper Status</h1>
+
+      <h2>Immutable Uploads</h2>
+      <ul t:data="helper_stats">
+        <li>Active: <span t:render="active_uploads" /></li>
+        <li>--</li>
+        <li>Bytes Fetched: <span t:render="upload_bytes_fetched" /></li>
+        <li>Incoming: <span t:render="incoming" /></li>
+        <li>Encoding: <span t:render="encoding" /></li>
+        <li>Bytes Encoded: <span t:render="upload_bytes_encoded" /></li>
+        <li>--</li>
+        <li>Total Requests: <span t:render="upload_requests" /></li>
+        <ul>
+          <li>Already Present: <span t:render="upload_already_present" /></li>
+          <li>Need Upload: <span t:render="upload_need_upload" /></li>
+        </ul>
       </ul>
-    </ul>
+
+    </div>
+
     <div>Return to the <a href="/">Welcome Page</a></div>
+
   </body>
 </html>

--- a/src/allmydata/web/helper.xhtml
+++ b/src/allmydata/web/helper.xhtml
@@ -1,4 +1,4 @@
-<html xmlns:n="http://nevow.com/ns/nevow/0.1">
+<html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
   <head>
     <title>Tahoe-LAFS - Helper Status</title>
     <link href="/tahoe.css" rel="stylesheet" type="text/css"/>
@@ -6,26 +6,22 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   </head>
   <body>
-
-<h1>Helper Status</h1>
-
-<h2>Immutable Uploads</h2>
-<ul n:data="helper_stats">
-  <li>Active: <span n:render="active_uploads" /></li>
-  <li>--</li>
-  <li>Bytes Fetched: <span n:render="upload_bytes_fetched" /></li>
-  <li>Incoming: <span n:render="incoming" /></li>
-  <li>Encoding: <span n:render="encoding" /></li>
-  <li>Bytes Encoded: <span n:render="upload_bytes_encoded" /></li>
-  <li>--</li>
-  <li>Total Requests: <span n:render="upload_requests" /></li>
-  <ul>
-    <li>Already Present: <span n:render="upload_already_present" /></li>
-    <li>Need Upload: <span n:render="upload_need_upload" /></li>
-  </ul>
-</ul>
-
-<div>Return to the <a href="/">Welcome Page</a></div>
-
+    <h1>Helper Status</h1>
+    <h2>Immutable Uploads</h2>
+    <ul t:data="helper_stats">
+      <li>Active: <span t:render="active_uploads" /></li>
+      <li>--</li>
+      <li>Bytes Fetched: <span t:render="upload_bytes_fetched" /></li>
+      <li>Incoming: <span t:render="incoming" /></li>
+      <li>Encoding: <span t:render="encoding" /></li>
+      <li>Bytes Encoded: <span t:render="upload_bytes_encoded" /></li>
+      <li>--</li>
+      <li>Total Requests: <span t:render="upload_requests" /></li>
+      <ul>
+        <li>Already Present: <span t:render="upload_already_present" /></li>
+        <li>Need Upload: <span t:render="upload_need_upload" /></li>
+      </ul>
+    </ul>
+    <div>Return to the <a href="/">Welcome Page</a></div>
   </body>
 </html>

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -9,6 +9,7 @@ from twisted.web.template import (
     XMLFile,
     renderer,
     renderElement,
+    tags
 )
 from nevow import rend, tags as T
 from allmydata.util import base32, idlib
@@ -1154,7 +1155,10 @@ class HelperStatusElement(Element):
         :param _allmydata.immutable.offloaded.Helper helper
         """
         super(HelperStatusElement, self).__init__()
+        self._helper = helper
 
+    @renderer
+    def helper_running(self, req, tag):
         # helper.get_stats() returns a dict of this form:
         #
         #   {'chk_upload_helper.active_uploads': 0,
@@ -1171,7 +1175,11 @@ class HelperStatusElement(Element):
         #    'chk_upload_helper.upload_need_upload': 0,
         #    'chk_upload_helper.upload_requests': 0}
         #
-        self._data = helper.get_stats()
+        # If helper is running, we render the above data on the page.
+        if self._helper:
+            self._data = self._helper.get_stats()
+            return tag
+        return tags.h1("No helper is running")
 
     @renderer
     def active_uploads(self, req, tag):

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1187,33 +1187,33 @@ class HelperStatusElement(Element):
 
     @renderer
     def incoming(self, req, tag):
-        return "%d bytes in %d files" % (self._data["chk_upload_helper.incoming_size"],
-                                         self._data["chk_upload_helper.incoming_count"])
+        return tag("%d bytes in %d files" % (self._data["chk_upload_helper.incoming_size"],
+                                             self._data["chk_upload_helper.incoming_count"]))
 
     @renderer
     def encoding(self, req, tag):
-        return "%d bytes in %d files" % (self._data["chk_upload_helper.encoding_size"],
-                                         self._data["chk_upload_helper.encoding_count"])
+        return tag("%d bytes in %d files" % (self._data["chk_upload_helper.encoding_size"],
+                                             self._data["chk_upload_helper.encoding_count"]))
 
     @renderer
     def upload_requests(self, req, tag):
-        return str(self._data["chk_upload_helper.upload_requests"])
+        return tag(str(self._data["chk_upload_helper.upload_requests"]))
 
     @renderer
     def upload_already_present(self, req, tag):
-        return str(self._data["chk_upload_helper.upload_already_present"])
+        return tag(str(self._data["chk_upload_helper.upload_already_present"]))
 
     @renderer
     def upload_need_upload(self, req, tag):
-        return str(self._data["chk_upload_helper.upload_need_upload"])
+        return tag(str(self._data["chk_upload_helper.upload_need_upload"]))
 
     @renderer
     def upload_bytes_fetched(self, req, tag):
-        return str(self._data["chk_upload_helper.fetched_bytes"])
+        return tag(str(self._data["chk_upload_helper.fetched_bytes"]))
 
     @renderer
     def upload_bytes_encoded(self, req, tag):
-        return str(self._data["chk_upload_helper.encoded_bytes"])
+        return tag(str(self._data["chk_upload_helper.encoded_bytes"]))
 
 
 # Render "/statistics" page.

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1128,49 +1128,65 @@ class Status(MultiFormatPage):
                 if s.get_counter() == count:
                     return RetrieveStatusPage(s)
 
-
-class HelperStatus(MultiFormatPage):
-    docFactory = getxmlfile("helper.xhtml")
+# Render "/helper_status" page.
+class HelperStatus(MultiFormatResource):
 
     def __init__(self, helper):
-        rend.Page.__init__(self, helper)
-        self.helper = helper
+        super(HelperStatus, self).__init__()
+        self._helper = helper
 
-    def data_helper_stats(self, ctx, data):
-        return self.helper.get_stats()
+    def render_HTML(self, req):
+        return renderElement(req, HelperStatusElement(self._helper))
 
     def render_JSON(self, req):
         req.setHeader("content-type", "text/plain")
-        if self.helper:
-            stats = self.helper.get_stats()
+        if self._helper:
+            stats = self._helper.get_stats()
             return json.dumps(stats, indent=1) + "\n"
         return json.dumps({}) + "\n"
 
-    def render_active_uploads(self, ctx, data):
-        return data["chk_upload_helper.active_uploads"]
+class HelperStatusElement(Element):
 
-    def render_incoming(self, ctx, data):
-        return "%d bytes in %d files" % (data["chk_upload_helper.incoming_size"],
-                                         data["chk_upload_helper.incoming_count"])
+    loader = XMLFile(FilePath(__file__).sibling("helper.xhtml"))
 
-    def render_encoding(self, ctx, data):
-        return "%d bytes in %d files" % (data["chk_upload_helper.encoding_size"],
-                                         data["chk_upload_helper.encoding_count"])
+    def __init__(self, helper):
+        super(HelperStatusElement, self).__init__()
+        self._data = helper.get_stats()
 
-    def render_upload_requests(self, ctx, data):
-        return str(data["chk_upload_helper.upload_requests"])
+    @renderer
+    def active_uploads(self, req, tag):
+        return tag(str(self._data["chk_upload_helper.active_uploads"]))
 
-    def render_upload_already_present(self, ctx, data):
-        return str(data["chk_upload_helper.upload_already_present"])
+    @renderer
+    def incoming(self, req, tag):
+        return "%d bytes in %d files" % (self._data["chk_upload_helper.incoming_size"],
+                                         self._data["chk_upload_helper.incoming_count"])
 
-    def render_upload_need_upload(self, ctx, data):
-        return str(data["chk_upload_helper.upload_need_upload"])
+    @renderer
+    def encoding(self, req, tag):
+        return "%d bytes in %d files" % (self._data["chk_upload_helper.encoding_size"],
+                                         self._data["chk_upload_helper.encoding_count"])
 
-    def render_upload_bytes_fetched(self, ctx, data):
-        return str(data["chk_upload_helper.fetched_bytes"])
+    @renderer
+    def upload_requests(self, req, tag):
+        return str(self._data["chk_upload_helper.upload_requests"])
 
-    def render_upload_bytes_encoded(self, ctx, data):
-        return str(data["chk_upload_helper.encoded_bytes"])
+    @renderer
+    def upload_already_present(self, req, tag):
+        return str(self._data["chk_upload_helper.upload_already_present"])
+
+    @renderer
+    def upload_need_upload(self, req, tag):
+        return str(self._data["chk_upload_helper.upload_need_upload"])
+
+    @renderer
+    def upload_bytes_fetched(self, req, tag):
+        return str(self._data["chk_upload_helper.fetched_bytes"])
+
+    @renderer
+    def upload_bytes_encoded(self, req, tag):
+        return str(self._data["chk_upload_helper.encoded_bytes"])
+
 
 # Render "/statistics" page.
 class Statistics(MultiFormatResource):

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1152,7 +1152,7 @@ class HelperStatusElement(Element):
 
     def __init__(self, helper):
         """
-        :param _allmydata.immutable.offloaded.Helper helper
+        :param _allmydata.immutable.offloaded.Helper helper: upload helper.
         """
         super(HelperStatusElement, self).__init__()
         self._helper = helper

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1150,7 +1150,27 @@ class HelperStatusElement(Element):
     loader = XMLFile(FilePath(__file__).sibling("helper.xhtml"))
 
     def __init__(self, helper):
+        """
+        :param _allmydata.immutable.offloaded.Helper helper
+        """
         super(HelperStatusElement, self).__init__()
+
+        # helper.get_stats() returns a dict of this form:
+        #
+        #   {'chk_upload_helper.active_uploads': 0,
+        #    'chk_upload_helper.encoded_bytes': 0,
+        #    'chk_upload_helper.encoding_count': 0,
+        #    'chk_upload_helper.encoding_size': 0,
+        #    'chk_upload_helper.encoding_size_old': 0,
+        #    'chk_upload_helper.fetched_bytes': 0,
+        #    'chk_upload_helper.incoming_count': 0,
+        #    'chk_upload_helper.incoming_size': 0,
+        #    'chk_upload_helper.incoming_size_old': 0,
+        #    'chk_upload_helper.resumes': 0,
+        #    'chk_upload_helper.upload_already_present': 0,
+        #    'chk_upload_helper.upload_need_upload': 0,
+        #    'chk_upload_helper.upload_requests': 0}
+        #
         self._data = helper.get_stats()
 
     @renderer


### PR DESCRIPTION
Related to [3293](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3293) and thereby [3254](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3254).  This set of changes is responsible for rendering `/helper_status`.

Screenshots below.

--------------

Before:

![Screenshot_2020-04-22 Tahoe-LAFS - Helper Status(1)](https://user-images.githubusercontent.com/23618/80039420-c5317d00-84c5-11ea-8d5d-e5090a389d0a.png)

--------------

After:

![Screenshot_2020-04-22 Tahoe-LAFS - Helper Status(2)](https://user-images.githubusercontent.com/23618/80039442-cfec1200-84c5-11ea-9790-652d63118ac0.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/708)
<!-- Reviewable:end -->
