### PR TITLE
Provide future 0.18.2 for the Nix builds

### DIFF
--- a/nix/future.nix
+++ b/nix/future.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "future";
+  version = "0.18.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:0zakvfj87gy6mn1nba06sdha63rn4njm7bhh0wzyrxhcny8avgmi";
+  };
+
+  doCheck = false;
+
+  meta = {
+    description = "Clean single-source support for Python 3 and 2";
+    longDescription = ''
+      python-future is the missing compatibility layer between Python 2 and
+      Python 3. It allows you to use a single, clean Python 3.x-compatible
+      codebase to support both Python 2 and Python 3 with minimal overhead.
+
+      It provides future and past packages with backports and forward ports
+      of features from Python 3 and 2. It also comes with futurize and
+      pasteurize, customized 2to3-based scripts that helps you to convert
+      either Py2 or Py3 code easily to support both Python 2 and 3 in a
+      single clean Py3-style codebase, module by module.
+    '';
+    homepage = https://python-future.org;
+    downloadPage = https://github.com/PythonCharmers/python-future/releases;
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ prikhi ];
+  };
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -10,6 +10,11 @@ self: super: {
       # NixOS autobahn package has trollius as a dependency, although
       # it is optional. Trollius is unmaintained and fails on CI.
       autobahn = python-super.callPackage ./autobahn.nix { };
+
+      # Porting to Python 3 is greatly aided by the future package.  A
+      # slightly newer version than appears in nixos 19.09 is helpful.
+      future = python-super.callPackage ./future.nix { };
+
     };
   };
 }

--- a/nix/tahoe-lafs.nix
+++ b/nix/tahoe-lafs.nix
@@ -50,6 +50,7 @@ python.pkgs.buildPythonPackage rec {
     setuptoolsTrial pyasn1 zope_interface
     service-identity pyyaml magic-wormhole treq
     eliot autobahn cryptography setuptools
+    future
   ];
 
   checkInputs = with python.pkgs; [


### PR DESCRIPTION
This fixes ticket:3338 by removing the immediate problem of future 0.18.2 not being available from nixpkgs 19.09 for the nix builds.  This lets porting work use future 0.18.2 while keeping the nix build succeeding.

