### PR TITLE
3403 Pin Pyrsistent at a Python 2 compatible version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,11 @@ install_requires = [
     # know works on Python 2.7.
     "eliot ~= 1.7",
 
+    # Pyrsistent 0.17.0 (which we use by way of Eliot) has dropped
+    # Python 2 entirely; stick to the version known to work for us.
+    # XXX: drop this bound: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3404
+    "pyrsistent <= 0.16.0",
+
     # A great way to define types of values.
     # XXX: drop the upper bound: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3390
     "attrs >= 18.2.0, < 20",

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ install_requires = [
     # Pyrsistent 0.17.0 (which we use by way of Eliot) has dropped
     # Python 2 entirely; stick to the version known to work for us.
     # XXX: drop this bound: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3404
-    "pyrsistent <= 0.16.0",
+    "pyrsistent < 0.17.0",
 
     # A great way to define types of values.
     # XXX: drop the upper bound: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3390


### PR DESCRIPTION
Fix for [3403](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3403): per Pyrsistent [changelog](https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt), Python 2 support code has been removed in 0.17.0, and as a result our [CI is red](https://app.circleci.com/pipelines/github/tahoe-lafs/tahoe-lafs/777/workflows/46deb837-1398-4a6f-9494-7c17ad221c73/jobs/28190) now.  Pyrsistent 0.16.0 should work for us.

[3404](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3404) is the placeholder/reminder ticket to remove this constraint when we're ready.