### PR TITLE
Port humanreadable.py to Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
       - image: "nixorg/nix:circleci"
 
     environment:
-      NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03-small.tar.gz"
+      NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09-small.tar.gz"
 
     steps:
       - "checkout"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
       - image: "nixorg/nix:circleci"
 
     environment:
-      NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09-small.tar.gz"
+      NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03-small.tar.gz"
 
     steps:
       - "checkout"

--- a/nix/tahoe-lafs.nix
+++ b/nix/tahoe-lafs.nix
@@ -4,7 +4,7 @@
 , setuptools, setuptoolsTrial, pyasn1, zope_interface
 , service-identity, pyyaml, magic-wormhole, treq, appdirs
 , beautifulsoup4, eliot, autobahn, cryptography
-, html5lib
+, html5lib, future
 }:
 python.pkgs.buildPythonPackage rec {
   version = "1.14.0.dev";

--- a/nix/tahoe-lafs.nix
+++ b/nix/tahoe-lafs.nix
@@ -4,7 +4,7 @@
 , setuptools, setuptoolsTrial, pyasn1, zope_interface
 , service-identity, pyyaml, magic-wormhole, treq, appdirs
 , beautifulsoup4, eliot, autobahn, cryptography
-, html5lib, future
+, html5lib
 }:
 python.pkgs.buildPythonPackage rec {
   version = "1.14.0.dev";

--- a/nix/tahoe-lafs.nix
+++ b/nix/tahoe-lafs.nix
@@ -50,6 +50,7 @@ python.pkgs.buildPythonPackage rec {
     setuptoolsTrial pyasn1 zope_interface
     service-identity pyyaml magic-wormhole treq
     eliot autobahn cryptography setuptools
+    future
   ];
 
   checkInputs = with python.pkgs; [

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -27,15 +27,29 @@ added_files = [
     ('src/allmydata/web/static/img/*.png', 'allmydata/web/static/img')]
 
 hidden_imports = [
+    '__builtin__',
     'allmydata.client',
     'allmydata.introducer',
     'allmydata.stats',
+    'base64',
     'cffi',
+    'collections',
+    'commands',
     'Crypto',
+    'functools',
+    'future.backports.misc',
+    'itertools',
+    'math',
     'packaging.specifiers',
+    're',
+    'reprlib',
     'six.moves.html_parser',
+    'subprocess',
+    'UserDict',
+    'UserList',
+    'UserString',
     'yaml',
-    'zfec'
+    'zfec',
 ]
 
 a = Analysis(

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,9 @@ install_requires = [
     # * foolscap >= 0.12.5 has ConnectionInfo and ReconnectionInfo
     # * foolscap >= 0.12.6 has an i2p.sam_endpoint() that takes kwargs
     # * foolscap 0.13.2 drops i2p support completely
-    "foolscap == 0.13.1",
+    # * foolscap >= 20.4 is necessary for Python 3
+    "foolscap == 0.13.1; ; python_version < '3.0'",
+    "foolscap >= 20.4.0; ; python_version > '3.0'",
 
     # * cryptography 2.6 introduced some ed25519 APIs we rely on.  Note that
     #   Twisted[conch] also depends on cryptography and Twisted[tls]

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,9 @@ install_requires = [
 
     # WebSocket library for twisted and asyncio
     "autobahn >= 19.5.2",
+
+    # Support for Python 3 transition
+    "future >= 0.18.2",
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ install_requires = [
     # * foolscap >= 0.12.6 has an i2p.sam_endpoint() that takes kwargs
     # * foolscap 0.13.2 drops i2p support completely
     # * foolscap >= 20.4 is necessary for Python 3
-    "foolscap == 0.13.1; ; python_version < '3.0'",
-    "foolscap >= 20.4.0; ; python_version > '3.0'",
+    "foolscap == 0.13.1 ; python_version < '3.0'",
+    "foolscap >= 20.4.0 ; python_version > '3.0'",
 
     # * cryptography 2.6 introduced some ed25519 APIs we rely on.  Note that
     #   Twisted[conch] also depends on cryptography and Twisted[tls]

--- a/src/allmydata/__init__.py
+++ b/src/allmydata/__init__.py
@@ -37,3 +37,8 @@ __appname__ = "tahoe-lafs"
 # in the "application" part of the Tahoe versioning scheme:
 # https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Versioning
 __full_version__ = __appname__ + '/' + str(__version__)
+
+
+# Install Python 3 module locations in Python 2:
+from future import standard_library
+standard_library.install_aliases()

--- a/src/allmydata/ported-modules.txt
+++ b/src/allmydata/ported-modules.txt
@@ -1,1 +1,0 @@
-allmydata.util.namespace

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *
+from past.builtins import long
 from twisted.trial import unittest
 
 from allmydata.util import humanreadable
@@ -26,8 +26,9 @@ class HumanReadable(unittest.TestCase):
         self.failUnlessEqual(hr(self.test_repr),
                              "<bound method HumanReadable.test_repr of <allmydata.test.test_humanreadable.HumanReadable testMethod=test_repr>>")
         self.failUnlessEqual(hr(long(1)), "1")
-        self.failUnlessEqual(hr(10**40),
-                             "100000000000000000...000000000000000000")
+        self.assertIn(hr(10**40),
+                      ["100000000000000000...000000000000000000",
+                       "100000000000000000...0000000000000000000"])
         self.failUnlessEqual(hr(self), "<allmydata.test.test_humanreadable.HumanReadable testMethod=test_repr>")
         self.failUnlessEqual(hr([1,2]), "[1, 2]")
         self.failUnlessEqual(hr({1:2}), "{1:2}")
@@ -50,4 +51,5 @@ class HumanReadable(unittest.TestCase):
         except Exception as e:
             self.failUnless(
                 hr(e) == "<NoArgumentException>" # python-2.4
-                or hr(e) == "NoArgumentException()") # python-2.5
+                or hr(e) == "NoArgumentException()" # python-2.5
+                or hr(e) == "<NoArgumentException: ()>", hr(e)) # python-3

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -12,7 +12,7 @@ from allmydata.util import humanreadable
 
 
 
-def foo(): pass # keep the line number constant
+def foo(): pass # FYI foo()'s line number is used in the test below
 
 
 class NoArgumentException(Exception):

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -9,6 +9,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from future.utils import PY2
+if PY2:
+    from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, int, list, object, range, str, max, min  # noqa: F401
+
 from past.builtins import long
 
 from twisted.trial import unittest
@@ -27,7 +31,7 @@ class NoArgumentException(Exception):
 class HumanReadable(unittest.TestCase):
     def test_repr(self):
         hr = humanreadable.hr
-        self.failUnlessEqual(hr(foo), "<foo() at test_humanreadable.py:15>")
+        self.failUnlessEqual(hr(foo), "<foo() at test_humanreadable.py:24>")
         self.failUnlessEqual(hr(self.test_repr),
                              "<bound method HumanReadable.test_repr of <allmydata.test.test_humanreadable.HumanReadable testMethod=test_repr>>")
         self.failUnlessEqual(hr(long(1)), "1")

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -1,10 +1,15 @@
 """Tests for allmydata.util.humanreadable."""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from twisted.trial import unittest
 
 from allmydata.util import humanreadable
-
-
 
 
 def foo(): pass # keep the line number constant
@@ -17,7 +22,7 @@ class NoArgumentException(Exception):
 class HumanReadable(unittest.TestCase):
     def test_repr(self):
         hr = humanreadable.hr
-        self.failUnlessEqual(hr(foo), "<foo() at test_humanreadable.py:10>")
+        self.failUnlessEqual(hr(foo), "<foo() at test_humanreadable.py:15>")
         self.failUnlessEqual(hr(self.test_repr),
                              "<bound method HumanReadable.test_repr of <allmydata.test.test_humanreadable.HumanReadable testMethod=test_repr>>")
         self.failUnlessEqual(hr(long(1)), "1")
@@ -37,7 +42,9 @@ class HumanReadable(unittest.TestCase):
         except Exception as e:
             self.failUnless(
                 hr(e) == "<ValueError: 'oops'>" # python-2.4
-                or hr(e) == "ValueError('oops',)") # python-2.5
+                or hr(e) == "ValueError('oops',)" # python-2.5
+                or hr(e) == "ValueError(u'oops',)" # python 2 during py3 transition
+            )
         try:
             raise NoArgumentException
         except Exception as e:

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -1,4 +1,9 @@
-"""Tests for allmydata.util.humanreadable."""
+"""
+Tests for allmydata.util.humanreadable.
+
+This module has been ported to Python 3.
+"""
+
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from __future__ import division

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -1,0 +1,46 @@
+"""Tests for allmydata.util.humanreadable."""
+
+from twisted.trial import unittest
+
+from allmydata.util import humanreadable
+
+
+
+
+def foo(): pass # keep the line number constant
+
+
+class NoArgumentException(Exception):
+    def __init__(self):
+        pass
+
+class HumanReadable(unittest.TestCase):
+    def test_repr(self):
+        hr = humanreadable.hr
+        self.failUnlessEqual(hr(foo), "<foo() at test_humanreadable.py:10>")
+        self.failUnlessEqual(hr(self.test_repr),
+                             "<bound method HumanReadable.test_repr of <allmydata.test.test_humanreadable.HumanReadable testMethod=test_repr>>")
+        self.failUnlessEqual(hr(long(1)), "1")
+        self.failUnlessEqual(hr(10**40),
+                             "100000000000000000...000000000000000000")
+        self.failUnlessEqual(hr(self), "<allmydata.test.test_humanreadable.HumanReadable testMethod=test_repr>")
+        self.failUnlessEqual(hr([1,2]), "[1, 2]")
+        self.failUnlessEqual(hr({1:2}), "{1:2}")
+        try:
+            raise ValueError
+        except Exception as e:
+            self.failUnless(
+                hr(e) == "<ValueError: ()>" # python-2.4
+                or hr(e) == "ValueError()") # python-2.5
+        try:
+            raise ValueError("oops")
+        except Exception as e:
+            self.failUnless(
+                hr(e) == "<ValueError: 'oops'>" # python-2.4
+                or hr(e) == "ValueError('oops',)") # python-2.5
+        try:
+            raise NoArgumentException
+        except Exception as e:
+            self.failUnless(
+                hr(e) == "<NoArgumentException>" # python-2.4
+                or hr(e) == "NoArgumentException()") # python-2.5

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -4,12 +4,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from future import standard_library
-standard_library.install_aliases()
 from past.builtins import long
+
 from twisted.trial import unittest
 
 from allmydata.util import humanreadable
+
 
 
 def foo(): pass # keep the line number constant

--- a/src/allmydata/test/test_python3.py
+++ b/src/allmydata/test/test_python3.py
@@ -1,6 +1,18 @@
 """
 Tests related to the Python 3 porting effort itself.
+
+This module has been ported to Python 3.
 """
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from future.utils import PY2
+if False:#PY2:
+    from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, int, list, object, range, str, max, min  # noqa: F401
+
+from unittest import expectedFailure
 
 from pkg_resources import (
     resource_stream,
@@ -13,11 +25,18 @@ from twisted.trial.unittest import (
     SynchronousTestCase,
 )
 
+from allmydata.util._python3 import PORTED_MODULES, PORTED_TEST_MODULES
+
 
 class Python3PortingEffortTests(SynchronousTestCase):
+
     def test_finished_porting(self):
         """
         Tahoe-LAFS has been ported to Python 3.
+
+        Once
+        https://tahoe-lafs.org/trac/tahoe-lafs/milestone/Support%20Python%203
+        is completed this test should pass (and can be deleted!).
         """
         tahoe_lafs_module_names = set(all_module_names("allmydata"))
         ported_names = set(ported_module_names())
@@ -31,7 +50,10 @@ class Python3PortingEffortTests(SynchronousTestCase):
                 ),
             ),
         )
-    test_finished_porting.todo = "https://tahoe-lafs.org/trac/tahoe-lafs/milestone/Support%20Python%203 should be completed"
+    if PY2:
+        test_finished_porting.skip = "For some reason todo isn't working on Python 2 now"
+    else:
+        test_finished_porting.todo = "https://tahoe-lafs.org/trac/tahoe-lafs/milestone/Support%20Python%203 should be completed"
 
     def test_ported_modules_exist(self):
         """
@@ -70,18 +92,18 @@ def all_module_names(toplevel):
     """
     allmydata = getModule(toplevel)
     for module in allmydata.walkModules():
-        yield module.name.decode("utf-8")
+        name = module.name
+        if PY2:
+            name = name.decode("utf-8")
+        yield name
 
 
 def ported_module_names():
     """
-    :return list[unicode]: A ``set`` of ``unicode`` giving the names of
+    :return list[unicode]: A ``list`` of ``unicode`` giving the names of
         Tahoe-LAFS modules which have been ported to Python 3.
     """
-    return resource_stream(
-        "allmydata",
-        u"ported-modules.txt",
-    ).read().splitlines()
+    return PORTED_MODULES + PORTED_TEST_MODULES
 
 
 def unported_report(tahoe_lafs_module_names, ported_names):
@@ -100,8 +122,8 @@ def count_lines(module_name):
     try:
         source = module.filePath.getContent()
     except Exception as e:
-        print(module_name, e)
+        print((module_name, e))
         return 0
     lines = source.splitlines()
-    nonblank = filter(None, lines)
+    nonblank = [_f for _f in lines if _f]
     return len(nonblank)

--- a/src/allmydata/test/test_python3.py
+++ b/src/allmydata/test/test_python3.py
@@ -9,14 +9,8 @@ from __future__ import division
 from __future__ import print_function
 
 from future.utils import PY2
-if False:#PY2:
+if PY2:
     from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, int, list, object, range, str, max, min  # noqa: F401
-
-from unittest import expectedFailure
-
-from pkg_resources import (
-    resource_stream,
-)
 
 from twisted.python.modules import (
     getModule,

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -1,8 +1,5 @@
 from __future__ import print_function
 
-
-def foo(): pass # keep the line number constant
-
 import binascii
 import six
 import hashlib
@@ -17,7 +14,7 @@ from twisted.internet import defer, reactor
 from twisted.python.failure import Failure
 from twisted.python import log
 
-from allmydata.util import base32, idlib, humanreadable, mathutil, hashutil
+from allmydata.util import base32, idlib, mathutil, hashutil
 from allmydata.util import assertutil, fileutil, deferredutil, abbreviate
 from allmydata.util import limiter, time_format, pollmixin
 from allmydata.util import statistics, dictutil, pipeline, yamlutil
@@ -57,44 +54,13 @@ class Base32(unittest.TestCase):
         self.failUnlessEqual(base32.a2b("ci2a"), "\x12\x34")
         self.failUnlessRaises(AssertionError, base32.a2b, "b0gus")
 
+
 class IDLib(unittest.TestCase):
     def test_nodeid_b2a(self):
         self.failUnlessEqual(idlib.nodeid_b2a("\x00"*20), "a"*32)
 
-class NoArgumentException(Exception):
-    def __init__(self):
-        pass
 
-class HumanReadable(unittest.TestCase):
-    def test_repr(self):
-        hr = humanreadable.hr
-        self.failUnlessEqual(hr(foo), "<foo() at test_util.py:4>")
-        self.failUnlessEqual(hr(self.test_repr),
-                             "<bound method HumanReadable.test_repr of <allmydata.test.test_util.HumanReadable testMethod=test_repr>>")
-        self.failUnlessEqual(hr(long(1)), "1")
-        self.failUnlessEqual(hr(10**40),
-                             "100000000000000000...000000000000000000")
-        self.failUnlessEqual(hr(self), "<allmydata.test.test_util.HumanReadable testMethod=test_repr>")
-        self.failUnlessEqual(hr([1,2]), "[1, 2]")
-        self.failUnlessEqual(hr({1:2}), "{1:2}")
-        try:
-            raise ValueError
-        except Exception as e:
-            self.failUnless(
-                hr(e) == "<ValueError: ()>" # python-2.4
-                or hr(e) == "ValueError()") # python-2.5
-        try:
-            raise ValueError("oops")
-        except Exception as e:
-            self.failUnless(
-                hr(e) == "<ValueError: 'oops'>" # python-2.4
-                or hr(e) == "ValueError('oops',)") # python-2.5
-        try:
-            raise NoArgumentException
-        except Exception as e:
-            self.failUnless(
-                hr(e) == "<NoArgumentException>" # python-2.4
-                or hr(e) == "NoArgumentException()") # python-2.5
+class Abbreviate(unittest.TestCase):
 
     def test_abbrev_time_1s(self):
         diff = timedelta(seconds=1)

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -60,45 +60,6 @@ class IDLib(unittest.TestCase):
         self.failUnlessEqual(idlib.nodeid_b2a("\x00"*20), "a"*32)
 
 
-class Abbreviate(unittest.TestCase):
-
-    def test_abbrev_time_1s(self):
-        diff = timedelta(seconds=1)
-        s = abbreviate.abbreviate_time(diff)
-        self.assertEqual('1 second ago', s)
-
-    def test_abbrev_time_25s(self):
-        diff = timedelta(seconds=25)
-        s = abbreviate.abbreviate_time(diff)
-        self.assertEqual('25 seconds ago', s)
-
-    def test_abbrev_time_future_5_minutes(self):
-        diff = timedelta(minutes=-5)
-        s = abbreviate.abbreviate_time(diff)
-        self.assertEqual('5 minutes in the future', s)
-
-    def test_abbrev_time_hours(self):
-        diff = timedelta(hours=4)
-        s = abbreviate.abbreviate_time(diff)
-        self.assertEqual('4 hours ago', s)
-
-    def test_abbrev_time_day(self):
-        diff = timedelta(hours=49)  # must be more than 2 days
-        s = abbreviate.abbreviate_time(diff)
-        self.assertEqual('2 days ago', s)
-
-    def test_abbrev_time_month(self):
-        diff = timedelta(days=91)
-        s = abbreviate.abbreviate_time(diff)
-        self.assertEqual('3 months ago', s)
-
-    def test_abbrev_time_year(self):
-        diff = timedelta(weeks=(5 * 52) + 1)
-        s = abbreviate.abbreviate_time(diff)
-        self.assertEqual('5 years ago', s)
-
-
-
 class MyList(list):
     pass
 
@@ -950,6 +911,41 @@ class HashUtilTests(unittest.TestCase):
                         )
 
 class Abbreviate(unittest.TestCase):
+    def test_abbrev_time_1s(self):
+        diff = timedelta(seconds=1)
+        s = abbreviate.abbreviate_time(diff)
+        self.assertEqual('1 second ago', s)
+
+    def test_abbrev_time_25s(self):
+        diff = timedelta(seconds=25)
+        s = abbreviate.abbreviate_time(diff)
+        self.assertEqual('25 seconds ago', s)
+
+    def test_abbrev_time_future_5_minutes(self):
+        diff = timedelta(minutes=-5)
+        s = abbreviate.abbreviate_time(diff)
+        self.assertEqual('5 minutes in the future', s)
+
+    def test_abbrev_time_hours(self):
+        diff = timedelta(hours=4)
+        s = abbreviate.abbreviate_time(diff)
+        self.assertEqual('4 hours ago', s)
+
+    def test_abbrev_time_day(self):
+        diff = timedelta(hours=49)  # must be more than 2 days
+        s = abbreviate.abbreviate_time(diff)
+        self.assertEqual('2 days ago', s)
+
+    def test_abbrev_time_month(self):
+        diff = timedelta(days=91)
+        s = abbreviate.abbreviate_time(diff)
+        self.assertEqual('3 months ago', s)
+
+    def test_abbrev_time_year(self):
+        diff = timedelta(weeks=(5 * 52) + 1)
+        s = abbreviate.abbreviate_time(diff)
+        self.assertEqual('5 years ago', s)
+
     def test_time(self):
         a = abbreviate.abbreviate_time
         self.failUnlessEqual(a(None), "unknown")

--- a/src/allmydata/util/_python3.py
+++ b/src/allmydata/util/_python3.py
@@ -1,0 +1,3 @@
+"""Track the port to Python 3."""
+
+PORTED_MODULES = []

--- a/src/allmydata/util/_python3.py
+++ b/src/allmydata/util/_python3.py
@@ -3,6 +3,7 @@
 # Keep these sorted alphabetically, to reduce merge conflicts:
 PORTED_MODULES = [
     "allmydata.util.humanreadable",
+    "allmydata.util.namespace",
 ]
 
 PORTED_TEST_MODULES = [

--- a/src/allmydata/util/_python3.py
+++ b/src/allmydata/util/_python3.py
@@ -1,3 +1,10 @@
 """Track the port to Python 3."""
 
-PORTED_MODULES = []
+# Keep these sorted alphabetically, to reduce merge conflicts:
+PORTED_MODULES = [
+    "allmydata.util.humanreadable",
+]
+
+PORTED_TEST_MODULES = [
+    "allmydata.test.test_humanreadable",
+]

--- a/src/allmydata/util/_python3.py
+++ b/src/allmydata/util/_python3.py
@@ -1,11 +1,26 @@
-"""Track the port to Python 3."""
+"""
+Track the port to Python 3.
+
+This module has been ported to Python 3.
+"""
+
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from future.utils import PY2
+if PY2:
+    from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, int, list, object, range, str, max, min  # noqa: F401
 
 # Keep these sorted alphabetically, to reduce merge conflicts:
 PORTED_MODULES = [
     "allmydata.util.humanreadable",
     "allmydata.util.namespace",
+    "allmydata.util._python3",
 ]
 
 PORTED_TEST_MODULES = [
     "allmydata.test.test_humanreadable",
+    "allmydata.test.test_python3",
 ]

--- a/src/allmydata/util/humanreadable.py
+++ b/src/allmydata/util/humanreadable.py
@@ -1,5 +1,12 @@
-import exceptions, os
-from repr import Repr
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+import os
+from reprlib import Repr
 
 class BetterRepr(Repr, object):
     def __init__(self):
@@ -14,21 +21,21 @@ class BetterRepr(Repr, object):
         self.maxother = 300
 
     def repr_function(self, obj, level):
-        if hasattr(obj, 'func_code'):
-            return '<' + obj.func_name + '() at ' + os.path.basename(obj.func_code.co_filename) + ':' + str(obj.func_code.co_firstlineno) + '>'
+        if hasattr(obj, '__code__'):
+            return '<' + obj.__name__ + '() at ' + os.path.basename(obj.__code__.co_filename) + ':' + str(obj.__code__.co_firstlineno) + '>'
         else:
-            return '<' + obj.func_name + '() at (builtin)'
+            return '<' + obj.__name__ + '() at (builtin)'
 
     def repr_instance_method(self, obj, level):
-        if hasattr(obj, 'func_code'):
-            return '<' + obj.im_class.__name__ + '.' + obj.im_func.__name__ + '() at ' + os.path.basename(obj.im_func.func_code.co_filename) + ':' + str(obj.im_func.func_code.co_firstlineno) + '>'
+        if hasattr(obj, '__code__'):
+            return '<' + obj.__self__.__class__.__name__ + '.' + obj.__func__.__name__ + '() at ' + os.path.basename(obj.__func__.__code__.co_filename) + ':' + str(obj.__func__.__code__.co_firstlineno) + '>'
         else:
-            return '<' + obj.im_class.__name__ + '.' + obj.im_func.__name__ + '() at (builtin)'
+            return '<' + obj.__self__.__class__.__name__ + '.' + obj.__func__.__name__ + '() at (builtin)'
 
     def repr_long(self, obj, level):
         s = repr(obj) # XXX Hope this isn't too slow...
         if len(s) > self.maxlong:
-            i = max(0, (self.maxlong-3)/2)
+            i = max(0, (self.maxlong-3) // 2)
             j = max(0, self.maxlong-3-i)
             s = s[:i] + '...' + s[len(s)-j:]
         if s[-1] == 'L':
@@ -43,7 +50,7 @@ class BetterRepr(Repr, object):
         on it.  If it is an instance of list call self.repr_list() on it. Else
         call Repr.repr_instance().
         """
-        if isinstance(obj, exceptions.Exception):
+        if isinstance(obj, Exception):
             # Don't cut down exception strings so much.
             tms = self.maxstring
             self.maxstring = max(512, tms * 4)
@@ -91,7 +98,7 @@ class BetterRepr(Repr, object):
         if level <= 0: return '{...}'
         s = ''
         n = len(obj)
-        items = obj.items()[:min(n, self.maxdict)]
+        items = list(obj.items())[:min(n, self.maxdict)]
         items.sort()
         for key, val in items:
             entry = self.repr1(key, level-1) + ':' + self.repr1(val, level-1)

--- a/src/allmydata/util/humanreadable.py
+++ b/src/allmydata/util/humanreadable.py
@@ -1,3 +1,9 @@
+"""
+Utilities for turning objects into human-readable strings.
+
+This module has been ported to Python 3.
+"""
+
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function

--- a/src/allmydata/util/humanreadable.py
+++ b/src/allmydata/util/humanreadable.py
@@ -2,8 +2,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
 
 import os
 from reprlib import Repr

--- a/src/allmydata/util/humanreadable.py
+++ b/src/allmydata/util/humanreadable.py
@@ -9,6 +9,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from future.utils import PY2
+if PY2:
+    from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, int, list, object, range, str, max, min  # noqa: F401
+
 import os
 from reprlib import Repr
 

--- a/src/allmydata/util/namespace.py
+++ b/src/allmydata/util/namespace.py
@@ -1,3 +1,6 @@
+"""
+This module has been ported to Python 3.
+"""
 
 class Namespace(object):
     pass


### PR DESCRIPTION
Fixes ticket:3324

I did the port by using `futurize --unicode-literals --both-stages` and then deleting the bits that were wrong or unnecessary.

Basic steps:

1. Port the test module.
2. Make sure tests still pass on Python 2.
3. Port the code module.
4. Make sure tests pass on Python 3.
5. Add both modules to the list of ported modules in `_python3.py`.
6. Didn't actually do this, but once there's a ratcheting Python 3 CI runner the newly passing tests will be added to the required-to-pass list.

Open questions:

1. Is unicode literals by default a good idea? In this particular module it definitely seems fine, later on I expect to do some policy decisions about interfaces that are explicitly bytes or explicitly unicode.
2. Do we want to use the `from builtins import *` idiom from `future`? That will make e.g. `map()` always lazy on both Python 2 and Python 3.