### PR TITLE
Backported configparser for Python 2

### DIFF
--- a/nix/tahoe-lafs.nix
+++ b/nix/tahoe-lafs.nix
@@ -4,7 +4,7 @@
 , setuptools, setuptoolsTrial, pyasn1, zope_interface
 , service-identity, pyyaml, magic-wormhole, treq, appdirs
 , beautifulsoup4, eliot, autobahn, cryptography
-, html5lib, pyutil, distro
+, html5lib, pyutil, distro, configparser
 }:
 python.pkgs.buildPythonPackage rec {
   version = "1.14.0.dev";
@@ -50,7 +50,7 @@ python.pkgs.buildPythonPackage rec {
     setuptoolsTrial pyasn1 zope_interface
     service-identity pyyaml magic-wormhole treq
     eliot autobahn cryptography setuptools
-    future pyutil distro
+    future pyutil distro configparser
   ];
 
   checkInputs = with python.pkgs; [

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ install_requires = [
     "distro >= 1.4.0",
 
     # Backported configparser for Python 2:
-    "configparser >= 4.0.0 ; python_version < '3.0'",
+    "configparser ; python_version < '3.0'",
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,9 @@ install_requires = [
 
     # Linux distribution detection:
     "distro >= 1.4.0",
+
+    # Backported configparser for Python 2:
+    "configparser >= 5.0.1 ; python_version < '3.0'",
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ install_requires = [
     "distro >= 1.4.0",
 
     # Backported configparser for Python 2:
-    "configparser >= 5.0.1 ; python_version < '3.0'",
+    "configparser >= 4.0.0 ; python_version < '3.0'",
 ]
 
 setup_requires = [

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -717,6 +717,9 @@ class _Client(node.Node, pollmixin.PollMixin):
 
     def init_stats_provider(self):
         gatherer_furl = self.config.get_config("client", "stats_gatherer.furl", None)
+        if gatherer_furl:
+            # FURLs should be bytes:
+            gatherer_furl = gatherer_furl.encode("utf-8")
         self.stats_provider = StatsProvider(self, gatherer_furl)
         self.stats_provider.setServiceParent(self)
         self.stats_provider.register_producer(self)

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -2,10 +2,9 @@ import os, stat, time, weakref
 from base64 import urlsafe_b64encode
 from functools import partial
 from errno import ENOENT, EPERM
-try:
-    from ConfigParser import NoSectionError
-except ImportError:
-    from configparser import NoSectionError
+
+# On Python 2 this will be the backported package:
+from configparser import NoSectionError
 
 from foolscap.furl import (
     decode_furl,

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -34,8 +34,7 @@ from allmydata.util import (
     hashutil, base32, pollmixin, log, idlib,
     yamlutil, configutil,
 )
-from allmydata.util.encodingutil import (get_filesystem_encoding,
-                                         from_utf8_or_none)
+from allmydata.util.encodingutil import get_filesystem_encoding
 from allmydata.util.abbreviate import parse_abbreviated_size
 from allmydata.util.time_format import parse_duration, parse_date
 from allmydata.util.i2p_provider import create as create_i2p_provider
@@ -805,7 +804,7 @@ class _Client(node.Node, pollmixin.PollMixin):
 
         config_storedir = self.get_config(
             "storage", "storage_dir", self.STOREDIR,
-        ).decode('utf-8')
+        )
         storedir = self.config.get_config_path(config_storedir)
 
         data = self.config.get_config("storage", "reserved_space", None)
@@ -1042,15 +1041,14 @@ class _Client(node.Node, pollmixin.PollMixin):
 
         from allmydata.webish import WebishServer
         nodeurl_path = self.config.get_config_path("node.url")
-        staticdir_config = self.config.get_config("node", "web.static", "public_html").decode("utf-8")
+        staticdir_config = self.config.get_config("node", "web.static", "public_html")
         staticdir = self.config.get_config_path(staticdir_config)
         ws = WebishServer(self, webport, nodeurl_path, staticdir)
         ws.setServiceParent(self)
 
     def init_ftp_server(self):
         if self.config.get_config("ftpd", "enabled", False, boolean=True):
-            accountfile = from_utf8_or_none(
-                self.config.get_config("ftpd", "accounts.file", None))
+            accountfile = self.config.get_config("ftpd", "accounts.file", None)
             if accountfile:
                 accountfile = self.config.get_config_path(accountfile)
             accounturl = self.config.get_config("ftpd", "accounts.url", None)
@@ -1062,14 +1060,13 @@ class _Client(node.Node, pollmixin.PollMixin):
 
     def init_sftp_server(self):
         if self.config.get_config("sftpd", "enabled", False, boolean=True):
-            accountfile = from_utf8_or_none(
-                self.config.get_config("sftpd", "accounts.file", None))
+            accountfile = self.config.get_config("sftpd", "accounts.file", None)
             if accountfile:
                 accountfile = self.config.get_config_path(accountfile)
             accounturl = self.config.get_config("sftpd", "accounts.url", None)
             sftp_portstr = self.config.get_config("sftpd", "port", "8022")
-            pubkey_file = from_utf8_or_none(self.config.get_config("sftpd", "host_pubkey_file"))
-            privkey_file = from_utf8_or_none(self.config.get_config("sftpd", "host_privkey_file"))
+            pubkey_file = self.config.get_config("sftpd", "host_pubkey_file")
+            privkey_file = self.config.get_config("sftpd", "host_privkey_file")
 
             from allmydata.frontends import sftpd
             s = sftpd.SFTPServer(self, accountfile, accounturl,

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -936,6 +936,10 @@ class _Client(node.Node, pollmixin.PollMixin):
         if helper_furl in ("None", ""):
             helper_furl = None
 
+        # FURLs need to be bytes:
+        if helper_furl is not None:
+            helper_furl = helper_furl.encode("utf-8")
+
         DEP = self.encoding_params
         DEP["k"] = int(self.config.get_config("client", "shares.needed", DEP["k"]))
         DEP["n"] = int(self.config.get_config("client", "shares.total", DEP["n"]))

--- a/src/allmydata/frontends/ftpd.py
+++ b/src/allmydata/frontends/ftpd.py
@@ -1,3 +1,4 @@
+from six import ensure_str
 
 from types import NoneType
 
@@ -333,5 +334,7 @@ class FTPServer(service.MultiService):
             raise NeedRootcapLookupScheme("must provide some translation")
 
         f = ftp.FTPFactory(p)
+        # strports requires a native string.
+        ftp_portstr = ensure_str(ftp_portstr)
         s = strports.service(ftp_portstr, f)
         s.setServiceParent(self)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -184,7 +184,7 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config=None):
 
     # (try to) read the main config file
     config_fname = os.path.join(basedir, "tahoe.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     try:
         parser = configutil.get_config(config_fname)
     except EnvironmentError as e:
@@ -207,7 +207,7 @@ def config_from_string(basedir, portnumfile, config_str, _valid_config=None):
         _valid_config = _common_valid_config()
 
     # load configuration from in-memory string
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     if isinstance(config_str, bytes):
         config_str = config_str.decode("utf-8")
     parser.read_string(config_str)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -3,6 +3,7 @@ This module contains classes and functions to implement and manage
 a node for Tahoe-LAFS.
 """
 from past.builtins import unicode
+from six import ensure_str
 
 import datetime
 import os.path
@@ -640,6 +641,10 @@ def _tub_portlocation(config):
             new_locations.append(loc)
     location = ",".join(new_locations)
 
+    # Lacking this, Python 2 blows up in PB when it is confused by a Unicode
+    # FURL.
+    location = location.encode("utf-8")
+
     return tubport, location
 
 
@@ -687,6 +692,9 @@ def create_main_tub(config, tub_options,
                 port_or_endpoint = tor_provider.get_listener()
             else:
                 port_or_endpoint = port
+            # Foolscap requires native strings:
+            if isinstance(port_or_endpoint, (bytes, unicode)):
+                port_or_endpoint = ensure_str(port_or_endpoint)
             tub.listenOn(port_or_endpoint)
         tub.setLocation(location)
         log.msg("Tub location set to %s" % (location,))

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -184,12 +184,13 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config=None):
 
     # (try to) read the main config file
     config_fname = os.path.join(basedir, "tahoe.cfg")
-    parser = configparser.ConfigParser()
     try:
         parser = configutil.get_config(config_fname)
     except EnvironmentError as e:
         if e.errno != errno.ENOENT:
             raise
+        # The file is missing, just create empty ConfigParser.
+        parser = configutil.create_parser()
 
     configutil.validate_config(config_fname, parser, _valid_config)
 
@@ -207,7 +208,7 @@ def config_from_string(basedir, portnumfile, config_str, _valid_config=None):
         _valid_config = _common_valid_config()
 
     # load configuration from in-memory string
-    parser = configparser.ConfigParser()
+    parser = configutil.create_parser()
     if isinstance(config_str, bytes):
         config_str = config_str.decode("utf-8")
     parser.read_string(config_str)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -13,8 +13,9 @@ from io import StringIO
 import tempfile
 from base64 import b32decode, b32encode
 
-# Python 2 compatibility
-from six.moves import configparser
+# On Python 2 this will be the backported package.
+import configparser
+
 from future.utils import PY2
 if PY2:
     from io import BytesIO as StringIO  # noqa: F811

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -190,7 +190,7 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config=None):
         if e.errno != errno.ENOENT:
             raise
         # The file is missing, just create empty ConfigParser.
-        parser = configutil.create_parser()
+        parser = configutil.get_config_from_string(u"")
 
     configutil.validate_config(config_fname, parser, _valid_config)
 
@@ -207,11 +207,11 @@ def config_from_string(basedir, portnumfile, config_str, _valid_config=None):
     if _valid_config is None:
         _valid_config = _common_valid_config()
 
-    # load configuration from in-memory string
-    parser = configutil.create_parser()
     if isinstance(config_str, bytes):
         config_str = config_str.decode("utf-8")
-    parser.read_string(config_str)
+
+    # load configuration from in-memory string
+    parser = configutil.get_config_from_string(config_str)
 
     fname = "<in-memory>"
     configutil.validate_config(fname, parser, _valid_config)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -10,16 +10,11 @@ import os.path
 import re
 import types
 import errno
-from io import StringIO
 import tempfile
 from base64 import b32decode, b32encode
 
 # On Python 2 this will be the backported package.
 import configparser
-
-from future.utils import PY2
-if PY2:
-    from io import BytesIO as StringIO  # noqa: F811
 
 from twisted.python import log as twlog
 from twisted.application import service
@@ -213,7 +208,9 @@ def config_from_string(basedir, portnumfile, config_str, _valid_config=None):
 
     # load configuration from in-memory string
     parser = configparser.SafeConfigParser()
-    parser.readfp(StringIO(config_str))
+    if isinstance(config_str, bytes):
+        config_str = config_str.decode("utf-8")
+    parser.read_string(config_str)
 
     fname = "<in-memory>"
     configutil.validate_config(fname, parser, _valid_config)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -638,8 +638,8 @@ def _tub_portlocation(config):
             new_locations.append(loc)
     location = ",".join(new_locations)
 
-    # Lacking this, Python 2 blows up in PB when it is confused by a Unicode
-    # FURL.
+    # Lacking this, Python 2 blows up in Foolscap when it is confused by a
+    # Unicode FURL.
     location = location.encode("utf-8")
 
     return tubport, location

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -848,6 +848,7 @@ class Node(service.MultiService):
         lgfurl = self.config.get_config("node", "log_gatherer.furl", "")
         if lgfurl:
             # this is in addition to the contents of log-gatherer-furlfile
+            lgfurl = lgfurl.encode("utf-8")
             self.log_tub.setOption("log-gatherer-furl", lgfurl)
         self.log_tub.setOption("log-gatherer-furlfile",
                                self.config.get_config_path("log_gatherer.furl"))

--- a/src/allmydata/scripts/common.py
+++ b/src/allmydata/scripts/common.py
@@ -8,7 +8,9 @@ from os.path import join
 from future.utils import PY2
 if PY2:
     from future.builtins import str  # noqa: F401
-from six.moves.configparser import NoSectionError
+
+# On Python 2 this will be the backported package:
+from configparser import NoSectionError
 
 from twisted.python import usage
 

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -31,12 +31,10 @@ the foolscap-based server implemented in src/allmydata/storage/*.py .
 from past.builtins import unicode
 
 import re, time, hashlib
-try:
-    from ConfigParser import (
-        NoSectionError,
-    )
-except ImportError:
-    from configparser import NoSectionError
+
+# On Python 2 this will be the backport.
+from configparser import NoSectionError
+
 import attr
 from zope.interface import (
     Attribute,

--- a/src/allmydata/test/test_configutil.py
+++ b/src/allmydata/test/test_configutil.py
@@ -154,3 +154,12 @@ enabled = false
             self.dynamic_valid_config,
         )
         self.assertIn("section [node] contains unknown option 'invalid'", str(e))
+
+    def test_duplicate_sections(self):
+        """
+        Duplicate section names are merged.
+        """
+        fname = self.create_tahoe_cfg('[node]\na = foo\n[node]\n b = bar\n')
+        config = configutil.get_config(fname)
+        self.assertEqual(config.get("node", "a"), "foo")
+        self.assertEqual(config.get("node", "b"), "bar")

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -168,7 +168,11 @@ class Tor(unittest.TestCase):
             tor_provider = create_tor_provider(reactor, config)
             tor_provider.get_tor_handler()
         self.assertIn(
-            "invalid literal for int() with base 10: 'kumquat'",
+            "invalid literal for int()",
+            str(ctx.exception)
+        )
+        self.assertIn(
+            "kumquat",
             str(ctx.exception)
         )
 

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -151,7 +151,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         f.close()
 
         config = read_config(basedir, "")
-        self.failUnlessEqual(config.get_config("node", "nickname").decode('utf-8'),
+        self.failUnlessEqual(config.get_config("node", "nickname"),
                              u"\u2621")
 
     def test_tahoe_cfg_hash_in_name(self):

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -35,15 +35,11 @@ def get_config(tahoe_cfg):
     Configuration is returned as native strings.
     """
     config = SafeConfigParser(strict=False)
-    with open(tahoe_cfg, "r") as f:
-        # Who put the BOM in the BOM SHOO BOP SHOO BOP.
-        #
-        # Byte Order Mark is an optional garbage byte you sometimes get at the
-        # start of UTF-8 encoded files. Especially on Windows. Skip it.
-        # https://en.wikipedia.org/wiki/Byte_order_mark
-        if f.read(1) != u'\uFEFF':
-            f.seek(0)
-        config.readfp(f)
+    # Byte Order Mark is an optional garbage byte you sometimes get at the
+    # start of UTF-8 encoded files. Especially on Windows. Skip it by using
+    # utf-8-sig. https://en.wikipedia.org/wiki/Byte_order_mark
+    with open(tahoe_cfg, "r", encoding="utf-8-sig") as f:
+        config.read_file(f)
     return config
 
 def set_config(config, section, option, value):

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -1,7 +1,7 @@
 """
 Read/write config files.
 
-Configuration is returned as native strings.
+Configuration is returned as Unicode strings.
 
 Ported to Python 3.
 """
@@ -32,11 +32,11 @@ class UnknownConfigError(Exception):
 def get_config(tahoe_cfg):
     """Load the config, returning a ConfigParser.
 
-    Configuration is returned as native strings.
+    Configuration is returned as Unicode strings.
     """
     config = ConfigParser(strict=False)
-    # Byte Order Mark is an optional garbage byte you sometimes get at the
-    # start of UTF-8 encoded files. Especially on Windows. Skip it by using
+    # Byte Order Mark is an optional garbage code point you sometimes get at
+    # the start of UTF-8 encoded files. Especially on Windows. Skip it by using
     # utf-8-sig. https://en.wikipedia.org/wiki/Byte_order_mark
     with open(tahoe_cfg, "r", encoding="utf-8-sig") as f:
         config.read_file(f)

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -16,7 +16,7 @@ if PY2:
 
 # On Python 2 we use the backport package; that means we always get unicode
 # out.
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 import attr
 
@@ -30,11 +30,11 @@ class UnknownConfigError(Exception):
 
 
 def get_config(tahoe_cfg):
-    """Load the config, returning a SafeConfigParser.
+    """Load the config, returning a ConfigParser.
 
     Configuration is returned as native strings.
     """
-    config = SafeConfigParser(strict=False)
+    config = ConfigParser(strict=False)
     # Byte Order Mark is an optional garbage byte you sometimes get at the
     # start of UTF-8 encoded files. Especially on Windows. Skip it by using
     # utf-8-sig. https://en.wikipedia.org/wiki/Byte_order_mark

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -12,9 +12,7 @@ from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:
-    # We don't do open(), because we want files to read/write native strs when
-    # we do "r" or "w".
-    from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
+    from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 
 # On Python 2 we use the backport package; that means we always get unicode
 # out.
@@ -38,10 +36,12 @@ def get_config(tahoe_cfg):
     """
     config = SafeConfigParser()
     with open(tahoe_cfg, "r") as f:
-        # On Python 2, where we read in bytes, skip any initial Byte Order
-        # Mark. Since this is an ordinary file, we don't need to handle
-        # incomplete reads, and can assume seekability.
-        if PY2 and f.read(3) != b'\xEF\xBB\xBF':
+        # Who put the BOM in the BOM SHOO BOP SHOO BOP.
+        #
+        # Byte Order Mark is an optional garbage byte you sometimes get at the
+        # start of UTF-8 encoded files. Especially on Windows. Skip it.
+        # https://en.wikipedia.org/wiki/Byte_order_mark
+        if f.read(1) != u'\uFEFF':
             f.seek(0)
         config.readfp(f)
     return config

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -16,13 +16,9 @@ if PY2:
     # we do "r" or "w".
     from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 
-if PY2:
-    # In theory on Python 2 configparser also works, but then code gets the
-    # wrong exceptions and they don't get handled. So just use native parser
-    # for now.
-    from ConfigParser import SafeConfigParser
-else:
-    from configparser import SafeConfigParser
+# On Python 2 we use the backport package; that means we always get unicode
+# out.
+from configparser import SafeConfigParser
 
 import attr
 

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -29,26 +29,28 @@ class UnknownConfigError(Exception):
     """
 
 
-def create_parser():
-    """
-    Create a ConfigParser pre-configured the way we want it, for consistency
-    across different code paths.
-    """
-    return ConfigParser(strict=False)
-
-
 def get_config(tahoe_cfg):
     """Load the config, returning a ConfigParser.
 
     Configuration is returned as Unicode strings.
     """
-    config = create_parser()
     # Byte Order Mark is an optional garbage code point you sometimes get at
     # the start of UTF-8 encoded files. Especially on Windows. Skip it by using
     # utf-8-sig. https://en.wikipedia.org/wiki/Byte_order_mark
     with open(tahoe_cfg, "r", encoding="utf-8-sig") as f:
-        config.read_file(f)
-    return config
+        cfg_string = f.read()
+    return get_config_from_string(cfg_string)
+
+
+def get_config_from_string(tahoe_cfg_string):
+    """Load the config from a string, return the ConfigParser.
+
+    Configuration is returned as Unicode strings.
+    """
+    parser = ConfigParser(strict=False)
+    parser.read_string(tahoe_cfg_string)
+    return parser
+
 
 def set_config(config, section, option, value):
     if not config.has_section(section):

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -34,7 +34,7 @@ def get_config(tahoe_cfg):
 
     Configuration is returned as native strings.
     """
-    config = SafeConfigParser()
+    config = SafeConfigParser(strict=False)
     with open(tahoe_cfg, "r") as f:
         # Who put the BOM in the BOM SHOO BOP SHOO BOP.
         #

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -29,12 +29,20 @@ class UnknownConfigError(Exception):
     """
 
 
+def create_parser():
+    """
+    Create a ConfigParser pre-configured the way we want it, for consistency
+    across different code paths.
+    """
+    return ConfigParser(strict=False)
+
+
 def get_config(tahoe_cfg):
     """Load the config, returning a ConfigParser.
 
     Configuration is returned as Unicode strings.
     """
-    config = ConfigParser(strict=False)
+    config = create_parser()
     # Byte Order Mark is an optional garbage code point you sometimes get at
     # the start of UTF-8 encoded files. Especially on Windows. Skip it by using
     # utf-8-sig. https://en.wikipedia.org/wiki/Byte_order_mark

--- a/src/allmydata/webish.py
+++ b/src/allmydata/webish.py
@@ -1,3 +1,5 @@
+from six import ensure_str
+
 import re, time
 
 from functools import (
@@ -186,6 +188,8 @@ class WebishServer(service.MultiService):
             self.root.putChild("static", static.File(staticdir))
         if re.search(r'^\d', webport):
             webport = "tcp:"+webport # twisted warns about bare "0" or "3456"
+        # strports must be native strings.
+        webport = ensure_str(webport)
         s = strports.service(webport, self.site)
         s.setServiceParent(self)
 


### PR DESCRIPTION
This will make Python 3 porting easier, since it makes configs always unicode.

My guess is this will break some integration tests, so leaving as draft until I see full run.

Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3485#ticket