### PR TITLE
Run integration tests on Windows using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
       matrix:
         os:
           - macos-latest
+          - windows-latest
         python-version:
           - 2.7
 

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -358,10 +358,9 @@ def bob(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, reques
 
 
 @pytest.fixture(scope='session')
+@pytest.mark.skipif(sys.platform.startswith('win'),
+                    'Tor tests are unstable on Windows')
 def chutney(reactor, temp_dir):
-
-    if sys.platform.startswith('win'):
-        pytest.skip('Tor tests are unstable on Windows')
 
     chutney_dir = join(temp_dir, 'chutney')
     mkdir(chutney_dir)
@@ -392,10 +391,9 @@ def chutney(reactor, temp_dir):
 
 
 @pytest.fixture(scope='session')
+@pytest.mark.skipif(sys.platform.startswith('win'),
+                    reason='Tor tests are unstable on Windows')
 def tor_network(reactor, temp_dir, chutney, request):
-
-    if sys.platform.startswith('win'):
-        pytest.skip('Tor tests are unstable on Windows')
 
     # this is the actual "chutney" script at the root of a chutney checkout
     chutney_dir = chutney

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -359,6 +359,10 @@ def bob(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, reques
 
 @pytest.fixture(scope='session')
 def chutney(reactor, temp_dir):
+
+    if sys.platform.startswith('win'):
+        pytest.skip('Tor tests are unstable on Windows')
+
     chutney_dir = join(temp_dir, 'chutney')
     mkdir(chutney_dir)
 
@@ -389,6 +393,10 @@ def chutney(reactor, temp_dir):
 
 @pytest.fixture(scope='session')
 def tor_network(reactor, temp_dir, chutney, request):
+
+    if sys.platform.startswith('win'):
+        pytest.skip('Tor tests are unstable on Windows')
+
     # this is the actual "chutney" script at the root of a chutney checkout
     chutney_dir = chutney
     chut = join(chutney_dir, 'chutney')

--- a/integration/test_tor.py
+++ b/integration/test_tor.py
@@ -18,6 +18,10 @@ import util
 
 # see "conftest.py" for the fixtures (e.g. "tor_network")
 
+# XXX: Integration tests that involve Tor do not run reliably on
+# Windows.  They are skipped for now, in order to reduce CI noise.
+#
+# https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3347
 if sys.platform.startswith('win'):
     pytest.skip('Skipping Tor tests on Windows', allow_module_level=True)
 

--- a/integration/test_tor.py
+++ b/integration/test_tor.py
@@ -10,11 +10,16 @@ from six.moves import StringIO
 from twisted.internet.protocol import ProcessProtocol
 from twisted.internet.error import ProcessExitedAlready, ProcessDone
 from twisted.internet.defer import inlineCallbacks, Deferred
+
+import pytest
 import pytest_twisted
 
 import util
 
 # see "conftest.py" for the fixtures (e.g. "tor_network")
+
+if sys.platform.startswith('win'):
+    pytest.skip('Skipping Tor tests on Windows', allow_module_level=True)
 
 @pytest_twisted.inlineCallbacks
 def test_onion_service_storage(reactor, request, temp_dir, flog_gatherer, tor_network, tor_introducer_furl):


### PR DESCRIPTION
See [3320](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3320): Integration tests are currently not run on Windows, because they turned out to be a little unreliable: sometimes they fail, and when that happens restarting the test would make things pass.

We will re-enable them and see what happens.