### PR TITLE
public RSA exponent 17 -> 65537

### DIFF
--- a/newsfragments/3349.bugfix
+++ b/newsfragments/3349.bugfix
@@ -1,0 +1,1 @@
+Mutable files now use RSA exponent 65537

--- a/src/allmydata/crypto/rsa.py
+++ b/src/allmydata/crypto/rsa.py
@@ -46,18 +46,8 @@ def create_signing_keypair(key_size):
 
     :returns: 2-tuple of (private_key, public_key)
     """
-    # Tahoe's original use of pycryptopp would use cryptopp's default
-    # public_exponent, which is 17
-    #
-    # Thus, we are using 17 here as well. However, there are other
-    # choices; see this for more discussion:
-    # https://security.stackexchange.com/questions/2335/should-rsa-public-exponent-be-only-in-3-5-17-257-or-65537-due-to-security-c
-    #
-    # Another popular choice is 65537. See:
-    # https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key
-    # https://www.daemonology.net/blog/2009-06-11-cryptographic-right-answers.html
     priv_key = rsa.generate_private_key(
-        public_exponent=17,
+        public_exponent=65537,
         key_size=key_size,
         backend=default_backend()
     )


### PR DESCRIPTION
The `cryptography` library has forced tahoe's hand here because they only accept 3 or 65537 for the `public_exponent=` value now. That said, the reason we're using 17 right now is because that was pycryptopp's default (it seems to still be: https://github.com/weidai11/cryptopp/blob/b613522794a7633aa2bd81932a98a0b0a51bc04f/rsa.cpp#L123 ).

We should ask for cryptographic advice before merging this.