### PR TITLE
Keep future.builtins imports consistent

### DIFF
--- a/src/allmydata/test/test_uri.py
+++ b/src/allmydata/test/test_uri.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:
-    from future.builtins import filter, map, zip, ascii, chr, dict, hex, input, next, oct, open, pow, round, super, bytes, int, list, object, range, str, max, min  # noqa: F401
+    from future.builtins import filter, map, zip, ascii, chr, dict, hex, input, next, oct, open, pow, round, super, bytes, list, object, range, str, max, min  # noqa: F401
 
 import os
 from twisted.trial import unittest

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:
+    # open is not here because we want to use native strings on Py2
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 import six
 import os, time, sys


### PR DESCRIPTION
Much simpler alternative to #854 for https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3467.

- remove int from a stock import
- comment a non-stock import