### PR TITLE
Use coveralls.io for coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
           token: abf679b6-e2e6-4b33-b7b5-6cfbd41ee691
           file: coverage.xml
 
+      - name: Upload coverage report to coveralls.io
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: QYoETxGMjCXkFstKHhdsL5dhAtU2tL5Wv
+
   integration:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           token: abf679b6-e2e6-4b33-b7b5-6cfbd41ee691
           file: coverage.xml
 
+      # See https://github.com/coverallsapp/github-action
       - name: Upload coverage report to coveralls.io
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           name: eliot.log
           path: eliot.log
 
-      - name: Upload coverage report
+      - name: Upload coverage report to codecov.io
         uses: codecov/codecov-action@v1
         with:
           token: abf679b6-e2e6-4b33-b7b5-6cfbd41ee691

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
 
       # See https://github.com/coverallsapp/github-action
       - name: Upload coverage report to coveralls.io
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: QYoETxGMjCXkFstKHhdsL5dhAtU2tL5Wv
+        run: coveralls
+        env:
+          COVERALLS_REPO_TOKEN: QYoETxGMjCXkFstKHhdsL5dhAtU2tL5Wv
 
   integration:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade codecov tox setuptools
+          pip install --upgrade codecov tox setuptools coveralls
           pip list
 
       - name: Display tool versions

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ zope.interface-*.egg
 # This is the plaintext of the private environment needed for some CircleCI
 # operations.  It's never supposed to be checked in.
 secret-env-plain
+
+# coverage 5.x writes a series of sqlite files.
+/.coverage.*
+
+# ignore results of running integration tests.
+/integration.eliot.json

--- a/newsfragments/3384.minor
+++ b/newsfragments/3384.minor
@@ -1,0 +1,1 @@
+Coverage is not pinned at ~= 4.5 anymore.

--- a/setup.py
+++ b/setup.py
@@ -377,7 +377,7 @@ setup(name="tahoe-lafs", # also set in __init__.py
               # coverage 5.0 breaks the integration tests in some opaque way.
               # This probably needs to be addressed in a more permanent way
               # eventually...
-              "coverage ~= 4.5",
+              "coverage",
               "mock",
               "tox",
               "pytest",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = {py27,pypy27,py36}{-coverage,}
 minversion = 2.4
 
 [testenv]
-passenv = TAHOE_LAFS_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
+passenv = TAHOE_LAFS_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH GITHUB_*
 # Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
 # a package to be installed (with setuptools) then it'll fail on certain
 # platforms (travis's OX-X 10.12, Slackware 14.2) because PyPI's TLS


### PR DESCRIPTION
For [3385](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3385).  

This is stacked on top of PR #783, because coveralls.io (or at least [coveralls for python](https://github.com/coveralls-clients/coveralls-python)) requires that coverage reports to be in 5.0 format.