### PR TITLE
Replace nevow with twisted.web in test.web.test_grid

### DIFF
--- a/src/allmydata/test/web/test_grid.py
+++ b/src/allmydata/test/web/test_grid.py
@@ -28,7 +28,7 @@ DIR_HTML_TAG = '<html lang="en">'
 class CompletelyUnhandledError(Exception):
     pass
 
-class ErrorBoom(resource.Resource):
+class ErrorBoom(object, resource.Resource):
     def render(self, req):
         raise CompletelyUnhandledError("whoops")
 

--- a/src/allmydata/test/web/test_grid.py
+++ b/src/allmydata/test/web/test_grid.py
@@ -6,7 +6,7 @@ from six.moves import StringIO
 
 from bs4 import BeautifulSoup
 
-from nevow import rend
+from twisted.web import resource
 from twisted.trial import unittest
 from allmydata import uri, dirnode
 from allmydata.util import base32
@@ -27,8 +27,9 @@ DIR_HTML_TAG = '<html lang="en">'
 
 class CompletelyUnhandledError(Exception):
     pass
-class ErrorBoom(rend.Page):
-    def beforeRender(self, ctx):
+
+class ErrorBoom(resource.Resource):
+    def render(self, req):
         raise CompletelyUnhandledError("whoops")
 
 class Grid(GridTestMixin, WebErrorMixin, ShouldFailMixin, testutil.ReallyEqualMixin, unittest.TestCase):


### PR DESCRIPTION
Tiny PR related to [3306](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3306).

Twisted web's `Resource` doesn't seem to have an equivalent of nevow's `Page.beforeRender()`, so I replaced `beforeRender()` with `Resource.render()`.