### PR TITLE
Replace nevow with twisted.web.template in status.DownloadStatusPage

### DIFF
--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -1,4 +1,6 @@
-# Tests for code in allmydata.web.status
+"""
+Tests for ```allmydata.web.status```.
+"""
 
 from bs4 import BeautifulSoup
 from twisted.web.template import flattenString
@@ -62,8 +64,10 @@ class FakeDownloadStatus(DownloadStatus):
                                    self.timings)
 
 
-# Tests for code in allmydata.web.status.DownloadStatusElement
 class DownloadStatusElementTests(TrialTestCase):
+    """
+    Tests for ```allmydata.web.status.DownloadStatusElement```.
+    """
 
     def _render_download_status_element(self, status):
         """

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -82,35 +82,72 @@ class DownloadStatusElementTests(TrialTestCase):
         """
         See if we can render the page almost fully.
         """
-        status = FakeDownloadStatus("si-1", 123,
-                                    ["s-1", "s-2", "s-3"],
-                                    {"s-1": "unknown problem"},
-                                    {"s-1": [1], "s-2": [1,2], "s-3": [2,3]},
-                                    {"fetch_per_server": {"s-1": [1], "s-2": [2,3], "s-3": [3,2]}})
+        status = FakeDownloadStatus(
+            "si-1", 123,
+            ["s-1", "s-2", "s-3"],
+            {"s-1": "unknown problem"},
+            {"s-1": [1], "s-2": [1,2], "s-3": [2,3]},
+            {"fetch_per_server":
+             {"s-1": [1], "s-2": [2,3], "s-3": [3,2]}}
+        )
 
         result = self._render_download_status_element(status)
         soup = BeautifulSoup(result, 'html5lib')
 
-        assert_soup_has_text(self, soup, u"Tahoe-LAFS - File Download Status")
         assert_soup_has_favicon(self, soup)
 
-        assert_soup_has_tag_with_content(self, soup, u"li", u"File Size: 123 bytes")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"Progress: 0.0%")
+        assert_soup_has_tag_with_content(
+            self, soup, u"title", u"Tahoe-LAFS - File Download Status"
+        )
 
-        assert_soup_has_tag_with_content(self, soup, u"li", u"Servers Used: [omwtc], [omwte], [omwtg]")
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"File Size: 123 bytes"
+        )
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"Progress: 0.0%"
+        )
 
-        assert_soup_has_tag_with_content(self, soup, u"li", u"Server Problems:")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtc]: unknown problem")
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"Servers Used: [omwtc], [omwte], [omwtg]"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"Server Problems:"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"[omwtc]: unknown problem"
+        )
 
         assert_soup_has_tag_with_content(self, soup, u"li", u"Servermap:")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtc] has share: #1")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwte] has shares: #1,#2")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtg] has shares: #2,#3")
 
-        assert_soup_has_tag_with_content(self, soup, u"li", u"Per-Server Segment Fetch Response Times:")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtc]: 1.00s")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwte]: 2.00s, 3.00s")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtg]: 3.00s, 2.00s")
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"[omwtc] has share: #1"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"[omwte] has shares: #1,#2"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"[omwtg] has shares: #2,#3"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"Per-Server Segment Fetch Response Times:"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"[omwtc]: 1.00s"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"[omwte]: 2.00s, 3.00s"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"[omwtg]: 3.00s, 2.00s"
+        )
 
     def test_download_status_element_partial(self):
         """
@@ -120,6 +157,14 @@ class DownloadStatusElementTests(TrialTestCase):
         result = self._render_download_status_element(status)
         soup = BeautifulSoup(result, 'html5lib')
 
-        assert_soup_has_tag_with_content(self, soup, u"li", u"Servermap: None")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"File Size: 0 bytes")
-        assert_soup_has_tag_with_content(self, soup, u"li", u"Total: None (None)")
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"Servermap: None"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"File Size: 0 bytes"
+        )
+
+        assert_soup_has_tag_with_content(
+            self, soup, u"li", u"Total: None (None)"
+        )

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -1,3 +1,4 @@
+# Tests for code in allmydata.web.status
 
 from bs4 import BeautifulSoup
 from twisted.web.template import flattenString
@@ -19,11 +20,13 @@ from ..common import TrialTestCase
 
 @implementer(IDownloadResults)
 class FakeDownloadResults(object):
-    file_size = 0
-    servers_used = 0
-    server_problems = {"s-1": "unknown problem"}
-    servermap = dict()
-    timings = dict()
+
+    def __init__(self, file_size):
+    	self.file_size = file_size
+    	self.servers_used = ["s-1", "s-2", "s-3"]
+    	self.server_problems = {"s-1": "unknown problem"}
+    	self.servermap = {"s-1": [1,2,3], "s-2": [2,3,4], "s-3": [0,1,3]}
+    	self.timings = { "fetch_per_server": {"s-1": [1,2,3], "s-2": [2], "s-3": [3]}}
 
 
 @implementer(IDownloadStatus)
@@ -62,10 +65,10 @@ class FakeDownloadStatus(object):
         return 0
 
     def get_results(self):
-        return FakeDownloadResults()
+        return FakeDownloadResults(self.size)
 
-
-class StatusTests(TrialTestCase):
+# Tests for code in allmydata.web.status.DownloadStatusElement
+class DownloadStatusElementTests(TrialTestCase):
 
     def _render_download_status_element(self):
         elem = DownloadStatusElement(FakeDownloadStatus("si-1", 123))
@@ -76,7 +79,23 @@ class StatusTests(TrialTestCase):
         result = self._render_download_status_element()
         soup = BeautifulSoup(result, 'html5lib')
 
-        assert_soup_has_text(self, soup, u'Tahoe-LAFS - File Download Status')
+        assert_soup_has_text(self, soup, u"Tahoe-LAFS - File Download Status")
         assert_soup_has_favicon(self, soup)
 
-        assert_soup_has_tag_with_content(self, soup, u'li', u'[omwtc]: unknown problem')
+        assert_soup_has_tag_with_content(self, soup, u"li", u"File Size: 123 bytes")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"Progress: 0.0%")
+
+        assert_soup_has_tag_with_content(self, soup, u"li", u"Servers Used: [omwtc], [omwte], [omwtg]")
+
+        assert_soup_has_tag_with_content(self, soup, u"li", u"Server Problems:")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtc]: unknown problem")
+
+        assert_soup_has_tag_with_content(self, soup, u"li", u"Servermap:")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtc] has shares: #1,#2,#3")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwte] has shares: #2,#3,#4")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtg] has shares: #0,#1,#3")
+
+        assert_soup_has_tag_with_content(self, soup, u"li", u"Per-Server Segment Fetch Response Times:")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtc]: 1.00s, 2.00s, 3.00s")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwte]: 2.00s")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtg]: 3.00s")

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -30,7 +30,7 @@ class FakeDownloadResults(object):
         """
         See IDownloadResults for parameters.
         """
-    	self.file_size = file_size
+        self.file_size = file_size
         self.servers_used = servers_used
         self.server_problems = server_problems
         self.servermap = servermap

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -31,10 +31,10 @@ class FakeDownloadResults(object):
         See IDownloadResults for parameters.
         """
     	self.file_size = file_size
-    	self.servers_used = servers_used
-    	self.server_problems = server_problems
-    	self.servermap = servermap
-    	self.timings = timings
+        self.servers_used = servers_used
+        self.server_problems = server_problems
+        self.servermap = servermap
+        self.timings = timings
 
 
 @implementer(IDownloadStatus)

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -4,11 +4,9 @@ from bs4 import BeautifulSoup
 from twisted.web.template import flattenString
 from zope.interface import implementer
 
-from allmydata.interfaces import (
-    IDownloadResults,
-    IDownloadStatus,
-)
+from allmydata.interfaces import IDownloadResults
 from allmydata.web.status import DownloadStatusElement
+from allmydata.immutable.downloader.status import DownloadStatus
 
 from .common import (
     assert_soup_has_favicon,
@@ -37,8 +35,7 @@ class FakeDownloadResults(object):
         self.timings = timings
 
 
-@implementer(IDownloadStatus)
-class FakeDownloadStatus(object):
+class FakeDownloadStatus(DownloadStatus):
 
     def __init__(self,
                  storage_index = None,
@@ -50,48 +47,20 @@ class FakeDownloadStatus(object):
         """
         See IDownloadStatus and IDownloadResults for parameters.
         """
-        self.storage_index = storage_index
-        self.file_size = file_size
-        self.dyhb_requests = []
-        self.read_events = []
-        self.segment_events = []
-        self.block_requests = []
+        super(FakeDownloadStatus, self).__init__(storage_index, file_size)
 
         self.servers_used = servers_used
         self.server_problems = server_problems
         self.servermap = servermap
         self.timings = timings
 
-    def get_started(self):
-        return None
-
-    def get_storage_index(self):
-        return self.storage_index
-
-    def get_size(self):
-        return self.file_size
-
-    def using_helper(self):
-        return False
-
-    def get_status(self):
-        return "FakeDownloadStatus"
-
-    def get_progress(self):
-        return 0
-
-    def get_active():
-        return False
-
-    def get_counter():
-        return 0
-
     def get_results(self):
-        return FakeDownloadResults(self.file_size,
+        return FakeDownloadResults(self.size,
                                    self.servers_used,
                                    self.server_problems,
                                    self.servermap,
                                    self.timings)
+
 
 # Tests for code in allmydata.web.status.DownloadStatusElement
 class DownloadStatusElementTests(TrialTestCase):

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -26,7 +26,7 @@ class FakeDownloadResults(object):
     	self.servers_used = ["s-1", "s-2", "s-3"]
     	self.server_problems = {"s-1": "unknown problem"}
     	self.servermap = {"s-1": [1,2,3], "s-2": [2,3,4], "s-3": [0,1,3]}
-    	self.timings = { "fetch_per_server": {"s-1": [1,2,3], "s-2": [2], "s-3": [3]}}
+    	self.timings = {"fetch_per_server": {"s-1": [1,2,3], "s-2": [2], "s-3": [3]}}
 
 
 @implementer(IDownloadStatus)

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -12,7 +12,6 @@ from allmydata.immutable.downloader.status import DownloadStatus
 
 from .common import (
     assert_soup_has_favicon,
-    assert_soup_has_text,
     assert_soup_has_tag_with_content,
 )
 from ..common import TrialTestCase

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -138,3 +138,15 @@ class DownloadStatusElementTests(TrialTestCase):
         assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtc]: 1.00s")
         assert_soup_has_tag_with_content(self, soup, u"li", u"[omwte]: 2.00s, 3.00s")
         assert_soup_has_tag_with_content(self, soup, u"li", u"[omwtg]: 3.00s, 2.00s")
+
+    def test_download_status_element_partial(self):
+        """
+        See if we can render the page with incomplete download status.
+        """
+        status = FakeDownloadStatus()
+        result = self._render_download_status_element(status)
+        soup = BeautifulSoup(result, 'html5lib')
+
+        assert_soup_has_tag_with_content(self, soup, u"li", u"Servermap: None")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"File Size: 0 bytes")
+        assert_soup_has_tag_with_content(self, soup, u"li", u"Total: None (None)")

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -1,0 +1,82 @@
+
+from bs4 import BeautifulSoup
+from twisted.web.template import flattenString
+from zope.interface import implementer
+
+from allmydata.interfaces import (
+    IDownloadResults,
+    IDownloadStatus,
+)
+from allmydata.web.status import DownloadStatusElement
+
+from .common import (
+    assert_soup_has_favicon,
+    assert_soup_has_text,
+    assert_soup_has_tag_with_content,
+)
+from ..common import TrialTestCase
+
+
+@implementer(IDownloadResults)
+class FakeDownloadResults(object):
+    file_size = 0
+    servers_used = 0
+    server_problems = {"s-1": "unknown problem"}
+    servermap = dict()
+    timings = dict()
+
+
+@implementer(IDownloadStatus)
+class FakeDownloadStatus(object):
+
+    def __init__(self, storage_index, size):
+        self.storage_index = storage_index
+        self.size = size
+        self.dyhb_requests = []
+        self.read_events = []
+        self.segment_events = []
+        self.block_requests = []
+
+    def get_started(self):
+        return None
+
+    def get_storage_index(self):
+        return self.storage_index
+
+    def get_size(self):
+        return self.size
+
+    def using_helper(self):
+        return False
+
+    def get_status(self):
+        return "FakeDownloadStatus"
+
+    def get_progress(self):
+        return 0
+
+    def get_active():
+        return False
+
+    def get_counter():
+        return 0
+
+    def get_results(self):
+        return FakeDownloadResults()
+
+
+class StatusTests(TrialTestCase):
+
+    def _render_download_status_element(self):
+        elem = DownloadStatusElement(FakeDownloadStatus("si-1", 123))
+        d = flattenString(None, elem)
+        return self.successResultOf(d)
+
+    def test_download_status_element(self):
+        result = self._render_download_status_element()
+        soup = BeautifulSoup(result, 'html5lib')
+
+        assert_soup_has_text(self, soup, u'Tahoe-LAFS - File Download Status')
+        assert_soup_has_favicon(self, soup)
+
+        assert_soup_has_tag_with_content(self, soup, u'li', u'[omwtc]: unknown problem')

--- a/src/allmydata/test/web/test_util.py
+++ b/src/allmydata/test/web/test_util.py
@@ -22,6 +22,9 @@ class Util(ShouldFailMixin, testutil.ReallyEqualMixin, unittest.TestCase):
         self.failUnlessReallyEqual(common.abbreviate_time(0.00123), "1.2ms")
         self.failUnlessReallyEqual(common.abbreviate_time(0.000123), "123us")
         self.failUnlessReallyEqual(common.abbreviate_time(-123000), "-123000000000us")
+        self.failUnlessReallyEqual(common.abbreviate_time(2.5), "2.50s")
+        self.failUnlessReallyEqual(common.abbreviate_time(0.25), "250ms")
+        self.failUnlessReallyEqual(common.abbreviate_time(0.0021), "2.1ms")
 
     def test_compute_rate(self):
         self.failUnlessReallyEqual(common.compute_rate(None, None), None)
@@ -43,6 +46,9 @@ class Util(ShouldFailMixin, testutil.ReallyEqualMixin, unittest.TestCase):
         self.failUnlessReallyEqual(common.abbreviate_rate(None), "")
         self.failUnlessReallyEqual(common.abbreviate_rate(1234000), "1.23MBps")
         self.failUnlessReallyEqual(common.abbreviate_rate(12340), "12.3kBps")
+        self.failUnlessReallyEqual(common.abbreviate_rate(123), "123Bps")
+        self.failUnlessReallyEqual(common.abbreviate_rate(2500000), "2.50MBps")
+        self.failUnlessReallyEqual(common.abbreviate_rate(30100), "30.1kBps")
         self.failUnlessReallyEqual(common.abbreviate_rate(123), "123Bps")
 
     def test_abbreviate_size(self):

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1035,17 +1035,6 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
         return d
 
     def test_status_numbers(self):
-        drrm = status.DownloadResultsRendererMixin()
-        self.failUnlessReallyEqual(drrm.render_time(None, None), "")
-        self.failUnlessReallyEqual(drrm.render_time(None, 2.5), "2.50s")
-        self.failUnlessReallyEqual(drrm.render_time(None, 0.25), "250ms")
-        self.failUnlessReallyEqual(drrm.render_time(None, 0.0021), "2.1ms")
-        self.failUnlessReallyEqual(drrm.render_time(None, 0.000123), "123us")
-        self.failUnlessReallyEqual(drrm.render_rate(None, None), "")
-        self.failUnlessReallyEqual(drrm.render_rate(None, 2500000), "2.50MBps")
-        self.failUnlessReallyEqual(drrm.render_rate(None, 30100), "30.1kBps")
-        self.failUnlessReallyEqual(drrm.render_rate(None, 123), "123Bps")
-
         urrm = status.UploadResultsRendererMixin()
         self.failUnlessReallyEqual(urrm.render_time(None, None), "")
         self.failUnlessReallyEqual(urrm.render_time(None, 2.5), "2.50s")

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1035,29 +1035,6 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
 
         return d
 
-    def test_status_numbers(self):
-        urrm = status.UploadResultsRendererMixin()
-        self.failUnlessReallyEqual(urrm.render_time(None, None), "")
-        self.failUnlessReallyEqual(urrm.render_time(None, 2.5), "2.50s")
-        self.failUnlessReallyEqual(urrm.render_time(None, 0.25), "250ms")
-        self.failUnlessReallyEqual(urrm.render_time(None, 0.0021), "2.1ms")
-        self.failUnlessReallyEqual(urrm.render_time(None, 0.000123), "123us")
-        self.failUnlessReallyEqual(urrm.render_rate(None, None), "")
-        self.failUnlessReallyEqual(urrm.render_rate(None, 2500000), "2.50MBps")
-        self.failUnlessReallyEqual(urrm.render_rate(None, 30100), "30.1kBps")
-        self.failUnlessReallyEqual(urrm.render_rate(None, 123), "123Bps")
-
-        drrm = status.DownloadResultsRendererMixin()
-        self.failUnlessReallyEqual(drrm.render_time(None, None), "")
-        self.failUnlessReallyEqual(drrm.render_time(None, 2.5), "2.50s")
-        self.failUnlessReallyEqual(drrm.render_time(None, 0.25), "250ms")
-        self.failUnlessReallyEqual(drrm.render_time(None, 0.0021), "2.1ms")
-        self.failUnlessReallyEqual(drrm.render_time(None, 0.000123), "123us")
-        self.failUnlessReallyEqual(drrm.render_rate(None, None), "")
-        self.failUnlessReallyEqual(drrm.render_rate(None, 2500000), "2.50MBps")
-        self.failUnlessReallyEqual(drrm.render_rate(None, 30100), "30.1kBps")
-        self.failUnlessReallyEqual(drrm.render_rate(None, 123), "123Bps")
-
     def test_GET_FILEURL(self):
         d = self.GET(self.public_url + "/foo/bar.txt")
         d.addCallback(self.failUnlessIsBarDotTxt)

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -33,7 +33,6 @@ from allmydata.immutable import upload
 from allmydata.immutable.downloader.status import DownloadStatus
 from allmydata.dirnode import DirectoryNode
 from allmydata.nodemaker import NodeMaker
-from allmydata.web import status
 from allmydata.web.common import WebError, MultiFormatPage
 from allmydata.util import fileutil, base32, hashutil
 from allmydata.util.consumer import download_to_data

--- a/src/allmydata/web/download-status.xhtml
+++ b/src/allmydata/web/download-status.xhtml
@@ -1,4 +1,4 @@
-<html xmlns:n="http://nevow.com/ns/nevow/0.1">
+<html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
 
   <head>
     <title>Tahoe-LAFS - File Download Status</title>
@@ -12,46 +12,46 @@
     <h1>File Download Status</h1>
 
     <ul>
-      <li>Started: <span n:render="started"/></li>
-      <li>Storage Index: <span n:render="si"/></li>
-      <li>Helper?: <span n:render="helper"/></li>
-      <li>Total Size: <span n:render="total_size"/></li>
-      <li>Progress: <span n:render="progress"/></li>
-      <li>Status: <span n:render="status"/></li>
+      <li>Started: <span t:render="started"/></li>
+      <li>Storage Index: <span t:render="si"/></li>
+      <li>Helper?: <span t:render="helper"/></li>
+      <li>Total Size: <span t:render="total_size"/></li>
+      <li>Progress: <span t:render="progress"/></li>
+      <li>Status: <span t:render="status"/></li>
     </ul>
 
-    <div n:render="events"></div>
+    <div t:render="events"></div>
 
-    <div n:render="results">
+    <div t:render="results">
 
       <h2>Download Results</h2>
 
       <ul>
-        <li n:render="servers_used" />
-        <li>Servermap: <span n:render="servermap" /></li>
-        <li n:render="problems" />
+        <li t:render="servers_used" />
+        <li>Servermap: <span t:render="servermap" /></li>
+        <li t:render="problems" />
         <li>Timings:</li>
         <ul>
-          <li>File Size: <span n:render="string" n:data="file_size" /> bytes</li>
-          <li>Total: <span n:render="time" n:data="time_total" />
-            (<span n:render="rate" n:data="rate_total" />)</li>
+          <li>File Size: <span t:render="file_size" /> bytes</li>
+          <li>Total: <span t:render="time_total" />
+            (<span t:render="rate_total" />)</li>
           <ul>
-            <li>Peer Selection: <span n:render="time" n:data="time_peer_selection" /></li>
-            <li>UEB Fetch: <span n:render="time" n:data="time_uri_extension" /></li>
-            <li>Hashtree Fetch: <span n:render="time" n:data="time_hashtrees" /></li>
-            <li>Segment Fetch: <span n:render="time" n:data="time_segments" />
-              (<span n:render="rate" n:data="rate_segments" />)</li>
+            <li>Peer Selection: <span t:render="time_peer_selection" /></li>
+            <li>UEB Fetch: <span t:render="time_uri_extension" /></li>
+            <li>Hashtree Fetch: <span t:render="time_hashtrees" /></li>
+            <li>Segment Fetch: <span t:render="time_segments" />
+              (<span t:render="rate_segments" />)</li>
             <ul>
-              <li>Cumulative Fetching: <span n:render="time" n:data="time_cumulative_fetch" />
-                (<span n:render="rate" n:data="rate_fetch" />)</li>
-              <li>Cumulative Decoding: <span n:render="time" n:data="time_cumulative_decode" />
-                (<span n:render="rate" n:data="rate_decode" />)</li>
-              <li>Cumulative Decrypting: <span n:render="time" n:data="time_cumulative_decrypt" />
-                (<span n:render="rate" n:data="rate_decrypt" />)</li>
+              <li>Cumulative Fetching: <span t:render="time_cumulative_fetch" />
+                (<span t:render="rate_fetch" />)</li>
+              <li>Cumulative Decoding: <span t:render="time_cumulative_decode" />
+                (<span t:render="rate_decode" />)</li>
+              <li>Cumulative Decrypting: <span t:render="time_cumulative_decrypt" />
+                (<span t:render="rate_decrypt" />)</li>
             </ul>
-            <li>Paused by client: <span n:render="time" n:data="time_paused" /></li>
+            <li>Paused by client: <span t:render="time_paused" /></li>
           </ul>
-          <li n:render="server_timings" />
+          <li t:render="server_timings" />
         </ul>
       </ul>
     </div>

--- a/src/allmydata/web/download-status.xhtml
+++ b/src/allmydata/web/download-status.xhtml
@@ -1,58 +1,63 @@
 <html xmlns:n="http://nevow.com/ns/nevow/0.1">
+
   <head>
     <title>Tahoe-LAFS - File Download Status</title>
     <link href="/tahoe.css" rel="stylesheet" type="text/css"/>
     <link href="/icon.png" rel="shortcut icon" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   </head>
+
   <body>
 
-<h1>File Download Status</h1>
+    <h1>File Download Status</h1>
 
-<ul>
-  <li>Started: <span n:render="started"/></li>
-  <li>Storage Index: <span n:render="si"/></li>
-  <li>Helper?: <span n:render="helper"/></li>
-  <li>Total Size: <span n:render="total_size"/></li>
-  <li>Progress: <span n:render="progress"/></li>
-  <li>Status: <span n:render="status"/></li>
-</ul>
-
-<div n:render="events"></div>
-
-<div n:render="results">
-  <h2>Download Results</h2>
-  <ul>
-    <li n:render="servers_used" />
-    <li>Servermap: <span n:render="servermap" /></li>
-    <li n:render="problems" />
-    <li>Timings:</li>
     <ul>
-      <li>File Size: <span n:render="string" n:data="file_size" /> bytes</li>
-      <li>Total: <span n:render="time" n:data="time_total" />
-      (<span n:render="rate" n:data="rate_total" />)</li>
-      <ul>
-        <li>Peer Selection: <span n:render="time" n:data="time_peer_selection" /></li>
-        <li>UEB Fetch: <span n:render="time" n:data="time_uri_extension" /></li>
-        <li>Hashtree Fetch: <span n:render="time" n:data="time_hashtrees" /></li>
-        <li>Segment Fetch: <span n:render="time" n:data="time_segments" />
-        (<span n:render="rate" n:data="rate_segments" />)</li>
-        <ul>
-          <li>Cumulative Fetching: <span n:render="time" n:data="time_cumulative_fetch" />
-          (<span n:render="rate" n:data="rate_fetch" />)</li>
-          <li>Cumulative Decoding: <span n:render="time" n:data="time_cumulative_decode" />
-          (<span n:render="rate" n:data="rate_decode" />)</li>
-          <li>Cumulative Decrypting: <span n:render="time" n:data="time_cumulative_decrypt" />
-          (<span n:render="rate" n:data="rate_decrypt" />)</li>
-        </ul>
-        <li>Paused by client: <span n:render="time" n:data="time_paused" /></li>
-      </ul>
-      <li n:render="server_timings" />
+      <li>Started: <span n:render="started"/></li>
+      <li>Storage Index: <span n:render="si"/></li>
+      <li>Helper?: <span n:render="helper"/></li>
+      <li>Total Size: <span n:render="total_size"/></li>
+      <li>Progress: <span n:render="progress"/></li>
+      <li>Status: <span n:render="status"/></li>
     </ul>
-  </ul>
-</div>
 
-<div>Return to the <a href="/">Welcome Page</a></div>
+    <div n:render="events"></div>
+
+    <div n:render="results">
+
+      <h2>Download Results</h2>
+
+      <ul>
+        <li n:render="servers_used" />
+        <li>Servermap: <span n:render="servermap" /></li>
+        <li n:render="problems" />
+        <li>Timings:</li>
+        <ul>
+          <li>File Size: <span n:render="string" n:data="file_size" /> bytes</li>
+          <li>Total: <span n:render="time" n:data="time_total" />
+            (<span n:render="rate" n:data="rate_total" />)</li>
+          <ul>
+            <li>Peer Selection: <span n:render="time" n:data="time_peer_selection" /></li>
+            <li>UEB Fetch: <span n:render="time" n:data="time_uri_extension" /></li>
+            <li>Hashtree Fetch: <span n:render="time" n:data="time_hashtrees" /></li>
+            <li>Segment Fetch: <span n:render="time" n:data="time_segments" />
+              (<span n:render="rate" n:data="rate_segments" />)</li>
+            <ul>
+              <li>Cumulative Fetching: <span n:render="time" n:data="time_cumulative_fetch" />
+                (<span n:render="rate" n:data="rate_fetch" />)</li>
+              <li>Cumulative Decoding: <span n:render="time" n:data="time_cumulative_decode" />
+                (<span n:render="rate" n:data="rate_decode" />)</li>
+              <li>Cumulative Decrypting: <span n:render="time" n:data="time_cumulative_decrypt" />
+                (<span n:render="rate" n:data="rate_decrypt" />)</li>
+            </ul>
+            <li>Paused by client: <span n:render="time" n:data="time_paused" /></li>
+          </ul>
+          <li n:render="server_timings" />
+        </ul>
+      </ul>
+    </div>
+
+    <div>Return to the <a href="/">Welcome Page</a></div>
 
   </body>
+
 </html>

--- a/src/allmydata/web/download-status.xhtml
+++ b/src/allmydata/web/download-status.xhtml
@@ -59,5 +59,4 @@
     <div>Return to the <a href="/">Welcome Page</a></div>
 
   </body>
-
 </html>

--- a/src/allmydata/web/download-status.xhtml
+++ b/src/allmydata/web/download-status.xhtml
@@ -12,12 +12,12 @@
     <h1>File Download Status</h1>
 
     <ul>
-      <li>Started: <span t:render="started"/></li>
-      <li>Storage Index: <span t:render="si"/></li>
-      <li>Helper?: <span t:render="helper"/></li>
-      <li>Total Size: <span t:render="total_size"/></li>
-      <li>Progress: <span t:render="progress"/></li>
-      <li>Status: <span t:render="status"/></li>
+      <li>Started: <t:transparent t:render="started"/></li>
+      <li>Storage Index: <t:transparent t:render="si"/></li>
+      <li>Helper?: <t:transparent t:render="helper"/></li>
+      <li>Total Size: <t:transparent t:render="total_size"/></li>
+      <li>Progress: <t:transparent t:render="progress"/></li>
+      <li>Status: <t:transparent t:render="status"/></li>
     </ul>
 
     <div t:render="events"></div>
@@ -28,28 +28,28 @@
 
       <ul>
         <li t:render="servers_used" />
-        <li>Servermap: <span t:render="servermap" /></li>
+        <li>Servermap: <t:transparent t:render="servermap" /></li>
         <li t:render="problems" />
         <li>Timings:</li>
         <ul>
-          <li>File Size: <span t:render="file_size" /> bytes</li>
-          <li>Total: <span t:render="time_total" />
-            (<span t:render="rate_total" />)</li>
+          <li>File Size: <t:transparent t:render="file_size" /> bytes</li>
+          <li>Total: <t:transparent t:render="time_total" />
+            (<t:transparent t:render="rate_total" />)</li>
           <ul>
-            <li>Peer Selection: <span t:render="time_peer_selection" /></li>
-            <li>UEB Fetch: <span t:render="time_uri_extension" /></li>
-            <li>Hashtree Fetch: <span t:render="time_hashtrees" /></li>
-            <li>Segment Fetch: <span t:render="time_segments" />
-              (<span t:render="rate_segments" />)</li>
+            <li>Peer Selection: <t:transparent t:render="time_peer_selection" /></li>
+            <li>UEB Fetch: <t:transparent t:render="time_uri_extension" /></li>
+            <li>Hashtree Fetch: <t:transparent t:render="time_hashtrees" /></li>
+            <li>Segment Fetch: <t:transparent t:render="time_segments" />
+              (<t:transparent t:render="rate_segments" />)</li>
             <ul>
-              <li>Cumulative Fetching: <span t:render="time_cumulative_fetch" />
-                (<span t:render="rate_fetch" />)</li>
-              <li>Cumulative Decoding: <span t:render="time_cumulative_decode" />
-                (<span t:render="rate_decode" />)</li>
-              <li>Cumulative Decrypting: <span t:render="time_cumulative_decrypt" />
-                (<span t:render="rate_decrypt" />)</li>
+              <li>Cumulative Fetching: <t:transparent t:render="time_cumulative_fetch" />
+                (<t:transparent t:render="rate_fetch" />)</li>
+              <li>Cumulative Decoding: <t:transparent t:render="time_cumulative_decode" />
+                (<t:transparent t:render="rate_decode" />)</li>
+              <li>Cumulative Decrypting: <t:transparent t:render="time_cumulative_decrypt" />
+                (<t:transparent t:render="rate_decrypt" />)</li>
             </ul>
-            <li>Paused by client: <span t:render="time_paused" /></li>
+            <li>Paused by client: <t:transparent t:render="time_paused" /></li>
           </ul>
           <li t:render="server_timings" />
         </ul>

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -366,7 +366,7 @@ class _EventJson(Resource, object):
         return json.dumps(data, indent=1) + "\n"
 
 
-class DownloadStatusPage(MultiFormatResource):
+class DownloadStatusPage(Resource):
     """Renders /status/down-%d."""
 
     def __init__(self, download_status):

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -424,6 +424,8 @@ class DownloadStatusElement(Element):
     # XXX: This method is a candidate for refactoring.  It renders
     # four tables from this function.  Layout part of those tables
     # could be moved to download-status.xhtml.
+    #
+    # See #3311: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3311
     @renderer
     def events(self, req, tag):
         if not self._download_status.storage_index:

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -540,6 +540,9 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
             return tags.span(time_s, title=rate)
         return tags.span(time_s)
 
+    # XXX: This method is a candidate for refactoring.  It renders
+    # four tables from this function.  Layout part of those tables
+    # could be moved to download-status.xhtml.
     @renderer
     def events(self, req, tag):
         if not self._download_status.storage_index:

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -510,7 +510,7 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
         self._download_status = download_status
 
     def download_results(self):
-        return defer.maybeDeferred(self.download_status.get_results)
+        return defer.maybeDeferred(self._download_status.get_results)
 
     def _relative_time(self, t):
         if t is None:
@@ -530,9 +530,9 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
         return T.a(href=url.URL.fromContext(ctx).child("timeline"))["timeline"]
 
     def _rate_and_time(self, bytes, seconds):
-        time_s = self.render_time(None, seconds)
+        time_s = abbreviate_time(seconds)
         if seconds != 0:
-            rate = self.render_rate(None, 1.0 * bytes / seconds)
+            rate = abbreviate_rate(1.0 * bytes / seconds)
             return tags.span(time_s, title=rate)
         return tags.span(time_s)
 
@@ -569,7 +569,7 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
                  tags.td(srt(sent)),
                  tags.td(srt(received)),
                  tags.td(",".join([str(shnum) for shnum in shnums])),
-                 tags.td(self.render_time(None, rtt)),
+                 tags.td(abbreviate_time(rtt)),
                 )))
 
         l(tags.h2("DYHB Requests:"), t)
@@ -597,9 +597,9 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
             speed, rtt = "",""
             if r_ev["finish_time"] is not None:
                 rtt = r_ev["finish_time"] - r_ev["start_time"] - r_ev["paused_time"]
-                speed = self.render_rate(None, compute_rate(bytes, rtt))
-                rtt = self.render_time(None, rtt)
-            paused = self.render_time(None, r_ev["paused_time"])
+                speed = abbreviate_rate(compute_rate(bytes, rtt))
+                rtt = abbreviate_time(rtt)
+            paused = abbreviate_time(r_ev["paused_time"])
 
             t(tags.tr(
                 tags.td("[%d:+%d]" % (start, length)),
@@ -635,10 +635,10 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
             if s_ev["finish_time"] is not None:
                 if s_ev["success"]:
                     segtime = s_ev["finish_time"] - s_ev["active_time"]
-                    segtime_s = self.render_time(None, segtime)
+                    segtime_s = abbreviate_time(segtime)
                     seglen = s_ev["segment_length"]
                     range_s = "[%d:+%d]" % (s_ev["segment_start"], seglen)
-                    speed = self.render_rate(None, compute_rate(seglen, segtime))
+                    speed = abbreviate_rate(compute_rate(seglen, segtime))
                     decode_time = self._rate_and_time(seglen, s_ev["decode_time"])
                 else:
                     # error
@@ -686,7 +686,7 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
                   tags.td(srt(r_ev["start_time"])),
                   tags.td(srt(r_ev["finish_time"])),
                   tags.td(str(r_ev["response_length"]) or ""),
-                  tags.td(self.render_time(None, rtt)),
+                  tags.td(abbreviate_time(rtt)),
               ))
 
         l(tags.h2("Requests:"), t)

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -431,6 +431,7 @@ class DownloadStatusElement(Element):
 
         evtag = tags.div()
 
+        # "DYHB Requests" table.
         dyhbtag = tags.table(align="left", class_="status-download-events")
 
         dyhbtag(tags.tr(tags.th("serverid"),
@@ -461,6 +462,7 @@ class DownloadStatusElement(Element):
         evtag(tags.h2("DYHB Requests:"), dyhbtag)
         evtag(tags.br(clear="all"))
 
+        # "Read Events" table.
         readtag = tags.table(align="left",class_="status-download-events")
 
         readtag(tags.tr((
@@ -501,6 +503,7 @@ class DownloadStatusElement(Element):
         evtag(tags.h2("Read Events:"), readtag)
         evtag(tags.br(clear="all"))
 
+        # "Segment Events" table.
         segtag = tags.table(align="left",class_="status-download-events")
 
         segtag(tags.tr(
@@ -546,6 +549,7 @@ class DownloadStatusElement(Element):
         evtag(tags.h2("Segment Events:"), segtag)
         evtag(tags.br(clear="all"))
 
+        # "Requests" table.
         reqtab = tags.table(align="left",class_="status-download-events")
 
         reqtab(tags.tr(

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -683,39 +683,39 @@ class DownloadStatusElement(Element):
 
     @renderer
     def time_total(self, req, tag):
-        return self._get_time("total")
+        return tag(str(self._get_time("total")))
 
     @renderer
     def time_peer_selection(self, req, tag):
-        return self._get_time("peer_selection")
+        return tag(str(self._get_time("peer_selection")))
 
     @renderer
     def time_uri_extension(self, req, tag):
-        return self._get_time("uri_extension")
+        return tag(str(self._get_time("uri_extension")))
 
     @renderer
     def time_hashtrees(self, req, tag):
-        return self._get_time("hashtrees")
+        return tag(str(self._get_time("hashtrees")))
 
     @renderer
     def time_segments(self, req, tag):
-        return self._get_time("segments")
+        return tag(str(self._get_time("segments")))
 
     @renderer
     def time_cumulative_fetch(self, req, tag):
-        return self._get_time("cumulative_fetch")
+        return tag(str(self._get_time("cumulative_fetch")))
 
     @renderer
     def time_cumulative_decode(self, req, tag):
-        return self._get_time("cumulative_decode")
+        return tag(str(self._get_time("cumulative_decode")))
 
     @renderer
     def time_cumulative_decrypt(self, req, tag):
-        return self._get_time("cumulative_decrypt")
+        return tag(str(self._get_time("cumulative_decrypt")))
 
     @renderer
     def time_paused(self, req, tag):
-        return self._get_time("paused")
+        return tag(str(self._get_time("paused")))
 
     def _get_rate(self, name):
         d = self.download_results()
@@ -728,23 +728,23 @@ class DownloadStatusElement(Element):
 
     @renderer
     def rate_total(self, req, tag):
-        return self._get_rate("total")
+        return tag(str(self._get_rate("total")))
 
     @renderer
     def rate_segments(self, req, tag):
-        return self._get_rate("segments")
+        return tag(str(self._get_rate("segments")))
 
     @renderer
     def rate_fetch(self, req, tag):
-        return self._get_rate("cumulative_fetch")
+        return tag(str(self._get_rate("cumulative_fetch")))
 
     @renderer
     def rate_decode(self, req, tag):
-        return self._get_rate("cumulative_decode")
+        return tag(str(self._get_rate("cumulative_decode")))
 
     @renderer
     def rate_decrypt(self, req, tag):
-        return self._get_rate("cumulative_decrypt")
+        return tag(str(self._get_rate("cumulative_decrypt")))
 
     @renderer
     def server_timings(self, req, tag):
@@ -756,7 +756,7 @@ class DownloadStatusElement(Element):
             ul = tags.ul()
             for peerid in sorted(per_server.keys()):
                 peerid_s = idlib.shortnodeid_b2a(peerid)
-                times_s = ", ".join([self.render_time(None, t)
+                times_s = ", ".join([abbreviate_time(t)
                                      for t in per_server[peerid]])
                 ul(tags.li("[%s]: %s" % (peerid_s, times_s)))
             return tags.li("Per-Server Segment Fetch Response Times: ", ul)

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -468,8 +468,8 @@ class DownloadStatusElement(Element):
     # See #3311: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3311
     @renderer
     def events(self, req, tag):
-        if not self._download_status.storage_index:
-            return
+        if not self._download_status.get_storage_index():
+            return tag
 
         srt = self._short_relative_time
 

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -698,7 +698,7 @@ class DownloadStatusElement(Element):
         server_problems = self.download_results().server_problems
         if not server_problems:
             return ""
-        ul = T.ul()
+        ul = tags.ul()
         for peerid in sorted(server_problems.keys()):
             peerid_s = idlib.shortnodeid_b2a(peerid)
             ul(tags.li("[%s]: %s" % (peerid_s, server_problems[peerid])))

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -547,15 +547,15 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
 
         srt = self._short_relative_time
 
-        l = tags.div()
+        evtag = tags.div()
 
-        t = tags.table(align="left", class_="status-download-events")
+        dyhbtag = tags.table(align="left", class_="status-download-events")
 
-        t(tags.tr(tags.th("serverid"),
-                  tags.th("sent"),
-                  tags.th("received"),
-                  tags.th("shnums"),
-                  tags.th("RTT")))
+        dyhbtag(tags.tr(tags.th("serverid"),
+                        tags.th("sent"),
+                        tags.th("received"),
+                        tags.th("shnums"),
+                        tags.th("RTT")))
 
         for d_ev in self._download_status.dyhb_requests:
             server = d_ev["server"]
@@ -568,7 +568,7 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
             if not shnums:
                 shnums = ["-"]
 
-            t(tags.tr(style="background: %s" % _color(server))(
+            dyhbtag(tags.tr(style="background: %s" % _color(server))(
                 (tags.td(server.get_name()),
                  tags.td(srt(sent)),
                  tags.td(srt(received)),
@@ -576,12 +576,12 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
                  tags.td(abbreviate_time(rtt)),
                 )))
 
-        l(tags.h2("DYHB Requests:"), t)
-        l(tags.br(clear="all"))
+        evtag(tags.h2("DYHB Requests:"), dyhbtag)
+        evtag(tags.br(clear="all"))
 
-        t = tags.table(align="left",class_="status-download-events")
+        readtag = tags.table(align="left",class_="status-download-events")
 
-        t(tags.tr((
+        readtag(tags.tr((
             tags.th("range"),
             tags.th("start"),
             tags.th("finish"),
@@ -605,7 +605,7 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
                 rtt = abbreviate_time(rtt)
             paused = abbreviate_time(r_ev["paused_time"])
 
-            t(tags.tr(
+            readtag(tags.tr(
                 tags.td("[%d:+%d]" % (start, length)),
                 tags.td(srt(r_ev["start_time"])),
                 tags.td(srt(r_ev["finish_time"])),
@@ -616,12 +616,12 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
                 tags.td(speed),
             ))
 
-        l(tags.h2("Read Events:"), t)
-        l(tags.br(clear="all"))
+        evtag(tags.h2("Read Events:"), readtag)
+        evtag(tags.br(clear="all"))
 
-        t = tags.table(align="left",class_="status-download-events")
+        segtag = tags.table(align="left",class_="status-download-events")
 
-        t(tags.tr(
+        segtag(tags.tr(
             tags.th("segnum"),
             tags.th("start"),
             tags.th("active"),
@@ -651,7 +651,7 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
                 # not finished yet
                 pass
 
-            t(tags.tr(
+            segtag(tags.tr(
                 tags.td("seg%d" % s_ev["segment_number"]),
                 tags.td(srt(s_ev["start_time"])),
                 tags.td(srt(s_ev["active_time"])),
@@ -661,13 +661,12 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
                 tags.td(segtime_s),
                 tags.td(speed)))
 
-        l(tags.h2("Segment Events:"), t)
+        evtag(tags.h2("Segment Events:"), segtag)
+        evtag(tags.br(clear="all"))
 
-        l(tags.br(clear="all"))
+        reqtab = tags.table(align="left",class_="status-download-events")
 
-        t = tags.table(align="left",class_="status-download-events")
-
-        t(tags.tr(
+        reqtab(tags.tr(
             tags.th("serverid"),
             tags.th("shnum"),
             tags.th("range"),
@@ -682,21 +681,21 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
             if r_ev["finish_time"] is not None:
                 rtt = r_ev["finish_time"] - r_ev["start_time"]
             color = _color(server)
-            t(tags.tr(style="background: %s" % color)
-              (
-                  tags.td(server.get_name()),
-                  tags.td(str(r_ev["shnum"])),
-                  tags.td("[%d:+%d]" % (r_ev["start"], r_ev["length"])),
-                  tags.td(srt(r_ev["start_time"])),
-                  tags.td(srt(r_ev["finish_time"])),
-                  tags.td(str(r_ev["response_length"]) or ""),
-                  tags.td(abbreviate_time(rtt)),
-              ))
+            reqtab(tags.tr(style="background: %s" % color)
+                   (
+                       tags.td(server.get_name()),
+                       tags.td(str(r_ev["shnum"])),
+                       tags.td("[%d:+%d]" % (r_ev["start"], r_ev["length"])),
+                       tags.td(srt(r_ev["start_time"])),
+                       tags.td(srt(r_ev["finish_time"])),
+                       tags.td(str(r_ev["response_length"]) or ""),
+                       tags.td(abbreviate_time(rtt)),
+                   ))
 
-        l(tags.h2("Requests:"), t)
-        l(tags.br(clear="all"))
+        evtag(tags.h2("Requests:"), reqtab)
+        evtag(tags.br(clear="all"))
 
-        return l
+        return evtag
 
     @renderer
     def results(self, req, tag):

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -390,6 +390,12 @@ class DownloadStatusElement(Element):
         super(DownloadStatusElement, self).__init__()
         self._download_status = download_status
 
+    # XXX: fun fact: the `get_results()` method which we wind up
+    # invoking here (see immutable.downloader.status.DownloadStatus)
+    # is unimplemented, and simply returns a `None`.  As a result,
+    # `results()` renderer returns an empty tag, and does not invoke
+    # any of the subsequent renderers.  Thus we end up not displaying
+    # download results on the download status page.
     def download_results(self):
         return defer.maybeDeferred(self._download_status.get_results)
 

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -694,11 +694,12 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
 
         return l
 
-    def render_results(self, ctx, data):
+    @renderer
+    def results(self, req, tag):
         d = self.download_results()
         def _got_results(results):
             if results:
-                return ctx.tag
+                return tag
             return ""
         d.addCallback(_got_results)
         return d

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -670,10 +670,8 @@ class DownloadStatusElement(Element):
     @renderer
     def servers_used(self, req, tag):
         servers_used = self.download_results().servers_used
-
         if not servers_used:
             return ""
-
         peerids_s = ", ".join(["[%s]" % idlib.shortnodeid_b2a(peerid)
                                for peerid in servers_used])
         return tags.li("Servers Used: ", peerids_s)

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -490,8 +490,12 @@ class _EventJson(Resource, object):
 
 
 class DownloadStatusPage(MultiFormatResource):
+    """Renders /status/down-%d."""
 
     def __init__(self, download_status):
+        """
+        :param IDownloadStatus download_status: stats provider
+        """
         super(DownloadStatusPage, self).__init__()
         self._download_status = download_status
         self.putChild("event_json", _EventJson(self._download_status))

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -396,6 +396,8 @@ class DownloadStatusElement(Element):
     # `results()` renderer returns an empty tag, and does not invoke
     # any of the subsequent renderers.  Thus we end up not displaying
     # download results on the download status page.
+    #
+    # See #3310: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3310
     def download_results(self):
         return defer.maybeDeferred(self._download_status.get_results)
 

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -529,10 +529,6 @@ class DownloadStatusElement(Element, DownloadResultsRendererMixin):
             return ""
         return "+%.6fs" % t
 
-    def render_timeline_link(self, ctx, data):
-        from nevow import url
-        return T.a(href=url.URL.fromContext(ctx).child("timeline"))["timeline"]
-
     def _rate_and_time(self, bytes, seconds):
         time_s = abbreviate_time(seconds)
         if seconds != 0:

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -707,7 +707,9 @@ class DownloadStatusElement(Element):
         return tag(str(self.download_results().file_size))
 
     def _get_time(self, name):
-        return self.download_results().timings.get(name)
+        if self.download_results().timings:
+            return self.download_results().timings.get(name)
+        return None
 
     @renderer
     def time_total(self, req, tag):
@@ -748,7 +750,9 @@ class DownloadStatusElement(Element):
     def _get_rate(self, name):
         r = self.download_results()
         file_size = r.file_size
-        duration = r.timings.get(name)
+        duration = None
+        if r.timings:
+            duration = r.timings.get(name)
         return compute_rate(file_size, duration)
 
     @renderer

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -366,7 +366,7 @@ class _EventJson(Resource, object):
         return json.dumps(data, indent=1) + "\n"
 
 
-class DownloadStatusPage(Resource):
+class DownloadStatusPage(Resource, object):
     """Renders /status/down-%d."""
 
     def __init__(self, download_status):

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -377,7 +377,7 @@ class DownloadStatusPage(Resource):
         self._download_status = download_status
         self.putChild("event_json", _EventJson(self._download_status))
 
-    def render_HTML(self, req):
+    def render_GET(self, req):
         elem = DownloadStatusElement(self._download_status)
         return renderElement(req, elem)
 

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -27,14 +27,6 @@ from allmydata.web.common import (
 from allmydata.interfaces import IUploadStatus, IDownloadStatus, \
      IPublishStatus, IRetrieveStatus, IServermapUpdaterStatus
 
-class RateAndTimeMixin(object):
-
-    def render_time(self, ctx, data):
-        return abbreviate_time(data)
-
-    def render_rate(self, ctx, data):
-        return abbreviate_rate(data)
-
 
 class UploadResultsRendererMixin(Element):
     # this requires a method named 'upload_results'


### PR DESCRIPTION
Fixes [3288](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3288).

Noteworthy changes:

* Methods in `DownloadResultsRendererMixin` have been pulled into `DownloadStatusElement`. `DownloadResultsRendererMixin` is entirely gone now.   We're also not using `RateAndTimeMixin` here anymore.  Some tests have been accordingly moved.

* Turns out that renderers that were in `DownloadResultsRendererMixin` have not been exercised before, and they are not exercised now either (reason below), so they are not really tested.

*  The reason the above methods are not exercised is is that `DownloadStatus.get_results()` is currently not implemented:

https://github.com/tahoe-lafs/tahoe-lafs/blob/538503c0f8b2ec2a4c6b50b2a02befc57489f736/src/allmydata/immutable/downloader/status.py#L275-L276

This page will require some testing and updates if/when that method is implemented.

* The `DownloadResultsElement.events()` renderer method is a little odd: it adds a bunch of layout which should probably have been done in the corresponding `download-status.xhtml` file.  But that change is not in the scope of porting, so it's been left alone.

Screenshots below.  This is the page after changes:

![wui-download-status-after](https://user-images.githubusercontent.com/23618/81982414-c571f380-95ff-11ea-8b70-f296653dc042.png)

----

And this is how it used to be before:

![wui-download-status-before](https://user-images.githubusercontent.com/23618/81982396-bf7c1280-95ff-11ea-93a6-01e61cf4c6fa.png)
