### PR TITLE
3455: Round 1 of porting `allmydata.node`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ test: .tox/create-venvs.log
 ## Run all tests with coverage collection and reporting.
 test-venv-coverage:
 # Special handling for reporting coverage even when the test run fails
+	rm -f ./.coverage.*
 	test_exit=
 	$(VIRTUAL_ENV)/bin/coverage run -m twisted.trial --rterrors --reporter=timing \
 		$(TEST_SUITE) || test_exit="$$?"

--- a/newsfragments/3455.minor
+++ b/newsfragments/3455.minor
@@ -1,1 +1,1 @@
-Cleanup casting to string for better Python 3 compatibility.
+Begin porting the `node` module to Python 3.

--- a/newsfragments/3455.minor
+++ b/newsfragments/3455.minor
@@ -1,0 +1,1 @@
+Cleanup casting to string for better Python 3 compatibility.

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -69,8 +69,8 @@ def _is_valid_section(section_name):
     Currently considers all possible storage server plugin sections valid.
     """
     return (
-        section_name.startswith(b"storageserver.plugins.") or
-        section_name.startswith(b"storageclient.plugins.")
+        section_name.startswith("storageserver.plugins.") or
+        section_name.startswith("storageclient.plugins.")
     )
 
 

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -70,7 +70,7 @@ def _common_valid_config():
 # Add our application versions to the data that Foolscap's LogPublisher
 # reports.
 for thing, things_version in get_package_versions().items():
-    app_versions.add_version(thing, str(things_version))
+    app_versions.add_version(thing, things_version)
 
 # group 1 will be addr (dotted quad string), group 3 if any will be portnum (string)
 ADDR_RE = re.compile("^([1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*)(:([1-9][0-9]*))?$")

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -821,7 +821,7 @@ class Node(service.MultiService):
         for o in twlog.theLogPublisher.observers:
             # o might be a FileLogObserver's .emit method
             if type(o) is type(self.setup_logging): # bound method
-                ob = o.im_self
+                ob = o.__self__
                 if isinstance(ob, twlog.FileLogObserver):
                     newmeth = types.UnboundMethodType(formatTimeTahoeStyle, ob, ob.__class__)
                     ob.formatTime = newmeth

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -9,10 +9,15 @@ import os.path
 import re
 import types
 import errno
-from six.moves import configparser
+from io import StringIO
 import tempfile
-from io import BytesIO
 from base64 import b32decode, b32encode
+
+# BBB: Python 2 compatibility
+from six.moves import configparser
+from future.utils import PY2
+if PY2:
+    from io import BytesIO as StringIO  # noqa: F811
 
 from twisted.python import log as twlog
 from twisted.application import service
@@ -206,7 +211,7 @@ def config_from_string(basedir, portnumfile, config_str, _valid_config=None):
 
     # load configuration from in-memory string
     parser = configparser.SafeConfigParser()
-    parser.readfp(BytesIO(config_str))
+    parser.readfp(StringIO(config_str))
 
     fname = "<in-memory>"
     configutil.validate_config(fname, parser, _valid_config)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -823,7 +823,7 @@ class Node(service.MultiService):
             if type(o) is type(self.setup_logging): # bound method
                 ob = o.__self__
                 if isinstance(ob, twlog.FileLogObserver):
-                    newmeth = types.UnboundMethodType(formatTimeTahoeStyle, ob, ob.__class__)
+                    newmeth = types.MethodType(formatTimeTahoeStyle, ob)
                     ob.formatTime = newmeth
         # TODO: twisted >2.5.0 offers maxRotatedFiles=50
 

--- a/src/allmydata/test/common.py
+++ b/src/allmydata/test/common.py
@@ -94,9 +94,9 @@ from .common_py3 import LoggingServiceParent, ShouldFailMixin  # noqa: F401
 TEST_RSA_KEY_SIZE = 522
 
 EMPTY_CLIENT_CONFIG = config_from_string(
-    b"/dev/null",
-    b"tub.port",
-    b""
+    "/dev/null",
+    "tub.port",
+    ""
 )
 
 
@@ -249,8 +249,8 @@ class UseNode(object):
 
         self.config = config_from_string(
             self.basedir.asTextMode().path,
-            u"tub.port",
-b"""
+            "tub.port",
+"""
 [node]
 {node_config}
 

--- a/src/allmydata/test/eliotutil.py
+++ b/src/allmydata/test/eliotutil.py
@@ -106,7 +106,7 @@ def eliot_logged_test(f):
 
         # Begin an action that should comprise all messages from the decorated
         # test method.
-        with RUN_TEST(name=self.id().decode("utf-8")).context() as action:
+        with RUN_TEST(name=self.id()).context() as action:
             # When the test method Deferred fires, the RUN_TEST action is
             # done.  However, we won't have re-published the MemoryLogger
             # messages into the global/default logger when this Deferred

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -252,11 +252,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         is not set.
         """
         config = client.config_from_string(
-            b"test_storage_default_anonymous_enabled",
-            b"tub.port",
+            "test_storage_default_anonymous_enabled",
+            "tub.port",
             BASECONFIG + (
-                b"[storage]\n"
-                b"enabled = true\n"
+                "[storage]\n"
+                "enabled = true\n"
             )
         )
         self.assertTrue(client.anonymous_storage_enabled(config))
@@ -268,11 +268,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         config = client.config_from_string(
             self.id(),
-            b"tub.port",
+            "tub.port",
             BASECONFIG + (
-                b"[storage]\n"
-                b"enabled = true\n"
-                b"anonymous = true\n"
+                "[storage]\n"
+                "enabled = true\n"
+                "anonymous = true\n"
             )
         )
         self.assertTrue(client.anonymous_storage_enabled(config))
@@ -284,11 +284,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         config = client.config_from_string(
             self.id(),
-            b"tub.port",
+            "tub.port",
             BASECONFIG + (
-                b"[storage]\n"
-                b"enabled = true\n"
-                b"anonymous = false\n"
+                "[storage]\n"
+                "enabled = true\n"
+                "anonymous = false\n"
             )
         )
         self.assertFalse(client.anonymous_storage_enabled(config))
@@ -300,11 +300,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         config = client.config_from_string(
             self.id(),
-            b"tub.port",
+            "tub.port",
             BASECONFIG + (
-                b"[storage]\n"
-                b"enabled = false\n"
-                b"anonymous = true\n"
+                "[storage]\n"
+                "enabled = false\n"
+                "anonymous = true\n"
             )
         )
         self.assertFalse(client.anonymous_storage_enabled(config))
@@ -680,11 +680,11 @@ class AnonymousStorage(SyncTestCase):
         os.makedirs(basedir + b"/private")
         config = client.config_from_string(
             basedir,
-            b"tub.port",
+            "tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                b"[storage]\n"
-                b"enabled = true\n"
-                b"anonymous = true\n"
+                "[storage]\n"
+                "enabled = true\n"
+                "anonymous = true\n"
             )
         )
         node = yield client.create_client_from_config(
@@ -711,11 +711,11 @@ class AnonymousStorage(SyncTestCase):
         os.makedirs(basedir + b"/private")
         config = client.config_from_string(
             basedir,
-            b"tub.port",
+            "tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                b"[storage]\n"
-                b"enabled = true\n"
-                b"anonymous = false\n"
+                "[storage]\n"
+                "enabled = true\n"
+                "anonymous = false\n"
             )
         )
         node = yield client.create_client_from_config(
@@ -732,7 +732,7 @@ class AnonymousStorage(SyncTestCase):
             ]),
         )
         self.expectThat(
-            config.get_private_config(b"storage.furl", default=None),
+            config.get_private_config("storage.furl", default=None),
             Is(None),
         )
 
@@ -748,18 +748,18 @@ class AnonymousStorage(SyncTestCase):
         os.makedirs(basedir + b"/private")
         enabled_config = client.config_from_string(
             basedir,
-            b"tub.port",
+            "tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                b"[storage]\n"
-                b"enabled = true\n"
-                b"anonymous = true\n"
+                "[storage]\n"
+                "enabled = true\n"
+                "anonymous = true\n"
             )
         )
         node = yield client.create_client_from_config(
             enabled_config,
             _introducer_factory=MemoryIntroducerClient,
         )
-        anonymous_storage_furl = enabled_config.get_private_config(b"storage.furl")
+        anonymous_storage_furl = enabled_config.get_private_config("storage.furl")
         def check_furl():
             return node.tub.getReferenceForURL(anonymous_storage_furl)
         # Perform a sanity check that our test code makes sense: is this a
@@ -772,11 +772,11 @@ class AnonymousStorage(SyncTestCase):
 
         disabled_config = client.config_from_string(
             basedir,
-            b"tub.port",
+            "tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                b"[storage]\n"
-                b"enabled = true\n"
-                b"anonymous = false\n"
+                "[storage]\n"
+                "enabled = true\n"
+                "anonymous = false\n"
             )
         )
         node = yield client.create_client_from_config(
@@ -1137,8 +1137,8 @@ class StorageAnnouncementTests(SyncTestCase):
         create_node_dir(self.basedir, u"")
 
 
-    def get_config(self, storage_enabled, more_storage=b"", more_sections=b""):
-        return b"""
+    def get_config(self, storage_enabled, more_storage="", more_sections=""):
+        return """
 [node]
 tub.location = tcp:192.0.2.0:1234
 
@@ -1163,7 +1163,7 @@ introducer.furl = pb://abcde@nowhere/fake
         """
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(storage_enabled=False),
         )
         self.assertThat(
@@ -1185,7 +1185,7 @@ introducer.furl = pb://abcde@nowhere/fake
         """
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(storage_enabled=True),
         )
         client_deferred = client.create_client_from_config(
@@ -1217,13 +1217,13 @@ introducer.furl = pb://abcde@nowhere/fake
         value = u"thing"
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage=b"plugins=tahoe-lafs-dummy-v1",
+                more_storage="plugins=tahoe-lafs-dummy-v1",
                 more_sections=(
-                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-                    b"some = {}\n".format(value)
+                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    "some = {}\n".format(value)
                 ),
             ),
         )
@@ -1258,15 +1258,15 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage=b"plugins=tahoe-lafs-dummy-v1,tahoe-lafs-dummy-v2",
+                more_storage="plugins=tahoe-lafs-dummy-v1,tahoe-lafs-dummy-v2",
                 more_sections=(
-                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-                    b"some = thing-1\n"
-                    b"[storageserver.plugins.tahoe-lafs-dummy-v2]\n"
-                    b"some = thing-2\n"
+                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    "some = thing-1\n"
+                    "[storageserver.plugins.tahoe-lafs-dummy-v2]\n"
+                    "some = thing-2\n"
                 ),
             ),
         )
@@ -1306,13 +1306,13 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage=b"plugins=tahoe-lafs-dummy-v1",
+                more_storage="plugins=tahoe-lafs-dummy-v1",
                 more_sections=(
-                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-                    b"some = thing\n"
+                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    "some = thing\n"
                 ),
             ),
         )
@@ -1342,10 +1342,10 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage=b"plugins=tahoe-lafs-dummy-v1",
+                more_storage="plugins=tahoe-lafs-dummy-v1",
             ),
         )
         self.assertThat(
@@ -1380,14 +1380,14 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage=b"plugins=tahoe-lafs-dummy-v1",
+                more_storage="plugins=tahoe-lafs-dummy-v1",
                 more_sections=(
-                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
                     # This will make it explode on instantiation.
-                    b"invalid = configuration\n"
+                    "invalid = configuration\n"
                 )
             ),
         )
@@ -1407,10 +1407,10 @@ introducer.furl = pb://abcde@nowhere/fake
         """
         config = client.config_from_string(
             self.basedir,
-            u"tub.port",
+            "tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage=b"plugins=tahoe-lafs-dummy-vX",
+                more_storage="plugins=tahoe-lafs-dummy-vX",
             ),
         )
         self.assertThat(

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -520,7 +520,6 @@ introducer.furl = empty
 enabled = false
 [i2p]
 enabled = false
-[node]
 """
 
 NOLISTEN = """
@@ -566,6 +565,7 @@ class Listeners(unittest.TestCase):
         create_node_dir(basedir, "testing")
         with open(os.path.join(basedir, "tahoe.cfg"), "w") as f:
             f.write(BASE_CONFIG)
+            f.write("[node]\n")
             f.write("tub.port = tcp:0\n")
             f.write("tub.location = AUTO\n")
 
@@ -594,6 +594,7 @@ class Listeners(unittest.TestCase):
         location = "tcp:localhost:%d,tcp:localhost:%d" % (port1, port2)
         with open(os.path.join(basedir, "tahoe.cfg"), "w") as f:
             f.write(BASE_CONFIG)
+            f.write("[node]\n")
             f.write("tub.port = %s\n" % port)
             f.write("tub.location = %s\n" % location)
 
@@ -617,6 +618,7 @@ class Listeners(unittest.TestCase):
         os.mkdir(os.path.join(basedir, "private"))
         with open(config_fname, "w") as f:
             f.write(BASE_CONFIG)
+            f.write("[node]\n")
             f.write("tub.port = listen:i2p,listen:tor\n")
             f.write("tub.location = tcp:example.org:1234\n")
         config = client.read_config(basedir, "client.port")


### PR DESCRIPTION
First set of changes porting `./src/allmydata/node.py` to Python 3 with Python 2
compatibility.  I've been comparing test output between commits and including those
details as well as discussion in each commit message, so it's probably best to review
commit by commit.  There are still failures and errors coming out of `allmydata.node`
and `allmydata.test.test_node` under Python 3 that are definitely related to porting but
I'm reasonably confident that these changes are correct and leave us better off than
before them and I didn't want to stack too much for review.

----

For reference, here's the net difference in the Python 3 test output between the
`feat(py3): Fix test runner exception` commit (needed for apples-to-apples diffs) and
this PR at the time of writing.

TL;DR:

```diff
-FAILED (skips=42, expectedFailures=1, failures=34, errors=532, successes=707)
+FAILED (skips=42, expectedFailures=1, failures=45, errors=476, successes=753)
```

Full diff:

``` diff
--- ../../.tox/make-test-py3-all-old.log	2020-10-04 22:36:00.468995771 -0700
+++ ../../.tox/make-test-py3-all-new.log	2020-10-04 22:38:51.405473485 -0700
@@ -1,5 +1,6 @@
 + make VIRTUAL_ENV=./.tox/py36-coverage TEST_SUITE=allmydata test-venv-coverage
 make[#]: Entering directory '/home/rpatterson/src/work/sfu/tahoe-lafs'
++ rm -f './.coverage.*'
 + test_exit=
 + ./.tox/py36-coverage/bin/coverage run -m twisted.trial allmydata
 allmydata.test.cli.test_alias
@@ -312,7 +313,7 @@
 ####-##-##T##:##:##-###0 [twisted.scripts._twistd_unix.UnixAppLogger#info] twistd 20.3.0 (/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/bin/python 3.6.12) starting up.
 ####-##-##T##:##:##-###0 [twisted.scripts._twistd_unix.UnixAppLogger#info] reactor class: mock.mock.MagicMock.
 ####-##-##T##:##:##-###0 [twisted.scripts._twistd_unix.UnixAppLogger#info] Server Shut Down.
-                                         [FAIL]
+                                           [OK]
 allmydata.test
   cli
     test_status ...                                                     [ERROR]
@@ -596,37 +597,38 @@
     test_reserved_4 ...                                                 [ERROR]
     test_reserved_bad ...                                               [ERROR]
     test_secrets ...                                                    [ERROR]
-    test_storage_anonymous_disabled_by_storage ...                      [ERROR]
-    test_storage_anonymous_disabled_explicitly ...                      [ERROR]
-    test_storage_anonymous_enabled_by_default ...                       [ERROR]
-    test_storage_anonymous_enabled_explicitly ...                       [ERROR]
+    test_storage_anonymous_disabled_by_storage ...                       [FAIL]
+    test_storage_anonymous_disabled_explicitly ...                       [FAIL]
+    test_storage_anonymous_enabled_by_default ...                          [OK]
+    test_storage_anonymous_enabled_explicitly ...                          [OK]
     test_unreadable_config ...                                          [ERROR]
     test_unreadable_introducers ...                                        [OK]
     test_versions ...                                                   [ERROR]
     test_web_apiauthtoken ...                                           [ERROR]
     test_web_staticdir ...                                              [ERROR]
   IntroducerClients
-    test_invalid_introducer_furl ...                                    [ERROR]
+    test_invalid_introducer_furl ...                                       [OK]
   NodeMaker
     test_maker ...                                                      [ERROR]
   Run
     test_loadable ...                                                   [ERROR]
     test_reloadable ...                                                 [ERROR]
   StorageAnnouncementTests
-    test_anonymous_storage_announcement ...                             [ERROR]
-    test_broken_storage_plugin ...                                      [ERROR]
-    test_multiple_storage_plugin_announcements ...                      [ERROR]
-    test_no_announcement ...                                            [ERROR]
-    test_single_storage_plugin_announcement ...                         [ERROR]
-    test_stable_storage_server_furl ...                                 [ERROR]
-    test_storage_plugin_not_found ...                                   [ERROR]
-    test_storage_plugin_without_configuration ...                       [ERROR]
+    test_anonymous_storage_announcement ...                              [FAIL]
+    test_broken_storage_plugin ...                                         [OK]
+    test_multiple_storage_plugin_announcements ...                       [FAIL]
+    test_no_announcement ...                                             [FAIL]
+    test_single_storage_plugin_announcement ...                          [FAIL]
+    test_stable_storage_server_furl ...                                  [FAIL]
+    test_storage_plugin_not_found ...                                    [FAIL]
+    test_storage_plugin_without_configuration ...                        [FAIL]
   StorageClients
     test_invalid_static_server ...                                       [FAIL]
     test_static_servers ...                                              [FAIL]
 allmydata.test.test_codec
   T
-    test_encode ...                                                        [OK]
+    test_encode ...                                                     [ERROR]
+                                                    [ERROR]
     test_encode1 ...                                                       [OK]
     test_encode2 ...                                                       [OK]
 allmydata.test.test_common_util
@@ -652,42 +654,42 @@
     test_reconnector_waiting ...                                           [OK]
 allmydata.test.test_connections
   Connections
-    test_default ...                                                    [ERROR]
-    test_tcp_disabled ...                                               [ERROR]
-    test_tor ...                                                        [ERROR]
-    test_tor_unimportable ...                                           [ERROR]
-    test_unknown ...                                                    [ERROR]
+    test_default ...                                                       [OK]
+    test_tcp_disabled ...                                                  [OK]
+    test_tor ...                                                           [OK]
+    test_tor_unimportable ...                                              [OK]
+    test_unknown ...                                                       [OK]
   I2P
-    test_configdir ...                                                  [ERROR]
-    test_default ...                                                    [ERROR]
-    test_disabled ...                                                   [ERROR]
-    test_launch ...                                                     [ERROR]
-    test_launch_configdir ...                                           [ERROR]
-    test_launch_configdir_and_executable ...                            [ERROR]
-    test_launch_executable ...                                          [ERROR]
-    test_samport ...                                                    [ERROR]
-    test_samport_and_launch ...                                         [ERROR]
-    test_unimportable ...                                               [ERROR]
+    test_configdir ...                                                     [OK]
+    test_default ...                                                       [OK]
+    test_disabled ...                                                      [OK]
+    test_launch ...                                                        [OK]
+    test_launch_configdir ...                                              [OK]
+    test_launch_configdir_and_executable ...                               [OK]
+    test_launch_executable ...                                             [OK]
+    test_samport ...                                                       [OK]
+    test_samport_and_launch ...                                            [OK]
+    test_unimportable ...                                                  [OK]
   Privacy
-    test_connections ...                                                [ERROR]
-    test_connections_tcp_disabled ...                                   [ERROR]
-    test_tub_location_auto ...                                          [ERROR]
-    test_tub_location_legacy_tcp ...                                    [ERROR]
-    test_tub_location_tcp ...                                           [ERROR]
+    test_connections ...                                                   [OK]
+    test_connections_tcp_disabled ...                                      [OK]
+    test_tub_location_auto ...                                             [OK]
+    test_tub_location_legacy_tcp ...                                     [FAIL]
+    test_tub_location_tcp ...                                            [FAIL]
   TCP
-    test_default ...                                                    [ERROR]
+    test_default ...                                                       [OK]
   Tor
-    test_controlport ...                                                [ERROR]
-    test_default ...                                                    [ERROR]
-    test_disabled ...                                                   [ERROR]
-    test_launch ...                                                     [ERROR]
-    test_launch_executable ...                                          [ERROR]
-    test_socksport_bad_endpoint ...                                     [ERROR]
-    test_socksport_endpoint ...                                         [ERROR]
-    test_socksport_endpoint_otherhost ...                               [ERROR]
-    test_socksport_not_integer ...                                      [ERROR]
-    test_socksport_unix_endpoint ...                                    [ERROR]
-    test_unimportable ...                                               [ERROR]
+    test_controlport ...                                                   [OK]
+    test_default ...                                                       [OK]
+    test_disabled ...                                                      [OK]
+    test_launch ...                                                        [OK]
+    test_launch_executable ...                                             [OK]
+    test_socksport_bad_endpoint ...                                        [OK]
+    test_socksport_endpoint ...                                            [OK]
+    test_socksport_endpoint_otherhost ...                                  [OK]
+    test_socksport_not_integer ...                                         [OK]
+    test_socksport_unix_endpoint ...                                       [OK]
+    test_unimportable ...                                                  [OK]
 allmydata.test.test_crawler
   Basic
     test_empty_subclass ...                                                [OK]
@@ -1190,7 +1192,7 @@
     test_disabled_but_helper ...                                         [FAIL]
     test_disabled_but_storage ...                                        [FAIL]
   Configuration
-    test_create_client_invalid_config ...                                [FAIL]
+    test_create_client_invalid_config ...                                  [OK]
     test_read_invalid_config ...                                           [OK]
   IntroducerNotListening
     test_port_none_introducer ...                                        [FAIL]
@@ -1201,12 +1203,12 @@
   TestCase
     test_config_items ...                                                [FAIL]
     test_config_required ...                                               [OK]
-    test_location1 ...                                                  [ERROR]
+    test_location1 ...                                                     [OK]
     test_location2 ...                                                  [ERROR]
-    test_location_auto_and_explicit ...                                 [ERROR]
-    test_location_not_set ...                                           [ERROR]
-    test_logdir_is_str ...                                              [ERROR]
-    test_private_config ...                                             [ERROR]
+    test_location_auto_and_explicit ...                                    [OK]
+    test_location_not_set ...                                              [OK]
+    test_logdir_is_str ...                                               [FAIL]
+    test_private_config ...                                              [FAIL]
     test_private_config_missing ...                                        [OK]
     test_private_config_unreadable ...                                  [ERROR]
     test_private_config_unreadable_preexisting ...                         [OK]
@@ -1215,16 +1217,16 @@
     test_tahoe_cfg_hash_in_name ...                                        [OK]
     test_tahoe_cfg_utf8 ...                                             [ERROR]
     test_timestamp ...                                                     [OK]
-    test_write_config_unwritable_file ...                               [ERROR]
+    test_write_config_unwritable_file ...                                  [OK]
   TestMissingPorts
-    test_disabled_port_not_tub ...                                      [ERROR]
-    test_disabled_tub_not_port ...                                      [ERROR]
-    test_empty_tub_location ...                                         [ERROR]
-    test_empty_tub_port ...                                             [ERROR]
-    test_parsing_all_disabled ...                                       [ERROR]
-    test_parsing_defaults ...                                           [ERROR]
+    test_disabled_port_not_tub ...                                         [OK]
+    test_disabled_tub_not_port ...                                         [OK]
+    test_empty_tub_location ...                                            [OK]
+    test_empty_tub_port ...                                                [OK]
+    test_parsing_all_disabled ...                                          [OK]
+    test_parsing_defaults ...                                              [OK]
     test_parsing_location_complex ...                                   [ERROR]
-    test_parsing_tcp ...                                                [ERROR]
+    test_parsing_tcp ...                                                   [OK]
 allmydata.test.test_observer
   Observer
     test_lazy_oneshot ...                                                  [OK]
@@ -1834,7 +1836,7 @@
     raise self.failureException(msg)
 twisted.trial.unittest.FailTest: ['allmydata', 'allmydata.__main__', 'allm[5873 chars]try'] != set() : Some unported modules remain: 
 Ported files: 96 / 292
-Ported lines: 27978 / 93480
+Ported lines: 27978 / 93486
 
 
 allmydata.test.test_python3.Python3PortingEffortTests.test_finished_porting
@@ -2023,18 +2025,6 @@
 ===============================================================================
 [FAIL]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/mock/mock.py", line 1369, in patched
-    return func(*newargs, **newkeywargs)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/cli/test_start.py", line 265, in test_run_invalid_config
-    output,
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 494, in assertIn
-    % (containee, container))
-twisted.trial.unittest.FailTest: 'invalid section' not in '\nUnknown error\nTraceback (most recent call last):\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/cli/test_start.py", line 232, in cwr\n    fn()\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/scripts/run_common.py", line 155, in start\n    d = service_factory()\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/scripts/run_common.py", line 136, in <lambda>\n    u"client": lambda: maybeDeferred(namedAny("allmydata.client.create_client"), self.basedir),\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred\n    result = f(*args, **kw)\n--- <exception caught here> ---\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 243, in create_client\n    config = read_config(basedir, u"client.port")\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 219, in read_config\n    _valid_config=_valid_config(),\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 192, in read_config\n    configutil.validate_config(config_fname, parser, _valid_config)\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/util/configutil.py", line 72, in validate_config\n    if not valid_config.is_valid_section(section):\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/util/configutil.py", line 113, in is_valid_section\n    self._is_valid_section(section_name)\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/util/configutil.py", line 141, in <lambda>\n    return lambda *a, **kw: f(*a, **kw) or g(*a, **kw)\n  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 72, in _is_valid_section\n    section_name.startswith(b"storageserver.plugins.") or\nbuiltins.TypeError: startswith first arg must be str or a tuple of str, not bytes\n'
-
-allmydata.test.cli.test_start.RunTests.test_run_invalid_config
-===============================================================================
-[FAIL]
-Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_asynctest.py", line 75, in _eb
     raise self.failureException(output)
 twisted.trial.unittest.FailTest: 
@@ -2047,6 +2037,255 @@
 ===============================================================================
 [FAIL]
 Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 310, in test_storage_anonymous_disabled_by_storage
+    self.assertFalse(client.anonymous_storage_enabled(config))
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 386, in assertFalse
+    super(_Assertions, self).assertFalse(condition, msg)
+  File "/usr/lib/python3.6/unittest/case.py", line 676, in assertFalse
+    raise self.failureException(msg)
+twisted.trial.unittest.FailTest: True is not false
+
+allmydata.test.test_client.Basic.test_storage_anonymous_disabled_by_storage
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 294, in test_storage_anonymous_disabled_explicitly
+    self.assertFalse(client.anonymous_storage_enabled(config))
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 386, in assertFalse
+    super(_Assertions, self).assertFalse(condition, msg)
+  File "/usr/lib/python3.6/unittest/case.py", line 676, in assertFalse
+    raise self.failureException(msg)
+twisted.trial.unittest.FailTest: True is not false
+
+allmydata.test.test_client.Basic.test_storage_anonymous_disabled_explicitly
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+Failure: testtools.testresult.real._StringException: traceback-1: {{{
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
+    return self._get_test_method()()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1204, in test_anonymous_storage_announcement
+    matches_storage_announcement(self.basedir),
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 502, in assertThat
+    raise mismatch_error
+testtools.matchers._impl.MismatchError: Success result expected on <Deferred at 0x############ current result: None>, found failure result instead: <twisted.python.failure.Failure builtins.TypeError: can't concat str to bytes>
+}}}
+
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 298, in create_client_from_config
+    storage_broker,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 676, in __init__
+    node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+TypeError: can't concat str to bytes
+
+
+allmydata.test.test_client.StorageAnnouncementTests.test_anonymous_storage_announcement
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+Failure: testtools.testresult.real._StringException: traceback-1: {{{
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
+    return self._get_test_method()()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1290, in test_multiple_storage_plugin_announcements
+    u"thing-2",
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 502, in assertThat
+    raise mismatch_error
+testtools.matchers._impl.MismatchError: Success result expected on <Deferred at 0x############ current result: None>, found failure result instead: <twisted.python.failure.Failure builtins.TypeError: cannot use a string pattern on a bytes-like object>
+}}}
+
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 281, in create_client_from_config
+    foolscap_connection_handlers, i2p_provider, tor_provider,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 669, in create_main_tub
+    portlocation = _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+TypeError: cannot use a string pattern on a bytes-like object
+
+
+allmydata.test.test_client.StorageAnnouncementTests.test_multiple_storage_plugin_announcements
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+Failure: testtools.testresult.real._StringException: traceback-1: {{{
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
+    return self._get_test_method()()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1176, in test_no_announcement
+    Equals([]),
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 502, in assertThat
+    raise mismatch_error
+testtools.matchers._impl.MismatchError: Success result expected on <Deferred at 0x############ current result: None>, found failure result instead: <twisted.python.failure.Failure builtins.TypeError: cannot use a string pattern on a bytes-like object>
+}}}
+
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 281, in create_client_from_config
+    foolscap_connection_handlers, i2p_provider, tor_provider,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 669, in create_main_tub
+    portlocation = _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+TypeError: cannot use a string pattern on a bytes-like object
+
+
+allmydata.test.test_client.StorageAnnouncementTests.test_no_announcement
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+Failure: testtools.testresult.real._StringException: traceback-1: {{{
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
+    return self._get_test_method()()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1243, in test_single_storage_plugin_announcement
+    value,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 502, in assertThat
+    raise mismatch_error
+testtools.matchers._impl.MismatchError: Success result expected on <Deferred at 0x############ current result: None>, found failure result instead: <twisted.python.failure.Failure builtins.TypeError: cannot use a string pattern on a bytes-like object>
+}}}
+
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 281, in create_client_from_config
+    foolscap_connection_handlers, i2p_provider, tor_provider,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 669, in create_main_tub
+    portlocation = _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+TypeError: cannot use a string pattern on a bytes-like object
+
+
+allmydata.test.test_client.StorageAnnouncementTests.test_single_storage_plugin_announcement
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+Failure: testtools.testresult.real._StringException: traceback-1: {{{
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
+    return self._get_test_method()()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1332, in test_stable_storage_server_furl
+    MatchesSameElements(),
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 502, in assertThat
+    raise mismatch_error
+testtools.matchers._impl.MismatchError: Success result expected on <DeferredList at 0x############ current result: None>, found failure result instead: <twisted.python.failure.Failure twisted.internet.defer.FirstError: FirstError[#0, [Failure instance: Traceback: <class 'TypeError'>: cannot use a string pattern on a bytes-like object
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py:723:_run_test_method
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py:1321:test_stable_storage_server_furl
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py:1613:unwindGenerator
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py:1529:_cancellableInlineCallbacks
+--- <exception caught here> ---
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py:1418:_inlineCallbacks
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py:281:create_client_from_config
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py:669:create_main_tub
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py:596:_tub_portlocation
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py:552:_convert_tub_port
+/usr/lib/python3.6/re.py:182:search
+]]>
+}}}
+
+Traceback (most recent call last):
+twisted.internet.defer.FirstError: FirstError[#0, [Failure instance: Traceback: <class 'TypeError'>: cannot use a string pattern on a bytes-like object
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py:723:_run_test_method
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py:1321:test_stable_storage_server_furl
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py:1613:unwindGenerator
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py:1529:_cancellableInlineCallbacks
+--- <exception caught here> ---
+/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py:1418:_inlineCallbacks
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py:281:create_client_from_config
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py:669:create_main_tub
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py:596:_tub_portlocation
+/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py:552:_convert_tub_port
+/usr/lib/python3.6/re.py:182:search
+]]
+
+
+allmydata.test.test_client.StorageAnnouncementTests.test_stable_storage_server_furl
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
+    return self._get_test_method()()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1424, in test_storage_plugin_not_found
+    Equals(configutil.UnknownConfigError),
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 502, in assertThat
+    raise mismatch_error
+testtools.matchers._impl.MismatchError: !=:
+reference = <class 'allmydata.util.configutil.UnknownConfigError'>
+actual    = <class 'TypeError'>
+: after <function <lambda>> on <twisted.python.failure.Failure builtins.TypeError: cannot use a string pattern on a bytes-like object>
+
+
+allmydata.test.test_client.StorageAnnouncementTests.test_storage_plugin_not_found
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+Failure: testtools.testresult.real._StringException: traceback-1: {{{
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
+    return self._get_test_method()()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1364, in test_storage_plugin_without_configuration
+    u"default-value",
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 502, in assertThat
+    raise mismatch_error
+testtools.matchers._impl.MismatchError: Success result expected on <Deferred at 0x############ current result: None>, found failure result instead: <twisted.python.failure.Failure builtins.TypeError: cannot use a string pattern on a bytes-like object>
+}}}
+
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 281, in create_client_from_config
+    foolscap_connection_handlers, i2p_provider, tor_provider,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 669, in create_main_tub
+    portlocation = _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+TypeError: cannot use a string pattern on a bytes-like object
+
+
+allmydata.test.test_client.StorageAnnouncementTests.test_storage_plugin_without_configuration
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
 Failure: testtools.testresult.real._StringException: traceback-1: {{{
 Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/fixtures/fixture.py", line 197, in setUp
@@ -2141,6 +2380,66 @@
 ===============================================================================
 [FAIL]
 Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 459, in test_tub_location_legacy_tcp
+    _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 355, in __exit__
+    self._expectedName, reason.getTraceback()),
+twisted.trial.unittest.FailTest: builtins.TypeError raised instead of PrivacyError:
+ Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_asynctest.py", line 112, in _run
+    utils.runWithWarningsSuppressed, self._getSuppress(), method)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/utils.py", line 217, in runWithWarningsSuppressed
+    result = f(*a, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 459, in test_tub_location_legacy_tcp
+    _tub_portlocation(config)
+--- <exception caught here> ---
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 459, in test_tub_location_legacy_tcp
+    _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+builtins.TypeError: cannot use a string pattern on a bytes-like object
+
+
+allmydata.test.test_connections.Privacy.test_tub_location_legacy_tcp
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 445, in test_tub_location_tcp
+    _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 355, in __exit__
+    self._expectedName, reason.getTraceback()),
+twisted.trial.unittest.FailTest: builtins.TypeError raised instead of PrivacyError:
+ Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_asynctest.py", line 112, in _run
+    utils.runWithWarningsSuppressed, self._getSuppress(), method)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
+    result = f(*args, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/utils.py", line 217, in runWithWarningsSuppressed
+    result = f(*a, **kw)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 445, in test_tub_location_tcp
+    _tub_portlocation(config)
+--- <exception caught here> ---
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 445, in test_tub_location_tcp
+    _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+builtins.TypeError: cannot use a string pattern on a bytes-like object
+
+
+allmydata.test.test_connections.Privacy.test_tub_location_tcp
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
 Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
     result = f(*args, **kw)
@@ -2165,11 +2464,11 @@
     result = result.throwExceptionIntoGenerator(g)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
     return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 685, in test_disabled_but_helper
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 687, in test_disabled_but_helper
     yield client.create_client(basedir)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 355, in __exit__
     self._expectedName, reason.getTraceback()),
-twisted.trial.unittest.FailTest: configparser.DuplicateSectionError raised instead of ValueError:
+twisted.trial.unittest.FailTest: builtins.NameError raised instead of ValueError:
  Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1529, in _cancellableInlineCallbacks
     _inlineCallbacks(None, g, status)
@@ -2177,12 +2476,12 @@
     result = result.throwExceptionIntoGenerator(g)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
     return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 685, in test_disabled_but_helper
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 687, in test_disabled_but_helper
     yield client.create_client(basedir)
 --- <exception caught here> ---
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 685, in test_disabled_but_helper
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 687, in test_disabled_but_helper
     yield client.create_client(basedir)
-configparser.DuplicateSectionError: While reading from '/home/rpatterson/src/work/sfu/tahoe-lafs/_trial_temp/test_node/test_disabled_but_helper/tahoe.cfg' [line 10]: section 'node' already exists
+builtins.NameError: name 'unicode' is not defined
 
 
 allmydata.test.test_node.ClientNotListening.test_disabled_but_helper
@@ -2193,11 +2492,11 @@
     result = result.throwExceptionIntoGenerator(g)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
     return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 668, in test_disabled_but_storage
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 670, in test_disabled_but_storage
     yield client.create_client(basedir)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 355, in __exit__
     self._expectedName, reason.getTraceback()),
-twisted.trial.unittest.FailTest: configparser.DuplicateSectionError raised instead of ValueError:
+twisted.trial.unittest.FailTest: builtins.NameError raised instead of ValueError:
  Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1529, in _cancellableInlineCallbacks
     _inlineCallbacks(None, g, status)
@@ -2205,12 +2504,12 @@
     result = result.throwExceptionIntoGenerator(g)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
     return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 668, in test_disabled_but_storage
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 670, in test_disabled_but_storage
     yield client.create_client(basedir)
 --- <exception caught here> ---
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 668, in test_disabled_but_storage
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 670, in test_disabled_but_storage
     yield client.create_client(basedir)
-configparser.DuplicateSectionError: While reading from '/home/rpatterson/src/work/sfu/tahoe-lafs/_trial_temp/test_node/test_disabled_but_storage/tahoe.cfg' [line 10]: section 'node' already exists
+builtins.NameError: name 'unicode' is not defined
 
 
 allmydata.test.test_node.ClientNotListening.test_disabled_but_storage
@@ -2221,39 +2520,11 @@
     result = result.throwExceptionIntoGenerator(g)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
     return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 739, in test_create_client_invalid_config
-    yield client.create_client(self.basedir)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 355, in __exit__
-    self._expectedName, reason.getTraceback()),
-twisted.trial.unittest.FailTest: builtins.TypeError raised instead of UnknownConfigError:
- Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1529, in _cancellableInlineCallbacks
-    _inlineCallbacks(None, g, status)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
-    result = result.throwExceptionIntoGenerator(g)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
-    return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 739, in test_create_client_invalid_config
-    yield client.create_client(self.basedir)
---- <exception caught here> ---
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 739, in test_create_client_invalid_config
-    yield client.create_client(self.basedir)
-builtins.TypeError: startswith first arg must be str or a tuple of str, not bytes
-
-
-allmydata.test.test_node.Configuration.test_create_client_invalid_config
-===============================================================================
-[FAIL]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
-    result = result.throwExceptionIntoGenerator(g)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
-    return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 702, in test_port_none_introducer
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 704, in test_port_none_introducer
     yield create_introducer(basedir)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 355, in __exit__
     self._expectedName, reason.getTraceback()),
-twisted.trial.unittest.FailTest: builtins.AttributeError raised instead of ValueError:
+twisted.trial.unittest.FailTest: builtins.TypeError raised instead of ValueError:
  Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1529, in _cancellableInlineCallbacks
     _inlineCallbacks(None, g, status)
@@ -2261,20 +2532,18 @@
     result = result.throwExceptionIntoGenerator(g)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
     return g.throw(self.type, self.value, self.tb)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 702, in test_port_none_introducer
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 704, in test_port_none_introducer
     yield create_introducer(basedir)
 --- <exception caught here> ---
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 702, in test_port_none_introducer
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 704, in test_port_none_introducer
     yield create_introducer(basedir)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 76, in create_introducer
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 
 allmydata.test.test_node.IntroducerNotListening.test_port_none_introducer
@@ -2306,6 +2575,44 @@
 ===============================================================================
 [FAIL]
 Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 340, in test_logdir_is_str
+    yield client.create_client(basedir)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 298, in create_client_from_config
+    storage_broker,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 676, in __init__
+    node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 739, in __init__
+    self.setup_logging()
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 847, in setup_logging
+    foolscap.logging.log.setLogDir(incident_dir.encode(get_filesystem_encoding()))
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 336, in call_setLogDir
+    self.failUnless(isinstance(logdir, str), logdir)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 397, in assertTrue
+    super(_Assertions, self).assertTrue(condition, msg)
+  File "/usr/lib/python3.6/unittest/case.py", line 682, in assertTrue
+    raise self.failureException(msg)
+twisted.trial.unittest.FailTest: False is not true : b'/home/rpatterson/src/work/sfu/tahoe-lafs/_trial_temp/test_node/test_logdir_is_str/logs/incidents'
+
+allmydata.test.test_node.TestCase.test_logdir_is_str
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 261, in test_private_config
+    self.assertEqual(config.get_private_config("already"), "secret")
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/trial/_synctest.py", line 434, in assertEqual
+    super(_Assertions, self).assertEqual(first, second, msg)
+  File "/usr/lib/python3.6/unittest/case.py", line 829, in assertEqual
+    assertion_func(first, second, msg=msg)
+  File "/usr/lib/python3.6/unittest/case.py", line 822, in _baseAssertEqual
+    raise self.failureException(msg)
+twisted.trial.unittest.FailTest: b'secret' != 'secret'
+
+allmydata.test.test_node.TestCase.test_private_config
+===============================================================================
+[FAIL]
+Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
     result = g.send(result)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_runner.py", line 192, in test_eliot_destination
@@ -5870,38 +6177,6 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 305, in test_storage_anonymous_disabled_by_storage
-    b"[storage]\n"
-builtins.TypeError: must be str, not bytes
-
-allmydata.test.test_client.Basic.test_storage_anonymous_disabled_by_storage
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 289, in test_storage_anonymous_disabled_explicitly
-    b"[storage]\n"
-builtins.TypeError: must be str, not bytes
-
-allmydata.test.test_client.Basic.test_storage_anonymous_disabled_explicitly
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 258, in test_storage_anonymous_enabled_by_default
-    b"[storage]\n"
-builtins.TypeError: must be str, not bytes
-
-allmydata.test.test_client.Basic.test_storage_anonymous_enabled_by_default
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 273, in test_storage_anonymous_enabled_explicitly
-    b"[storage]\n"
-builtins.TypeError: must be str, not bytes
-
-allmydata.test.test_client.Basic.test_storage_anonymous_enabled_explicitly
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 150, in test_unreadable_config
     fileutil.write(fn, BASECONFIG)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/util/fileutil.py", line 275, in write
@@ -5932,11 +6207,9 @@
     storage_broker,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 676, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 allmydata.test.test_client.Basic.test_web_apiauthtoken
 ===============================================================================
@@ -5954,16 +6227,6 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 803, in test_invalid_introducer_furl
-    config = client.config_from_string("basedir", "client.port", cfg)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_client.IntroducerClients.test_invalid_introducer_furl
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
     result = g.send(result)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1007, in test_maker
@@ -6000,417 +6263,22 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1189, in test_anonymous_storage_announcement
-    self.get_config(storage_enabled=True),
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1153, in get_config
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_anonymous_storage_announcement
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1388, in test_broken_storage_plugin
-    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1153, in get_config
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_broken_storage_plugin
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1266, in test_multiple_storage_plugin_announcements
-    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1153, in get_config
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_multiple_storage_plugin_announcements
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1167, in test_no_announcement
-    self.get_config(storage_enabled=False),
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1153, in get_config
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_no_announcement
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1225, in test_single_storage_plugin_announcement
-    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_single_storage_plugin_announcement
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1314, in test_stable_storage_server_furl
-    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1153, in get_config
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_stable_storage_server_furl
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1413, in test_storage_plugin_not_found
-    more_storage=b"plugins=tahoe-lafs-dummy-vX",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1153, in get_config
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_storage_plugin_not_found
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
-    result = f(*args, **kw)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 723, in _run_test_method
-    return self._get_test_method()()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1348, in test_storage_plugin_without_configuration
-    more_storage=b"plugins=tahoe-lafs-dummy-v1",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_client.py", line 1153, in get_config
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
-
-
-allmydata.test.test_client.StorageAnnouncementTests.test_storage_plugin_without_configuration
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 337, in setUp
-    self.config = config_from_string("fake.port", self.basedir, BASECONFIG)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Connections.test_default
-allmydata.test.test_connections.Connections.test_tcp_disabled
-allmydata.test.test_connections.Connections.test_tor
-allmydata.test.test_connections.Connections.test_tor_unimportable
-allmydata.test.test_connections.Connections.test_unknown
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 322, in test_configdir
-    BASECONFIG + "[i2p]\ni2p.configdir = cfg\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_configdir
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 216, in test_default
-    config = config_from_string("fake.port", "no-basedir", BASECONFIG)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_default
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 197, in test_disabled
-    BASECONFIG + "[i2p]\nenabled = false\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_disabled
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 261, in test_launch
-    BASECONFIG + "[i2p]\nlaunch = true\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_launch
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 291, in test_launch_configdir
-    BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.configdir = cfg\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_launch_configdir
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 307, in test_launch_configdir_and_executable
-    "i2p.executable = i2p\n" + "i2p.configdir = cfg\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_launch_configdir_and_executable
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 276, in test_launch_executable
-    BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.executable = i2p\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_launch_executable
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 229, in test_samport
-    BASECONFIG + "[i2p]\nsam.port = tcp:localhost:1234\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_samport
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 247, in test_samport_and_launch
-    "sam.port = tcp:localhost:1234\n" + "launch = true\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_samport_and_launch
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 207, in test_unimportable
-    BASECONFIG,
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.I2P.test_unimportable
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 403, in test_connections
-    BASECONFIG + "[node]\nreveal-IP-address = false\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Privacy.test_connections
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 419, in test_connections_tcp_disabled
-    "[node]\nreveal-IP-address = false\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Privacy.test_connections_tcp_disabled
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 428, in test_tub_location_auto
-    BASECONFIG + "[node]\nreveal-IP-address = false\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Privacy.test_tub_location_auto
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 455, in test_tub_location_legacy_tcp
-    BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=hostname:1234\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Privacy.test_tub_location_legacy_tcp
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 442, in test_tub_location_tcp
-    BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=tcp:hostname:1234\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Privacy.test_tub_location_tcp
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 23, in test_default
-    BASECONFIG,
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.TCP.test_default
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 182, in test_controlport
-    BASECONFIG + "[tor]\ncontrol.port = tcp:localhost:1234\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_controlport
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 57, in test_default
-    config = config_from_string("fake.port", "no-basedir", BASECONFIG)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_default
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 38, in test_disabled
-    BASECONFIG + "[tor]\nenabled = false\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_disabled
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 100, in test_launch
-    self._do_test_launch(None)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 72, in _do_test_launch
-    config = config_from_string("fake.port", ".", config)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_launch
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 103, in test_launch_executable
-    self._do_test_launch("/special/tor")
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 72, in _do_test_launch
-    config = config_from_string("fake.port", ".", config)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_launch_executable
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 151, in test_socksport_bad_endpoint
-    BASECONFIG + "[tor]\nsocks.port = meow:unsupported\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_socksport_bad_endpoint
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 126, in test_socksport_endpoint
-    BASECONFIG + "[tor]\nsocks.port = tcp:127.0.0.1:1234\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_socksport_endpoint
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 140, in test_socksport_endpoint_otherhost
-    BASECONFIG + "[tor]\nsocks.port = tcp:otherhost:1234\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_socksport_endpoint_otherhost
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 165, in test_socksport_not_integer
-    BASECONFIG + "[tor]\nsocks.port = tcp:localhost:kumquat\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_socksport_not_integer
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 112, in test_socksport_unix_endpoint
-    BASECONFIG + "[tor]\nsocks.port = unix:/var/lib/fw-daemon/tor_socks.socket\n",
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_connections.Tor.test_socksport_unix_endpoint
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_connections.py", line 47, in test_unimportable
-    config = config_from_string("fake.port", "no-basedir", BASECONFIG)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 281, in create_client_from_config
+    foolscap_connection_handlers, i2p_provider, tor_provider,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 669, in create_main_tub
+    portlocation = _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+builtins.TypeError: cannot use a string pattern on a bytes-like object
 
-allmydata.test.test_connections.Tor.test_unimportable
+allmydata.test.test_codec.T.test_encode
+allmydata.test.test_codec.T.test_encode
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
@@ -7129,8 +6997,12 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Empty attachments:
-  twisted-log
+Failure: testtools.testresult.real._StringException: twisted-log: {{{
+####-##-## ##:##:##.###Z [-] Foolscap logging initialized
+####-##-## ##:##:##.###Z [-] Note to developers: twistd.log does not receive very much.
+####-##-## ##:##:##.###Z [-] Use 'flogtool tail -c NODEDIR/private/logport.furl' instead
+####-##-## ##:##:##.###Z [-] and read docs/logging.rst
+}}}
 
 Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
@@ -7143,19 +7015,21 @@
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+TypeError: can't concat str to bytes
 
 
 allmydata.test.test_introducer.Node.test_create
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-Failure: testtools.testresult.real._StringException: Empty attachments:
-  twisted-log
+Failure: testtools.testresult.real._StringException: twisted-log: {{{
+####-##-## ##:##:##.###Z [-] Foolscap logging initialized
+####-##-## ##:##:##.###Z [-] Note to developers: twistd.log does not receive very much.
+####-##-## ##:##:##.###Z [-] Use 'flogtool tail -c NODEDIR/private/logport.furl' instead
+####-##-## ##:##:##.###Z [-] and read docs/logging.rst
+}}}
 
 Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
@@ -7168,11 +7042,9 @@
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+TypeError: can't concat str to bytes
 
 
 allmydata.test.test_introducer.Node.test_furl
@@ -7431,23 +7303,17 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 655, in test_disabled
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 657, in test_disabled
     n = yield client.create_client(basedir)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 243, in create_client
-    config = read_config(basedir, u"client.port")
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 219, in read_config
-    _valid_config=_valid_config(),
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 187, in read_config
-    parser = configutil.get_config(config_fname)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/util/configutil.py", line 50, in get_config
-    config.readfp(f)
-  File "/usr/lib/python3.6/configparser.py", line 764, in readfp
-    self.read_file(fp, source=filename)
-  File "/usr/lib/python3.6/configparser.py", line 718, in read_file
-    self._read(f, source)
-  File "/usr/lib/python3.6/configparser.py", line 1067, in _read
-    lineno)
-configparser.DuplicateSectionError: While reading from '/home/rpatterson/src/work/sfu/tahoe-lafs/_trial_temp/test_node/test_disabled/tahoe.cfg' [line 10]: section 'node' already exists
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
+    result = g.send(result)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 285, in create_client_from_config
+    introducer_clients = create_introducer_clients(config, main_tub, _introducer_factory)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 519, in create_introducer_clients
+    introducer_cache_filepath,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/client.py", line 29, in __init__
+    assert type(nickname) is unicode
+builtins.NameError: name 'unicode' is not defined
 
 allmydata.test.test_node.ClientNotListening.test_disabled
 ===============================================================================
@@ -7455,7 +7321,7 @@
 Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 577, in test_listen_on_zero
     t = FakeTub()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 549, in __init__
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 548, in __init__
     self.tubID = base64.b32encode("foo")
   File "/usr/lib/python3.6/base64.py", line 154, in b32encode
     s = memoryview(s).tobytes()
@@ -7465,9 +7331,9 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 605, in test_multiple_ports
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 606, in test_multiple_ports
     t = FakeTub()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 549, in __init__
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 548, in __init__
     self.tubID = base64.b32encode("foo")
   File "/usr/lib/python3.6/base64.py", line 154, in b32encode
     s = memoryview(s).tobytes()
@@ -7477,9 +7343,9 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 624, in test_tor_i2p_listeners
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 626, in test_tor_i2p_listeners
     t = FakeTub()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 549, in __init__
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 548, in __init__
     self.tubID = base64.b32encode("foo")
   File "/usr/lib/python3.6/base64.py", line 154, in b32encode
     s = memoryview(s).tobytes()
@@ -7489,93 +7355,29 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 112, in test_location1
-    tub_location="192.0.2.0:1234")
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 99, in _test_location
-    tub = testing_tub(config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 53, in testing_tub
-    config = config_from_string(basedir, 'DEFAULT_PORTNUMFILE_BLANK', config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestCase.test_location1
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 117, in test_location2
     tub_location="192.0.2.0:1234,example.org:8091")
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 99, in _test_location
     tub = testing_tub(config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 53, in testing_tub
-    config = config_from_string(basedir, 'DEFAULT_PORTNUMFILE_BLANK', config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 65, in testing_tub
+    cert_filename='DEFAULT_CERTFILE_BLANK'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 669, in create_main_tub
+    portlocation = _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+builtins.TypeError: cannot use a string pattern on a bytes-like object
 
 allmydata.test.test_node.TestCase.test_location2
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 142, in test_location_auto_and_explicit
-    local_addresses=["127.0.0.1", "192.0.2.0", "example.com:4321"],
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 99, in _test_location
-    tub = testing_tub(config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 53, in testing_tub
-    config = config_from_string(basedir, 'DEFAULT_PORTNUMFILE_BLANK', config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestCase.test_location_auto_and_explicit
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 128, in test_location_not_set
-    local_addresses=["127.0.0.1", "192.0.2.0"],
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 99, in _test_location
-    tub = testing_tub(config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 53, in testing_tub
-    config = config_from_string(basedir, 'DEFAULT_PORTNUMFILE_BLANK', config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestCase.test_location_not_set
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 340, in test_logdir_is_str
-    yield client.create_client(basedir)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
-    result = g.send(result)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 298, in create_client_from_config
-    storage_broker,
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 676, in __init__
-    node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
-
-allmydata.test.test_node.TestCase.test_logdir_is_str
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 259, in test_private_config
-    config = config_from_string(basedir, "", "")
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestCase.test_private_config
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 213, in test_private_config_unreadable
     config.get_or_create_private_config("foo", "contents")
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 369, in get_or_create_private_config
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 374, in get_or_create_private_config
     fileutil.write(privname, value)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/util/fileutil.py", line 275, in write
     f.write(data)
@@ -7593,96 +7395,20 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 288, in test_write_config_unwritable_file
-    config = config_from_string(basedir, "", "")
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestCase.test_write_config_unwritable_file
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 488, in test_disabled_port_not_tub
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestMissingPorts.test_disabled_port_not_tub
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 506, in test_disabled_tub_not_port
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestMissingPorts.test_disabled_tub_not_port
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 470, in test_empty_tub_location
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestMissingPorts.test_empty_tub_location
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 453, in test_empty_tub_port
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestMissingPorts.test_empty_tub_port
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 439, in test_parsing_all_disabled
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestMissingPorts.test_parsing_all_disabled
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 392, in test_parsing_defaults
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestMissingPorts.test_parsing_defaults
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 415, in test_parsing_location_complex
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 418, in test_parsing_location_complex
+    tubport, tublocation = _tub_portlocation(config)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 596, in _tub_portlocation
+    tubport = _convert_tub_port(file_tubport)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 552, in _convert_tub_port
+    if re.search(r'^\d+$', s):
+  File "/usr/lib/python3.6/re.py", line 182, in search
+    return _compile(pattern, flags).search(string)
+builtins.TypeError: cannot use a string pattern on a bytes-like object
 
 allmydata.test.test_node.TestMissingPorts.test_parsing_location_complex
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_node.py", line 370, in test_parsing_tcp
-    config = config_from_string(self.basedir, "portnum", config_data)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
-
-allmydata.test.test_node.TestMissingPorts.test_parsing_tcp
-===============================================================================
-[ERROR]
-Traceback (most recent call last):
 Failure: testtools.testresult.real._StringException: Traceback (most recent call last):
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/test_python2_regressions.py", line 53, in test_new_style_classes
     mod.load()
@@ -8306,9 +8032,19 @@
     raise exc_obj.with_traceback(exc_tb)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 735, in useFixture
     fixture.setUp()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/common.py", line 261, in setUp
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/common.py", line 265, in setUp
+    plugin_config_section=plugin_config_section,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 214, in config_from_string
+    parser.readfp(StringIO(config_str))
+  File "/usr/lib/python3.6/configparser.py", line 764, in readfp
+    self.read_file(fp, source=filename)
+  File "/usr/lib/python3.6/configparser.py", line 718, in read_file
+    self._read(f, source)
+  File "/usr/lib/python3.6/configparser.py", line 1112, in _read
+    raise e
+configparser.ParsingError: Source contains parsing errors: '<???>'
+	[line  3]: "b''\n"
+	[line  8]: "b''\n"
 
 
 allmydata.test.test_storage_client.PluginMatchedAnnouncement.test_enabled_no_configuration_plugin
@@ -8350,9 +8086,19 @@
     raise exc_obj.with_traceback(exc_tb)
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/.tox/py36-coverage/lib/python3.6/site-packages/testtools/testcase.py", line 735, in useFixture
     fixture.setUp()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/common.py", line 261, in setUp
-    """.format(
-AttributeError: 'bytes' object has no attribute 'format'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/common.py", line 265, in setUp
+    plugin_config_section=plugin_config_section,
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 214, in config_from_string
+    parser.readfp(StringIO(config_str))
+  File "/usr/lib/python3.6/configparser.py", line 764, in readfp
+    self.read_file(fp, source=filename)
+  File "/usr/lib/python3.6/configparser.py", line 718, in read_file
+    self._read(f, source)
+  File "/usr/lib/python3.6/configparser.py", line 1112, in _read
+    raise e
+configparser.ParsingError: Source contains parsing errors: '<???>'
+	[line  3]: "b''\n"
+	[line  8]: "b''\n"
 
 
 allmydata.test.test_storage_client.PluginMatchedAnnouncement.test_ignored_non_enabled_plugin
@@ -8451,11 +8197,9 @@
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 allmydata.test.test_system.Connections.test_rref
 allmydata.test.test_system.SystemTest.test_filesystem
@@ -8548,11 +8292,13 @@
 ===============================================================================
 [ERROR]
 Traceback (most recent call last):
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/web/test_introducer.py", line 187, in test_json
-    config = node.config_from_string(self.mktemp(), "", "")
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 209, in config_from_string
-    parser.readfp(BytesIO(config_str))
-builtins.TypeError: a bytes-like object is required, not 'str'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/test/web/test_introducer.py", line 192, in test_json
+    introducer_node = _IntroducerNode(config, main_tub, None, None, None)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
+    node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 allmydata.test.web.test_introducer.IntroducerRootTests.test_json
 ===============================================================================
@@ -8570,11 +8316,9 @@
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 allmydata.test.web.test_introducer.IntroducerWeb.test_basic_information
 ===============================================================================
@@ -8592,11 +8336,9 @@
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 allmydata.test.web.test_introducer.IntroducerWeb.test_json_front_page
 ===============================================================================
@@ -8614,11 +8356,9 @@
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 allmydata.test.web.test_introducer.IntroducerWeb.test_tahoe_css
 ===============================================================================
@@ -8636,11 +8376,9 @@
     tor_provider,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/introducer/server.py", line 87, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 
 allmydata.test.web.test_introducer.IntroducerWeb.test_welcome
 ===============================================================================
@@ -8726,7 +8464,7 @@
 -------------------------------------------------------------------------------
 Ran 1300 tests in ###.###s
 
-FAILED (skips=42, expectedFailures=1, failures=34, errors=532, successes=707)
+FAILED (skips=42, expectedFailures=1, failures=45, errors=476, successes=753)
 
 Unknown error
 Traceback (most recent call last):
@@ -8745,11 +8483,9 @@
     storage_broker,
   File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/client.py", line 676, in __init__
     node.Node.__init__(self, config, main_tub, control_tub, i2p_provider, tor_provider)
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 734, in __init__
-    self.setup_logging()
-  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 824, in setup_logging
-    ob = o.im_self
-builtins.AttributeError: 'function' object has no attribute 'im_self'
+  File "/home/rpatterson/src/work/sfu/tahoe-lafs/src/allmydata/node.py", line 745, in __init__
+    self.config.write_config_file("my_nodeid", b32encode(self.nodeid).lower() + "\n")
+builtins.TypeError: can't concat str to bytes
 + test_exit=1
 + ./.tox/py36-coverage/bin/coverage combine
 + ./.tox/py36-coverage/bin/coverage html
@@ -8760,7 +8496,7 @@
 src/allmydata/__main__.py                                4      1      2      1    67%   6, 5->6
 src/allmydata/blacklist.py                             110     51     10      1    52%   16-17, 34-48, 55, 64-66, 69, 72, 75, 78, 81, 84, 87, 91, 94, 97, 100, 103, 106, 109, 112, 115, 118, 121, 124, 127, 132, 135, 138, 141, 144, 147, 150, 153, 156, 159, 53->55
 src/allmydata/check_results.py                         208    109     62      7    44%   27-30, 33, 51, 55, 64-65, 70, 72, 74, 77, 79, 82, 90, 92, 95, 98, 101, 104, 107, 109, 112, 115-138, 141, 143, 145, 147, 153-154, 157, 159, 161, 163-165, 167, 169, 177, 181-188, 191, 194, 197, 200, 203, 206, 213-226, 229, 242-248, 251-279, 282, 297, 24->29, 26->27, 32->33, 50->51, 54->55, 63->64, 176->177
-src/allmydata/client.py                                472    197    107     14    52%   165, 311-322, 350-364, 373, 384, 400, 427-433, 444-451, 474-482, 493, 501, 521, 547, 562, 585-598, 615-617, 631, 643, 692, 697-700, 709-712, 727, 753-754, 757, 763, 766-785, 798-857, 861-893, 902, 910-911, 917-931, 936, 964, 989-993, 1004, 1021-1024, 1027-1036, 1042-1049, 1053-1062, 1066-1078, 1081-1089, 1095, 1098, 1101, 1104, 1111-1115, 1130, 1133, 77->exit, 270->273, 463->467, 492->493, 500->501, 561->562, 691->692, 696->697, 708->709, 717->exit, 935->936, 1003->1004, 1052->1053, 1065->1066
+src/allmydata/client.py                                472    192    107     10    54%   165, 311-322, 350-364, 373, 384, 400, 427-433, 444-451, 474-482, 493, 547, 585-598, 615-617, 692, 697-700, 709-712, 727, 753-754, 757, 763, 766-785, 798-857, 861-893, 902, 910-911, 917-931, 936, 964, 989-993, 1004, 1021-1024, 1027-1036, 1042-1049, 1053-1062, 1066-1078, 1081-1089, 1095, 1098, 1101, 1104, 1111-1115, 1130, 1133, 270->273, 492->493, 691->692, 696->697, 708->709, 717->exit, 935->936, 1003->1004, 1052->1053, 1065->1066
 src/allmydata/codec.py                                  60      2     12      1    96%   13, 74, 12->13
 src/allmydata/control.py                               227    186     62      0    16%   16-33, 36-37, 44-45, 47-51, 53, 55-56, 62, 65-84, 87-99, 102-106, 109, 115-121, 123-145, 149-154, 157-162, 165-178, 181-220, 223-242, 245-248, 253, 255-259, 261, 263
 src/allmydata/crypto/__init__.py                         7      1      2      1    78%   19, 18->19
@@ -8807,7 +8543,7 @@
 src/allmydata/mutable/repairer.py                       57     37     18      0    29%   13, 15, 17, 19, 29-34, 65-71, 74-126, 129-131
 src/allmydata/mutable/retrieve.py                      489    123    120     33    71%   46, 48, 50, 52, 56, 58, 60, 62, 64, 89-90, 133, 186-193, 204-208, 211-212, 224-226, 231, 240, 251, 312, 318, 344-354, 377, 385-386, 399-400, 425-434, 490, 501, 515-516, 529-540, 564-578, 591-592, 629-630, 653-654, 674-675, 681-682, 698, 712-729, 758-760, 765, 772-774, 790-792, 871, 883, 909-910, 919-941, 965-966, 981-994, 999-1005, 129->133, 167->169, 169->171, 201->204, 223->224, 230->231, 237->239, 239->240, 243->247, 249->251, 309->312, 317->318, 376->377, 381->385, 391->394, 396->399, 424->425, 489->490, 499->501, 514->515, 590->591, 628->629, 652->653, 673->674, 677->687, 680->681, 687->694, 694->698, 755->764, 764->765, 868->871, 880->883, 964->965
 src/allmydata/mutable/servermap.py                     612    240    186     26    56%   45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 74, 130-139, 142, 148, 159-161, 175, 177, 183, 186-199, 206, 213, 217-220, 231, 234-238, 243-252, 255-259, 315, 328-350, 358-363, 370-372, 379, 429, 433, 443-447, 495, 498, 506-508, 514-516, 569-570, 603-611, 623-638, 718-721, 732-741, 792, 796, 803-804, 850-851, 872-874, 911-915, 929-945, 961-975, 982-999, 1003-1013, 1043-1045, 1050-1052, 1060-1064, 1069-1070, 1093-1100, 1106-1186, 1214-1215, 1232-1233, 313->315, 427->429, 432->433, 439->443, 459->461, 493->495, 497->498, 504->506, 509->514, 566->569, 597->603, 687->exit, 702->exit, 710->exit, 717->718, 727->732, 759->exit, 791->792, 795->796, 869->872, 1039->1043, 1047->1050, 1059->1060, 1066->1069, 1092->1093, 1213->1214
-src/allmydata/node.py                                  388     84    146     34    75%   120, 132, 190, 241, 243-245, 278, 284, 294-295, 303-306, 315, 320, 339, 341, 361, 393-396, 422, 449, 453, 490, 493, 500, 511-512, 548, 566, 574, 581, 583, 590-591, 601, 612, 629-633, 679, 681, 738-741, 747, 756, 764, 792-805, 808-809, 814-815, 825-846, 189->190, 240->241, 242->243, 277->278, 314->315, 319->320, 338->339, 340->341, 360->361, 391->393, 421->422, 448->449, 451->453, 489->490, 492->493, 499->500, 510->511, 537->535, 547->548, 565->566, 573->574, 580->581, 582->583, 589->590, 600->601, 611->612, 622->629, 673->679, 680->681, 737->738, 746->747, 763->764, 821->830, 823->821
+src/allmydata/node.py                                  391     52    148     23    85%   20, 125, 137, 195, 246, 248-250, 283, 289, 308-311, 320, 325, 344, 346, 366, 398-401, 427, 454, 458, 606, 634-638, 684, 686, 746, 752, 761, 769, 797-810, 813-814, 819-820, 837, 842, 19->20, 194->195, 245->246, 247->248, 282->283, 319->320, 324->325, 343->344, 345->346, 365->366, 396->398, 426->427, 453->454, 456->458, 605->606, 627->634, 678->684, 685->686, 751->752, 768->769, 828->826, 836->837, 840->842
 src/allmydata/nodemaker.py                              97     23     38     10    70%   49, 61, 66, 70, 81, 94, 107-115, 130-138, 141-150, 57->61, 65->66, 69->70, 79->81, 86->95, 90->94, 104->107, 124->exit, 129->130, 129->133
 src/allmydata/scripts/admin.py                          51     20      2      1    60%   9-14, 25, 28, 31-37, 40-46, 57, 59, 61-66, 56->57
 src/allmydata/scripts/backupdb.py                      146     91     14      1    36%   84-91, 94-96, 99, 103, 106, 111-114, 117-119, 122, 125, 128, 176-221, 231-242, 245-263, 266-272, 308-324, 327-333, 336-341, 306->308
@@ -8817,7 +8553,7 @@
 src/allmydata/scripts/create_node.py                   302     98    114     10    66%   224-229, 235, 257-260, 262-265, 268-269, 289-292, 295-298, 329, 339, 347-380, 391-445, 461-477, 223->224, 234->235, 256->257, 261->262, 266->277, 267->268, 288->289, 294->295, 328->329, 338->339
 src/allmydata/scripts/debug.py                         719    638    202      0     9%   14, 31-32, 35-49, 52-60, 63-142, 146-154, 157-164, 168-217, 220-304, 307-401, 407, 417, 437-465, 468-485, 488-602, 606, 609-611, 637-648, 653-656, 659, 683-689, 692-810, 813-842, 845-848, 851-865, 869, 888, 891-940, 946, 949-950, 957, 960-961, 967-972, 984-985, 999-1000, 1003-1004, 1020-1021, 1025-1031, 1046-1050
 src/allmydata/scripts/default_nodedir.py                15      5      6      2    57%   10-14, 9->10, 16->exit
-src/allmydata/scripts/run_common.py                    135     18     24      6    85%   37, 41-46, 59-60, 149, 158, 192-193, 216-220, 226-227, 55->62, 135->exit, 135->exit, 148->149, 191->192, 225->226
+src/allmydata/scripts/run_common.py                    135     17     24      5    86%   37, 41-46, 59-60, 158, 192-193, 216-220, 226-227, 55->62, 135->exit, 135->exit, 191->192, 225->226
 src/allmydata/scripts/runner.py                        138     49     42      5    61%   84-85, 91, 97-99, 150, 153-160, 174-181, 188-192, 202-232, 237-252, 255, 31->36, 149->150, 151->153, 185->188, 254->255
 src/allmydata/scripts/slow_operation.py                 69     56     22      0    14%   15-44, 47-52, 55-61, 64-83
 src/allmydata/scripts/stats_gatherer.py                 44     16     12      3    59%   8, 30, 75-79, 84-93, 7->8, 29->30, 74->75
@@ -8869,9 +8605,9 @@
 src/allmydata/util/happinessutil.py                     77      1     42      1    98%   15, 13->15
 src/allmydata/util/hashutil.py                         157      3      8      1    98%   14, 236, 278, 12->14
 src/allmydata/util/humanreadable.py                     80     16     28      7    73%   14, 35, 38-41, 44-51, 74, 80, 83, 13->14, 32->35, 68->74, 79->80, 82->83, 91->exit, 106->exit
-src/allmydata/util/i2p_provider.py                     121      5     36      4    94%   93, 177, 206, 219, 226, 62->65, 92->93, 176->177, 205->206
+src/allmydata/util/i2p_provider.py                     121      4     36      3    96%   93, 206, 219, 226, 62->65, 92->93, 205->206
 src/allmydata/util/iputil.py                           172     25     56      7    83%   14, 65-67, 73-102, 153-166, 181-184, 242, 246, 13->14, 69->73, 125->128, 220->242, 245->246, 249->259, 265->261
-src/allmydata/util/log.py                               52      2     16      2    94%   13, 40, 12->13, 39->40
+src/allmydata/util/log.py                               52      1     16      1    97%   13, 12->13
 src/allmydata/util/mathutil.py                          12      1      2      1    86%   16, 15->16
 src/allmydata/util/netstring.py                         35      1     12      1    96%   13, 12->13
 src/allmydata/util/observer.py                          91      3     20      5    93%   14, 139, 145, 13->14, 96->exit, 138->139, 142->145, 156->exit
@@ -8904,7 +8640,7 @@
 src/allmydata/windows/fixups.py                        133    133     54      0     0%   1-237
 src/allmydata/windows/registry.py                       42     42     12      0     0%   1-77
 ------------------------------------------------------------------------------------------------
-TOTAL                                                27477  11800   8244    606    54%
+TOTAL                                                27480  11760   8246    588    54%
 
 18 files skipped due to complete coverage.
 + '[' '!' -z 1 ']'
```