### PR TITLE
3455: Begin porting test_node

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include relnotes.txt
 include Dockerfile
 include tox.ini .appveyor.yml .travis.yml
 include .coveragerc
-recursive-include src *.xhtml *.js *.png *.css *.svg *.txt
+recursive-include src *.xhtml *.js *.png *.css *.svg *.txt *.cfg
 graft docs
 graft misc
 graft static

--- a/newsfragments/3455.minor
+++ b/newsfragments/3455.minor
@@ -1,1 +1,1 @@
-Begin porting the `node` module to Python 3.
+Port the `test_node` tests to Python 3.

--- a/src/allmydata/test/common.py
+++ b/src/allmydata/test/common.py
@@ -94,9 +94,9 @@ from .common_util import ShouldFailMixin  # noqa: F401
 TEST_RSA_KEY_SIZE = 522
 
 EMPTY_CLIENT_CONFIG = config_from_string(
-    "/dev/null",
-    "tub.port",
-    ""
+    b"/dev/null",
+    b"tub.port",
+    b""
 )
 
 
@@ -249,8 +249,8 @@ class UseNode(object):
 
         self.config = config_from_string(
             self.basedir.asTextMode().path,
-            "tub.port",
-"""
+            u"tub.port",
+b"""
 [node]
 {node_config}
 

--- a/src/allmydata/test/data/test_node/test_tahoe_cfg_utf8/tahoe.cfg
+++ b/src/allmydata/test/data/test_node/test_tahoe_cfg_utf8/tahoe.cfg
@@ -1,0 +1,2 @@
+﻿[node]
+nickname = ☡

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -75,13 +75,15 @@ from .matchers import (
 
 SOME_FURL = b"pb://abcde@nowhere/fake"
 
-BASECONFIG = ("[client]\n"
-              "introducer.furl = \n"
-              )
+BASECONFIG = (
+    b"[client]\n"
+    b"introducer.furl = \n"
+)
 
-BASECONFIG_I = ("[client]\n"
-              "introducer.furl = %s\n"
-              )
+BASECONFIG_I = (
+    b"[client]\n"
+    b"introducer.furl = %s\n"
+)
 
 class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
     def test_loadable(self):
@@ -165,11 +167,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
     def test_error_on_old_config_files(self):
         basedir = "test_client.Basic.test_error_on_old_config_files"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"),
-                       BASECONFIG +
-                       "[storage]\n" +
-                       "enabled = false\n" +
-                       "reserved_space = bogus\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG +
+            b"[storage]\n" +
+            b"enabled = false\n" +
+            b"reserved_space = bogus\n",
+        )
         fileutil.write(os.path.join(basedir, "introducer.furl"), "")
         fileutil.write(os.path.join(basedir, "no_storage"), "")
         fileutil.write(os.path.join(basedir, "readonly_storage"), "")
@@ -241,8 +245,10 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = "test_client.Basic.test_nodekey_no_storage"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"),
-                       BASECONFIG + "[storage]\n" + "enabled = false\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG + b"[storage]\n" + b"enabled = false\n",
+        )
         c = yield client.create_client(basedir)
         self.failUnless(c.get_long_nodeid().startswith("v0-"))
 
@@ -252,11 +258,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         is not set.
         """
         config = client.config_from_string(
-            "test_storage_default_anonymous_enabled",
-            "tub.port",
+            b"test_storage_default_anonymous_enabled",
+            b"tub.port",
             BASECONFIG + (
-                "[storage]\n"
-                "enabled = true\n"
+                b"[storage]\n"
+                b"enabled = true\n"
             )
         )
         self.assertTrue(client.anonymous_storage_enabled(config))
@@ -268,11 +274,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         config = client.config_from_string(
             self.id(),
-            "tub.port",
+            b"tub.port",
             BASECONFIG + (
-                "[storage]\n"
-                "enabled = true\n"
-                "anonymous = true\n"
+                b"[storage]\n"
+                b"enabled = true\n"
+                b"anonymous = true\n"
             )
         )
         self.assertTrue(client.anonymous_storage_enabled(config))
@@ -284,11 +290,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         config = client.config_from_string(
             self.id(),
-            "tub.port",
+            b"tub.port",
             BASECONFIG + (
-                "[storage]\n"
-                "enabled = true\n"
-                "anonymous = false\n"
+                b"[storage]\n"
+                b"enabled = true\n"
+                b"anonymous = false\n"
             )
         )
         self.assertFalse(client.anonymous_storage_enabled(config))
@@ -300,11 +306,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         config = client.config_from_string(
             self.id(),
-            "tub.port",
+            b"tub.port",
             BASECONFIG + (
-                "[storage]\n"
-                "enabled = false\n"
-                "anonymous = true\n"
+                b"[storage]\n"
+                b"enabled = false\n"
+                b"anonymous = true\n"
             )
         )
         self.assertFalse(client.anonymous_storage_enabled(config))
@@ -316,11 +322,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = "client.Basic.test_reserved_1"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
-                           BASECONFIG + \
-                           "[storage]\n" + \
-                           "enabled = true\n" + \
-                           "reserved_space = 1000\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG +
+            b"[storage]\n" +
+            b"enabled = true\n" +
+            b"reserved_space = 1000\n",
+        )
         c = yield client.create_client(basedir)
         self.failUnlessEqual(c.getServiceNamed("storage").reserved_space, 1000)
 
@@ -331,11 +339,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = "client.Basic.test_reserved_2"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"),  \
-                           BASECONFIG + \
-                           "[storage]\n" + \
-                           "enabled = true\n" + \
-                           "reserved_space = 10K\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG +
+            b"[storage]\n" +
+            b"enabled = true\n" +
+            b"reserved_space = 10K\n",
+        )
         c = yield client.create_client(basedir)
         self.failUnlessEqual(c.getServiceNamed("storage").reserved_space, 10*1000)
 
@@ -346,11 +356,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = "client.Basic.test_reserved_3"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
-                           BASECONFIG + \
-                           "[storage]\n" + \
-                           "enabled = true\n" + \
-                           "reserved_space = 5mB\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG +
+            b"[storage]\n" +
+            b"enabled = true\n" +
+            b"reserved_space = 5mB\n",
+        )
         c = yield client.create_client(basedir)
         self.failUnlessEqual(c.getServiceNamed("storage").reserved_space,
                              5*1000*1000)
@@ -362,11 +374,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = "client.Basic.test_reserved_4"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
-                           BASECONFIG + \
-                           "[storage]\n" + \
-                           "enabled = true\n" + \
-                           "reserved_space = 78Gb\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG +
+            b"[storage]\n" +
+            b"enabled = true\n" +
+            b"reserved_space = 78Gb\n",
+        )
         c = yield client.create_client(basedir)
         self.failUnlessEqual(c.getServiceNamed("storage").reserved_space,
                              78*1000*1000*1000)
@@ -378,11 +392,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = "client.Basic.test_reserved_bad"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
-                           BASECONFIG + \
-                           "[storage]\n" + \
-                           "enabled = true\n" + \
-                           "reserved_space = bogus\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"), \
+            BASECONFIG + \
+            b"[storage]\n" + \
+            b"enabled = true\n" + \
+            b"reserved_space = bogus\n",
+        )
         with self.assertRaises(ValueError):
             yield client.create_client(basedir)
 
@@ -410,11 +426,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = u"client.Basic.test_web_staticdir"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"),
-                       BASECONFIG +
-                       "[node]\n" +
-                       "web.port = tcp:0:interface=127.0.0.1\n" +
-                       "web.static = relative\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG +
+            b"[node]\n" +
+            b"web.port = tcp:0:interface=127.0.0.1\n" +
+            b"web.static = relative\n",
+        )
         c = yield client.create_client(basedir)
         w = c.getServiceNamed("webish")
         abs_basedir = fileutil.abspath_expanduser_unicode(basedir)
@@ -449,12 +467,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = u"client.Basic.test_ftp_auth_keyfile"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"),
-                       (BASECONFIG +
-                        "[ftpd]\n"
-                        "enabled = true\n"
-                        "port = tcp:0:interface=127.0.0.1\n"
-                        "accounts.file = private/accounts\n"))
+        fileutil.write(os.path.join(basedir, "tahoe.cfg"), (
+            BASECONFIG +
+            b"[ftpd]\n"
+            b"enabled = true\n"
+            b"port = tcp:0:interface=127.0.0.1\n"
+            b"accounts.file = private/accounts\n"
+        ))
         os.mkdir(os.path.join(basedir, "private"))
         fileutil.write(os.path.join(basedir, "private", "accounts"), "\n")
         c = yield client.create_client(basedir) # just make sure it can be instantiated
@@ -467,12 +486,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = u"client.Basic.test_ftp_auth_url"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"),
-                       (BASECONFIG +
-                        "[ftpd]\n"
-                        "enabled = true\n"
-                        "port = tcp:0:interface=127.0.0.1\n"
-                        "accounts.url = http://0.0.0.0/\n"))
+        fileutil.write(os.path.join(basedir, "tahoe.cfg"), (
+            BASECONFIG +
+            b"[ftpd]\n"
+            b"enabled = true\n"
+            b"port = tcp:0:interface=127.0.0.1\n"
+            b"accounts.url = http://0.0.0.0/\n"
+        ))
         c = yield client.create_client(basedir) # just make sure it can be instantiated
         del c
 
@@ -483,11 +503,12 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = u"client.Basic.test_ftp_auth_no_accountfile_or_url"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"),
-                       (BASECONFIG +
-                        "[ftpd]\n"
-                        "enabled = true\n"
-                        "port = tcp:0:interface=127.0.0.1\n"))
+        fileutil.write(os.path.join(basedir, "tahoe.cfg"), (
+            BASECONFIG +
+            b"[ftpd]\n"
+            b"enabled = true\n"
+            b"port = tcp:0:interface=127.0.0.1\n"
+        ))
         with self.assertRaises(NeedRootcapLookupScheme):
             yield client.create_client(basedir)
 
@@ -501,13 +522,13 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         fileutil.write(
             cfg_path,
             BASECONFIG +
-            "[storage]\n"
-            "enabled = true\n",
+            b"[storage]\n"
+            b"enabled = true\n",
         )
         if storage_path is not None:
             fileutil.write(
                 cfg_path,
-                "storage_dir = %s\n" % (storage_path,),
+                b"storage_dir = %s\n" % (storage_path,),
                 mode="ab",
         )
         c = yield client.create_client(basedir)
@@ -615,10 +636,12 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         """
         basedir = "test_client.Basic.test_versions"
         os.mkdir(basedir)
-        fileutil.write(os.path.join(basedir, "tahoe.cfg"), \
-                           BASECONFIG + \
-                           "[storage]\n" + \
-                           "enabled = true\n")
+        fileutil.write(
+            os.path.join(basedir, "tahoe.cfg"),
+            BASECONFIG +
+            b"[storage]\n" +
+            b"enabled = true\n",
+        )
         c = yield client.create_client(basedir)
         ss = c.getServiceNamed("storage")
         verdict = ss.remote_get_version()
@@ -652,10 +675,10 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
             self.failUnlessEqual(furl, expected_furl)
 
         yield _check("", None)
-        yield _check("helper.furl =\n", None)
-        yield _check("helper.furl = \n", None)
-        yield _check("helper.furl = None", None)
-        yield _check("helper.furl = pb://blah\n", "pb://blah")
+        yield _check(b"helper.furl =\n", None)
+        yield _check(b"helper.furl = \n", None)
+        yield _check(b"helper.furl = None", None)
+        yield _check(b"helper.furl = pb://blah\n", "pb://blah")
 
 
 def flush_but_dont_ignore(res):
@@ -680,11 +703,11 @@ class AnonymousStorage(SyncTestCase):
         os.makedirs(basedir + b"/private")
         config = client.config_from_string(
             basedir,
-            "tub.port",
+            b"tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                "[storage]\n"
-                "enabled = true\n"
-                "anonymous = true\n"
+                b"[storage]\n"
+                b"enabled = true\n"
+                b"anonymous = true\n"
             )
         )
         node = yield client.create_client_from_config(
@@ -711,11 +734,11 @@ class AnonymousStorage(SyncTestCase):
         os.makedirs(basedir + b"/private")
         config = client.config_from_string(
             basedir,
-            "tub.port",
+            b"tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                "[storage]\n"
-                "enabled = true\n"
-                "anonymous = false\n"
+                b"[storage]\n"
+                b"enabled = true\n"
+                b"anonymous = false\n"
             )
         )
         node = yield client.create_client_from_config(
@@ -732,7 +755,7 @@ class AnonymousStorage(SyncTestCase):
             ]),
         )
         self.expectThat(
-            config.get_private_config("storage.furl", default=None),
+            config.get_private_config(b"storage.furl", default=None),
             Is(None),
         )
 
@@ -748,18 +771,18 @@ class AnonymousStorage(SyncTestCase):
         os.makedirs(basedir + b"/private")
         enabled_config = client.config_from_string(
             basedir,
-            "tub.port",
+            b"tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                "[storage]\n"
-                "enabled = true\n"
-                "anonymous = true\n"
+                b"[storage]\n"
+                b"enabled = true\n"
+                b"anonymous = true\n"
             )
         )
         node = yield client.create_client_from_config(
             enabled_config,
             _introducer_factory=MemoryIntroducerClient,
         )
-        anonymous_storage_furl = enabled_config.get_private_config("storage.furl")
+        anonymous_storage_furl = enabled_config.get_private_config(b"storage.furl")
         def check_furl():
             return node.tub.getReferenceForURL(anonymous_storage_furl)
         # Perform a sanity check that our test code makes sense: is this a
@@ -772,11 +795,11 @@ class AnonymousStorage(SyncTestCase):
 
         disabled_config = client.config_from_string(
             basedir,
-            "tub.port",
+            b"tub.port",
             BASECONFIG_I % (SOME_FURL,) + (
-                "[storage]\n"
-                "enabled = true\n"
-                "anonymous = false\n"
+                b"[storage]\n"
+                b"enabled = true\n"
+                b"anonymous = false\n"
             )
         )
         node = yield client.create_client_from_config(
@@ -797,8 +820,8 @@ class IntroducerClients(unittest.TestCase):
         create_introducer_clients to fail.
         """
         cfg = (
-            "[client]\n"
-            "introducer.furl = None\n"
+            b"[client]\n"
+            b"introducer.furl = None\n"
         )
         config = client.config_from_string("basedir", "client.port", cfg)
 
@@ -1137,8 +1160,8 @@ class StorageAnnouncementTests(SyncTestCase):
         create_node_dir(self.basedir, u"")
 
 
-    def get_config(self, storage_enabled, more_storage="", more_sections=""):
-        return """
+    def get_config(self, storage_enabled, more_storage=b"", more_sections=b""):
+        return b"""
 [node]
 tub.location = tcp:192.0.2.0:1234
 
@@ -1163,7 +1186,7 @@ introducer.furl = pb://abcde@nowhere/fake
         """
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(storage_enabled=False),
         )
         self.assertThat(
@@ -1185,7 +1208,7 @@ introducer.furl = pb://abcde@nowhere/fake
         """
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(storage_enabled=True),
         )
         client_deferred = client.create_client_from_config(
@@ -1217,13 +1240,13 @@ introducer.furl = pb://abcde@nowhere/fake
         value = u"thing"
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage="plugins=tahoe-lafs-dummy-v1",
+                more_storage=b"plugins=tahoe-lafs-dummy-v1",
                 more_sections=(
-                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-                    "some = {}\n".format(value)
+                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    b"some = {}\n".format(value)
                 ),
             ),
         )
@@ -1258,15 +1281,15 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage="plugins=tahoe-lafs-dummy-v1,tahoe-lafs-dummy-v2",
+                more_storage=b"plugins=tahoe-lafs-dummy-v1,tahoe-lafs-dummy-v2",
                 more_sections=(
-                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-                    "some = thing-1\n"
-                    "[storageserver.plugins.tahoe-lafs-dummy-v2]\n"
-                    "some = thing-2\n"
+                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    b"some = thing-1\n"
+                    b"[storageserver.plugins.tahoe-lafs-dummy-v2]\n"
+                    b"some = thing-2\n"
                 ),
             ),
         )
@@ -1306,13 +1329,13 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage="plugins=tahoe-lafs-dummy-v1",
+                more_storage=b"plugins=tahoe-lafs-dummy-v1",
                 more_sections=(
-                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
-                    "some = thing\n"
+                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    b"some = thing\n"
                 ),
             ),
         )
@@ -1342,10 +1365,10 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage="plugins=tahoe-lafs-dummy-v1",
+                more_storage=b"plugins=tahoe-lafs-dummy-v1",
             ),
         )
         self.assertThat(
@@ -1380,14 +1403,14 @@ introducer.furl = pb://abcde@nowhere/fake
 
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage="plugins=tahoe-lafs-dummy-v1",
+                more_storage=b"plugins=tahoe-lafs-dummy-v1",
                 more_sections=(
-                    "[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
+                    b"[storageserver.plugins.tahoe-lafs-dummy-v1]\n"
                     # This will make it explode on instantiation.
-                    "invalid = configuration\n"
+                    b"invalid = configuration\n"
                 )
             ),
         )
@@ -1407,10 +1430,10 @@ introducer.furl = pb://abcde@nowhere/fake
         """
         config = client.config_from_string(
             self.basedir,
-            "tub.port",
+            u"tub.port",
             self.get_config(
                 storage_enabled=True,
-                more_storage="plugins=tahoe-lafs-dummy-vX",
+                more_storage=b"plugins=tahoe-lafs-dummy-vX",
             ),
         )
         self.assertThat(

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -11,7 +11,7 @@ from ..util.i2p_provider import create as create_i2p_provider
 from ..util.tor_provider import create as create_tor_provider
 
 
-BASECONFIG = ""
+BASECONFIG = b""
 
 
 class TCP(unittest.TestCase):
@@ -35,7 +35,7 @@ class Tor(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[tor]\nenabled = false\n",
+            BASECONFIG + b"[tor]\nenabled = false\n",
         )
         tor_provider = create_tor_provider(reactor, config)
         h = tor_provider.get_tor_handler()
@@ -62,7 +62,7 @@ class Tor(unittest.TestCase):
 
     def _do_test_launch(self, executable):
         # the handler is created right away
-        config = BASECONFIG+"[tor]\nlaunch = true\n"
+        config = BASECONFIG + b"[tor]\nlaunch = true\n"
         if executable:
             config += "tor.executable = %s\n" % executable
         h1 = mock.Mock()
@@ -109,7 +109,10 @@ class Tor(unittest.TestCase):
             config = config_from_string(
                 "fake.port",
                 "no-basedir",
-                BASECONFIG + "[tor]\nsocks.port = unix:/var/lib/fw-daemon/tor_socks.socket\n",
+                (
+                    BASECONFIG +
+                    b"[tor]\nsocks.port = unix:/var/lib/fw-daemon/tor_socks.socket\n"
+                ),
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -123,7 +126,7 @@ class Tor(unittest.TestCase):
             config = config_from_string(
                 "fake.port",
                 "no-basedir",
-                BASECONFIG + "[tor]\nsocks.port = tcp:127.0.0.1:1234\n",
+                BASECONFIG + b"[tor]\nsocks.port = tcp:127.0.0.1:1234\n",
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -137,7 +140,7 @@ class Tor(unittest.TestCase):
             config = config_from_string(
                 "no-basedir",
                 "fake.port",
-                BASECONFIG + "[tor]\nsocks.port = tcp:otherhost:1234\n",
+                BASECONFIG + b"[tor]\nsocks.port = tcp:otherhost:1234\n",
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -148,7 +151,7 @@ class Tor(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[tor]\nsocks.port = meow:unsupported\n",
+            BASECONFIG + b"[tor]\nsocks.port = meow:unsupported\n",
         )
         with self.assertRaises(ValueError) as ctx:
             tor_provider = create_tor_provider(reactor, config)
@@ -162,7 +165,7 @@ class Tor(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[tor]\nsocks.port = tcp:localhost:kumquat\n",
+            BASECONFIG + b"[tor]\nsocks.port = tcp:localhost:kumquat\n",
         )
         with self.assertRaises(ValueError) as ctx:
             tor_provider = create_tor_provider(reactor, config)
@@ -179,7 +182,7 @@ class Tor(unittest.TestCase):
             config = config_from_string(
                 "fake.port",
                 "no-basedir",
-                BASECONFIG + "[tor]\ncontrol.port = tcp:localhost:1234\n",
+                BASECONFIG + b"[tor]\ncontrol.port = tcp:localhost:1234\n",
             )
             tor_provider = create_tor_provider(reactor, config)
             h = tor_provider.get_tor_handler()
@@ -194,7 +197,7 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[i2p]\nenabled = false\n",
+            BASECONFIG + b"[i2p]\nenabled = false\n",
         )
         i2p_provider = create_i2p_provider(None, config)
         h = i2p_provider.get_i2p_handler()
@@ -226,7 +229,7 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[i2p]\nsam.port = tcp:localhost:1234\n",
+            BASECONFIG + b"[i2p]\nsam.port = tcp:localhost:1234\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.sam_endpoint",
@@ -243,8 +246,12 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "no-basedir",
             "fake.port",
-            BASECONFIG + "[i2p]\n" +
-            "sam.port = tcp:localhost:1234\n" + "launch = true\n",
+            (
+                BASECONFIG +
+                b"[i2p]\n" +
+                b"sam.port = tcp:localhost:1234\n" +
+                b"launch = true\n"
+            ),
         )
         with self.assertRaises(ValueError) as ctx:
             i2p_provider = create_i2p_provider(reactor, config)
@@ -258,7 +265,7 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[i2p]\nlaunch = true\n",
+            BASECONFIG + b"[i2p]\nlaunch = true\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -273,7 +280,11 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.executable = i2p\n",
+            (
+                BASECONFIG +
+                b"[i2p]\nlaunch = true\n" +
+                b"i2p.executable = i2p\n"
+            ),
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -288,7 +299,11 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.configdir = cfg\n",
+            (
+                BASECONFIG +
+                b"[i2p]\nlaunch = true\n" +
+                b"i2p.configdir = cfg\n"
+            ),
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -303,8 +318,12 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "no-basedir",
             "fake.port",
-            BASECONFIG + "[i2p]\nlaunch = true\n" +
-            "i2p.executable = i2p\n" + "i2p.configdir = cfg\n",
+            (
+                BASECONFIG +
+                b"[i2p]\nlaunch = true\n" +
+                b"i2p.executable = i2p\n" +
+                b"i2p.configdir = cfg\n"
+            ),
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.launch",
@@ -319,7 +338,7 @@ class I2P(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[i2p]\ni2p.configdir = cfg\n",
+            BASECONFIG + b"[i2p]\ni2p.configdir = cfg\n",
         )
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.i2p.local_i2p",
@@ -346,7 +365,7 @@ class Connections(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[connections]\ntcp = tor\n",
+            BASECONFIG + b"[connections]\ntcp = tor\n",
         )
         default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
 
@@ -360,7 +379,7 @@ class Connections(unittest.TestCase):
             self.config = config_from_string(
                 "fake.port",
                 "no-basedir",
-                BASECONFIG + "[connections]\ntcp = tor\n",
+                BASECONFIG + b"[connections]\ntcp = tor\n",
             )
             with self.assertRaises(ValueError) as ctx:
                 tor_provider = create_tor_provider(reactor, self.config)
@@ -376,7 +395,7 @@ class Connections(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[connections]\ntcp = unknown\n",
+            BASECONFIG + b"[connections]\ntcp = unknown\n",
         )
         with self.assertRaises(ValueError) as ctx:
             create_connection_handlers(None, config, mock.Mock(), mock.Mock())
@@ -387,7 +406,7 @@ class Connections(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[connections]\ntcp = disabled\n",
+            BASECONFIG + b"[connections]\ntcp = disabled\n",
         )
         default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertEqual(default_connection_handlers["tcp"], None)
@@ -400,7 +419,7 @@ class Privacy(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[node]\nreveal-IP-address = false\n",
+            BASECONFIG + b"[node]\nreveal-IP-address = false\n",
         )
 
         with self.assertRaises(PrivacyError) as ctx:
@@ -415,8 +434,11 @@ class Privacy(unittest.TestCase):
         config = config_from_string(
             "no-basedir",
             "fake.port",
-            BASECONFIG + "[connections]\ntcp = disabled\n" +
-            "[node]\nreveal-IP-address = false\n",
+            (
+                BASECONFIG +
+                b"[connections]\ntcp = disabled\n" +
+                b"[node]\nreveal-IP-address = false\n"
+            ),
         )
         default_connection_handlers, _ = create_connection_handlers(None, config, mock.Mock(), mock.Mock())
         self.assertEqual(default_connection_handlers["tcp"], None)
@@ -425,7 +447,7 @@ class Privacy(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[node]\nreveal-IP-address = false\n",
+            BASECONFIG + b"[node]\nreveal-IP-address = false\n",
         )
 
         with self.assertRaises(PrivacyError) as ctx:
@@ -439,7 +461,10 @@ class Privacy(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=tcp:hostname:1234\n",
+            (
+                BASECONFIG +
+                b"[node]\nreveal-IP-address = false\ntub.location=tcp:hostname:1234\n"
+            ),
         )
         with self.assertRaises(PrivacyError) as ctx:
             _tub_portlocation(config)
@@ -452,7 +477,10 @@ class Privacy(unittest.TestCase):
         config = config_from_string(
             "fake.port",
             "no-basedir",
-            BASECONFIG + "[node]\nreveal-IP-address = false\ntub.location=hostname:1234\n",
+            (
+                BASECONFIG +
+                b"[node]\nreveal-IP-address = false\ntub.location=hostname:1234\n"
+            ),
         )
 
         with self.assertRaises(PrivacyError) as ctx:

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -3,6 +3,7 @@ import os
 import stat
 import sys
 import time
+import shutil
 import mock
 from textwrap import dedent
 
@@ -149,15 +150,20 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
 
     def test_tahoe_cfg_utf8(self):
         basedir = "test_node/test_tahoe_cfg_utf8"
-        fileutil.make_dirs(basedir)
-        f = open(os.path.join(basedir, 'tahoe.cfg'), 'wt')
-        f.write(u"\uFEFF[node]\n".encode('utf-8'))
-        f.write(u"nickname = \u2621\n".encode('utf-8'))
-        f.close()
+        shutil.copytree(
+            os.path.join(os.path.dirname(__file__), "data", basedir),
+            basedir,
+        )
 
         config = read_config(basedir, "")
-        self.failUnlessEqual(config.get_config("node", "nickname").decode('utf-8'),
-                             u"\u2621")
+        expected = u"\u2621"
+        if PY2:
+            expected = expected.encode("utf-8")
+        self.failUnlessEqual(
+            config.get_config("node", "nickname"),
+            expected,
+            "Wrong node configuration value with unicode character",
+        )
 
     def test_tahoe_cfg_hash_in_name(self):
         basedir = "test_node/test_cfg_hash_in_name"

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -1,3 +1,20 @@
+"""
+Tests for the `allmydata.node` module.
+
+This module has been ported to Python 3.
+"""
+
+# Python 2 backwards compatibility
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
+from future.utils import PY2
+if PY2:
+    from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: # F401, F811
+
 import base64
 import os
 import stat
@@ -8,11 +25,6 @@ import mock
 from textwrap import dedent
 
 from unittest import skipIf
-
-# Python 2 backwards compatibility
-from future.utils import PY2
-if PY2:
-    from future.builtins import bytes
 
 from twisted.trial import unittest
 from twisted.internet import defer

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -184,7 +184,7 @@ class IntroducerRootTests(unittest.TestCase):
         The JSON response includes totals for the number of subscriptions and
         announcements of each service type.
         """
-        config = node.config_from_string(self.mktemp(), "", "")
+        config = node.config_from_string(self.mktemp(), "", b"")
         config.get_private_path = lambda ignored: self.mktemp()
         main_tub = Tub()
         main_tub.listenOn(b"tcp:0")

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -10,6 +10,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from future.utils import PY3
 from future.utils import PY2
 if PY2:
     # We don't do open(), because we want files to read/write native strs when
@@ -25,6 +26,9 @@ else:
     from configparser import SafeConfigParser
 
 import attr
+
+BOM_CHARACTER = u"\uFEFF"
+
 
 
 class UnknownConfigError(Exception):
@@ -45,7 +49,11 @@ def get_config(tahoe_cfg):
         # On Python 2, where we read in bytes, skip any initial Byte Order
         # Mark. Since this is an ordinary file, we don't need to handle
         # incomplete reads, and can assume seekability.
-        if PY2 and f.read(3) != b'\xEF\xBB\xBF':
+        if (
+                (PY3 and f.read(1) != BOM_CHARACTER)
+                or
+                (PY2 and f.read(3) != BOM_CHARACTER.encode("utf-8"))
+        ):
             f.seek(0)
         config.readfp(f)
     return config


### PR DESCRIPTION
Working on the `allmydata.test.test_node` definitely involves some of the spaghetti
dependencies as described in the porting wiki page.  It's been difficult to track down
and resolve all the impacts elsewhere in the full Python 3 test suite, but I'm
reasonably confident that these changes are moving in the right direction.  There are
still some failures under Python 3 in `allmydata.test.test_node` so porting that module
isn't done yet.

As requested, I've pared down the detail in my commit messages and I assume we don't
want them included here in the PR for the same reasons.  I've kept such notes elsewhere,
so LMK what you'd like elaboration on.