### PR TITLE
Get `tox -e codechecks` to work on macOS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
          tahoe --version
 
 [testenv:py36]
-# git inside of ratchet.sh needs $HOME.
+# On macOS, git inside of ratchet.sh needs $HOME.
 passenv = HOME
 commands = {toxinidir}/misc/python3/ratchet.sh
 
@@ -77,6 +77,8 @@ commands =
          coverage xml
 
 [testenv:codechecks]
+# On macOS, git inside of towncrier needs $HOME.
+passenv = HOME
 whitelist_externals =
          /bin/mv
 commands =


### PR DESCRIPTION
Without this, git fails underneath towncrier with an "error: Could not expand include path '~/.gitcinclude'".

See: https://stackoverflow.com/q/36908041

I added similar for `tox -e py36` in d25c8b1a, harmonizing docs here.

Split from #759. Trac: [3366](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3366).