### PR TITLE
Run PyInstaller-generated binary in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,9 @@ jobs:
       # This step is to ensure there are no packaging/import errors.
       - name: Test PyInstaller executable
         run: dist/Tahoe-LAFS/tahoe --version
+
+      - name: Upload PyInstaller package
+        uses: actions/upload-artifact@v2
+        with:
+          name: Tahoe-LAFS-${{ matrix.os }}-Python-${{ matrix.python-version }}
+          path: dist/Tahoe-LAFS-*-*.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,7 @@ jobs:
 
       - name: Run "tox -e pyinstaller"
         run: tox -e pyinstaller
+
+      # This step is to ensure there are no packaging/import errors.
+      - name: Test PyInstaller executable
+        run: dist/Tahoe-LAFS/tahoe --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade tox setuptools
+          pip install --upgrade tox
           pip list
 
       - name: Display tool versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade codecov tox setuptools
+          pip install --upgrade tox setuptools
           pip list
 
       - name: Display tool versions


### PR DESCRIPTION
See [3309](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3309).  

We do try running the pyinstaller generated executable on CircleCI, but not on GitHub Actions.  This was my oversight when adding the GA configuration.