### PR TITLE
Tweak docstring on FakeCanary

### DIFF
--- a/src/allmydata/test/common_util.py
+++ b/src/allmydata/test/common_util.py
@@ -129,9 +129,6 @@ class Marker(object):
 
 class FakeCanary(object):
     """For use in storage tests.
-
-    Can be moved back to test_storage.py once enough Python 3 porting has been
-    done.
     """
     def __init__(self, ignore_disconnectors=False):
         self.ignore = ignore_disconnectors


### PR DESCRIPTION
Follow-on from #842.

Since this class is used in multiple test modules now, it makes sense to keep it in common_util instead of test_storage.