### PR TITLE
Remove trollius from NixOS CI

### DIFF
--- a/nix/autobahn.nix
+++ b/nix/autobahn.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k,
+  six, txaio, twisted, zope_interface, cffi, trollius, futures,
+  mock, pytest, cryptography, pynacl
+}:
+buildPythonPackage rec {
+  pname = "autobahn";
+  version = "19.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "294e7381dd54e73834354832604ae85567caf391c39363fed0ea2bfa86aa4304";
+  };
+
+  propagatedBuildInputs = [ six txaio twisted zope_interface cffi cryptography pynacl ] ++
+    (lib.optionals (!isPy3k) [ trollius futures ]);
+
+  checkInputs = [ mock pytest ];
+  checkPhase = ''
+    runHook preCheck
+    USE_TWISTED=true py.test $out
+    runHook postCheck
+  '';
+
+  # Tests do no seem to be compatible yet with pytest 5.1
+  # https://github.com/crossbario/autobahn-python/issues/1235
+  doCheck = false;
+
+  meta = with lib; {
+    description = "WebSocket and WAMP in Python for Twisted and asyncio.";
+    homepage    = "https://crossbar.io/autobahn";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ nand0p ];
+  };
+}

--- a/nix/autobahn.nix
+++ b/nix/autobahn.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, isPy3k,
-  six, txaio, twisted, zope_interface, cffi, trollius, futures,
+  six, txaio, twisted, zope_interface, cffi, futures,
   mock, pytest, cryptography, pynacl
 }:
 buildPythonPackage rec {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six txaio twisted zope_interface cffi cryptography pynacl ] ++
-    (lib.optionals (!isPy3k) [ trollius futures ]);
+    (lib.optionals (!isPy3k) [ futures ]);
 
   checkInputs = [ mock pytest ];
   checkPhase = ''

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -7,6 +7,10 @@ self: super: {
       # conflicts with the packaged version of Twisted.  Supply our own
       # slightly newer version.
       nevow = python-super.callPackage ./nevow.nix { };
+      # NixOS autobahn package has trollius as a dependency, although
+      # it is optional. Trollius is no longer maintained and fails on
+      # CI.
+      autobahn = python-super.callPackage ./autobahn.nix { };
     };
   };
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -8,8 +8,7 @@ self: super: {
       # slightly newer version.
       nevow = python-super.callPackage ./nevow.nix { };
       # NixOS autobahn package has trollius as a dependency, although
-      # it is optional. Trollius is no longer maintained and fails on
-      # CI.
+      # it is optional. Trollius is unmaintained and fails on CI.
       autobahn = python-super.callPackage ./autobahn.nix { };
     };
   };


### PR DESCRIPTION
Related to [3304](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3304): the dependency on [trollius](https://github.com/jamadden/trollius) has caused CI breakage.

[This](https://app.circleci.com/pipelines/github/sajith/tahoe-lafs/41/workflows/eab0510d-889b-45c8-a09f-d3febc9a6950/jobs/610) is an example of a failing CI job.  

[This](https://app.circleci.com/pipelines/github/sajith/tahoe-lafs/45/workflows/33ccdbf4-70d5-4dfb-a995-d8d045bcd0b0/jobs/668) post-removal CI job has no trollius in the log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tahoe-lafs/tahoe-lafs/709)
<!-- Reviewable:end -->
