### PR TITLE
3477 Do not install vcpython27 during Windows CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,6 @@ jobs:
 
     steps:
 
-      # Get vcpython27 on Windows + Python 2.7, to build zfec
-      # extension.  See https://chocolatey.org/packages/vcpython27 and
-      # https://github.com/crazy-max/ghaction-chocolatey
-      - name: Install MSVC 9.0 for Python 2.7 [Windows]
-        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install vcpython27
-
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
 
@@ -92,12 +83,6 @@ jobs:
         with:
           args: install tor
 
-      - name: Install MSVC 9.0 for Python 2.7 [Windows]
-        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install vcpython27
-
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
 
@@ -140,15 +125,6 @@ jobs:
           - 2.7
 
     steps:
-
-      # Get vcpython27 on Windows + Python 2.7, to build zfec
-      # extension.  See https://chocolatey.org/packages/vcpython27 and
-      # https://github.com/crazy-max/ghaction-chocolatey
-      - name: Install MSVC 9.0 for Python 2.7 [Windows]
-        if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install vcpython27
 
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes [3477](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3477):  with zfec ~~1.5.4~~ 1.5.5, wheel packages for Windows is available now.  Installing a compiler is no longer necessary.

Update, on Nov 12 2020: Turned out that zfec 1.5.4 wheel package for Windows + Python 2.7 was broken.  I have tested zfec 1.5.5 a little more on Windows.  I updated cibuildwheel version that builds zfec packages, added a step to check that the package cibuildwheel just built is actually usable, and did some manual testing on Windows and macOS.  Finally, re-running Tahoe's test suite on GitHub Actions confirms that this time zfec is usable.