### PR TITLE
Fix for "the webapi does not allow empty pathname components"

### DIFF
--- a/newsfragments/3312.bugfix
+++ b/newsfragments/3312.bugfix
@@ -1,0 +1,1 @@
+Add your info here

--- a/newsfragments/3312.bugfix
+++ b/newsfragments/3312.bugfix
@@ -1,1 +1,1 @@
-Add your info here
+Make directory page links work.

--- a/src/allmydata/test/common.py
+++ b/src/allmydata/test/common.py
@@ -1269,5 +1269,5 @@ class TrialTestCase(_TrialTestCase):
 
         if six.PY2:
             if isinstance(msg, six.text_type):
-                return super(self, TrialTestCase).fail(msg.encode("utf8"))
-        return super(self, TrialTestCase).fail(msg)
+                return super(TrialTestCase, self).fail(msg.encode("utf8"))
+        return super(TrialTestCase, self).fail(msg)

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -104,6 +104,7 @@ class DirectoryNodeHandler(ReplaceMeMixin, Resource, object):
         # "/uri/URI%3ADIR2%3Aj...vq/" (that is, with a trailing slash
         # or no further children) renders "this" page.  We also need
         # to reject "/uri/URI:DIR2:..//", so we look at postpath.
+        name = name.decode('utf8')
         if not name and req.postpath != ['']:
             return self
 
@@ -117,7 +118,6 @@ class DirectoryNodeHandler(ReplaceMeMixin, Resource, object):
                     u"The webapi does not allow empty pathname components",
                 )
 
-        name = name.decode('utf8')
         d = self.node.get(name)
         d.addBoth(self._got_child, req, name)
         return d

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -102,8 +102,9 @@ class DirectoryNodeHandler(ReplaceMeMixin, Resource, object):
         # trying to replicate what I have observed as Nevow behavior
         # for these nodes, which is that a URI like
         # "/uri/URI%3ADIR2%3Aj...vq/" (that is, with a trailing slash
-        # or no further children) renders "this" page
-        if not name:
+        # or no further children) renders "this" page.  We also need
+        # to reject "/uri/URI:DIR2:..//", so we look at postpath.
+        if not name and req.postpath != ['']:
             return self
 
         # Rejecting URIs that contain empty path pieces (for example:

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -103,12 +103,10 @@ class DirectoryNodeHandler(ReplaceMeMixin, Resource, object):
         # for these nodes, which is that a URI like
         # "/uri/URI%3ADIR2%3Aj...vq/" (that is, with a trailing slash
         # or no further children) renders "this" page
-        name = name.decode('utf8')
         if not name:
-            raise EmptyPathnameComponentError(
-                u"The webapi does not allow empty pathname components",
-            )
+            return self
 
+        name = name.decode('utf8')
         d = self.node.get(name)
         d.addBoth(self._got_child, req, name)
         return d

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -106,6 +106,16 @@ class DirectoryNodeHandler(ReplaceMeMixin, Resource, object):
         if not name:
             return self
 
+        # Rejecting URIs that contain empty path pieces (for example:
+        # "/uri/URI:DIR2:../foo//new.txt" or "/uri/URI:DIR2:..//") was
+        # the old nevow behavior and it is encoded in the test suite;
+        # we will follow suit.
+        for segment in req.prepath:
+            if not segment:
+                raise EmptyPathnameComponentError(
+                    u"The webapi does not allow empty pathname components",
+                )
+
         name = name.decode('utf8')
         d = self.node.get(name)
         d.addBoth(self._got_child, req, name)

--- a/src/allmydata/web/directory.xhtml
+++ b/src/allmydata/web/directory.xhtml
@@ -31,7 +31,7 @@
           <div class="well sidebar-nav">
             <ul class="nav nav-list">
               <li class="toolbar-item" t:render="welcome" />
-              <li class="toolbar-item"><a href=".">Refresh</a></li>
+              <li class="toolbar-item"><a href="">Refresh</a></li>
               <li class="toolbar-item"><a href="?t=info">More info on this directory</a></li>
               <li class="toolbar-item" t:render="show_readonly" />
             </ul>


### PR DESCRIPTION
A proposed fix for [3312](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3312): this will fixes the problem where directory page links became not navigable.

This PR contains a few things that are kinda-sorta related.  Some notes:

1. The code below is for `allmydata.test.web.test_web.Web.test_POST_NEWDIRURL_emptyname`: it does a `POST /uri/URI:DIR2:...//?t=mkdir`.  Looking for an empty path segment at this point made this test pass:

https://github.com/tahoe-lafs/tahoe-lafs/blob/dd14da4a55e043ab18d067c750ab20eb9050f5b4/src/allmydata/web/directory.py#L108-L109

2. This is for `test_PUT_NEWFILEURL_emptyname`: it does a `POST /uri/URI:DIR2:../foo//new.txt`:

https://github.com/tahoe-lafs/tahoe-lafs/blob/dd14da4a55e043ab18d067c750ab20eb9050f5b4/src/allmydata/web/directory.py#L115-L119

If we consider `/foo/bar` and `/foo//bar` to be equivalent, we can remove the extra code and adapt these tests accordingly, although I am not really sure if that would be the right thing.  [RFC 2396](https://tools.ietf.org/html/rfc2396#section-3.3) seems to say that `/foo/bar` and `foo//bar` are different things.

3. I chanced upon cf4b3ba008 when working on this PR: seems that `super()` is not exercised unless there is a test failure, which is probably how it stayed there.

4. Without dce73f7c2, "Refresh" link on `/uri/URI:.` page would target `/uri/`, and clicking on it would result in `GET /uri requires uri=` error.

