### PR TITLE
Use zfec wheel package from testpypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Fetch tags
-        # run: git fetch --prune --unshallow
-        run: "git fetch origin +refs/tags/*:refs/tags/*"
+        run: git fetch --prune --unshallow
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
 
-      - name: Fetch all history for all tags and branches
-        run: git fetch --prune --unshallow
+      - name: Fetch tags
+        # run: git fetch --prune --unshallow
+        run: "git fetch origin +refs/tags/*:refs/tags/*"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         os:
           - macos-latest
           - windows-latest
+          - ubuntu-latest
         python-version:
           - 2.7
 
@@ -64,6 +65,7 @@ jobs:
         os:
           - macos-latest
           - windows-latest
+          - ubuntu-latest
         python-version:
           - 2.7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,6 @@ jobs:
 
     steps:
 
-      # Get vcpython27 on Windows + Python 2.7, to build zfec
-      # extension.  See https://chocolatey.org/packages/vcpython27 and
-      # https://github.com/crazy-max/ghaction-chocolatey
-      - name: Install MSVC 9.0 for Python 2.7 [Windows]
-        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install vcpython27
-
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
 
@@ -91,12 +82,6 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v1
         with:
           args: install tor
-
-      - name: Install MSVC 9.0 for Python 2.7 [Windows]
-        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install vcpython27
 
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,15 +126,6 @@ jobs:
 
     steps:
 
-      # Get vcpython27 on Windows + Python 2.7, to build zfec
-      # extension.  See https://chocolatey.org/packages/vcpython27 and
-      # https://github.com/crazy-max/ghaction-chocolatey
-      - name: Install MSVC 9.0 for Python 2.7 [Windows]
-        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install vcpython27
-
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ twisted = 1
 envlist = {py27,pypy27,py36}{-coverage,}
 minversion = 2.4
 
+indexserver =
+    DEV = https://test.pypi.org/simple/
+
 [testenv]
 passenv = TAHOE_LAFS_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
 # Get "certifi" to avoid bug #2913. Basically if a `setup_requires=...` causes
@@ -37,6 +40,7 @@ deps =
      # regressions in new releases of this package that cause us the kind of
      # suffering we're trying to avoid with the above pins.
      certifi
+     :DEV:zfec
 
 # We add usedevelop=False because testing against a true installation gives
 # more useful results.

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,8 @@ deps =
      # regressions in new releases of this package that cause us the kind of
      # suffering we're trying to avoid with the above pins.
      certifi
+
+     # Test using zfec packages from testpypi.
      :DEV:zfec
 
 # We add usedevelop=False because testing against a true installation gives


### PR DESCRIPTION
Testing that Tahoe-LAFS can use [zfec wheel packages](https://test.pypi.org/project/zfec/1.5.4/).