### PR TITLE
3428 Resource subclasses should not return Deferreds

### DIFF
--- a/src/allmydata/web/filenode.py
+++ b/src/allmydata/web/filenode.py
@@ -521,7 +521,7 @@ class FileDownloader(Resource, object):
                 eh = MyExceptionHandler()
                 eh.renderHTTP_exception(req, f)
         d.addCallbacks(_finished, _error)
-        return req.deferred
+        return ""
 
 
 def _file_json_metadata(req, filenode, edge_metadata):

--- a/src/allmydata/web/filenode.py
+++ b/src/allmydata/web/filenode.py
@@ -521,7 +521,14 @@ class FileDownloader(Resource, object):
                 eh = MyExceptionHandler()
                 eh.renderHTTP_exception(req, f)
         d.addCallbacks(_finished, _error)
-        return ""
+
+        # XXX: Things that I do not quite understand are going on
+        # here.  Previously this method was returning `req.deferred`
+        # (which had a `` as current result) here, which of course is
+        # not a thing in twisted.web.  Doing a `return d` here makes
+        # the test suite unhappy, because result held in `d` is None.
+        from twisted.web.util import DeferredResource
+        return DeferredResource(defer.Deferred())
 
 
 def _file_json_metadata(req, filenode, edge_metadata):


### PR DESCRIPTION
This is (currently!) just an experimental branch to figure out the deal with [3428](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3428).

I've found that these `getChild()` and `render_*()` methods return `Deferred`:

- `web.directory.DirectoryNodeHandler.getChild()`
- `web.directory.DirectoryNodeHandler.render_GET()`
- `web.directory.DirectoryNodeHandler.render_PUT()`
- `web.directory.DirectoryNodeHandler.render_POST()`
- `web.directory.UnknownNodeHandler.render_GET()`
- `web.filenode.PlaceHolderNodeHandler.render_PUT()`
- `web.filenode.FileNodeHandler.render_GET()`
- `web.filenode.FileNodeHandler.render_PUT()`
- `web.filenode.FileNodeHandler.render_POST()`
- `web.filenode.FileNodeHandler.render_DELETE()`
- `web.root.URIHandler.render_PUT()`
- `web.root.URIHandler.render_POST()`

I think this is pretty exhaustive, but I am not sure all of them should attempt to _not_ return a `Deferred`.  Wrapping the return values of `PlaceHolderNodeHandler.render_PUT()` in `twisted.web.util.DeferredResource()`, for example, breaks the test suite in pretty opaque ways.

Of these,  `web.filenode.FileDownloader.render()` looks kind of pesky.  It does a `return req.deferred` that contains an empty string as its result; changing it to `return d` breaks many tests.