### PR TITLE
Port allmydata.node to python 3

### DIFF
--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -131,7 +131,7 @@ def _valid_config():
     return cfg.update(_client_config)
 
 # this is put into README in new node-directories
-CLIENT_README = """
+CLIENT_README = u"""
 This directory contains files which contain private data for the Tahoe node,
 such as private keys.  On Unix-like systems, the permissions on this directory
 are set to disallow users other than its owner from reading the contents of
@@ -512,7 +512,7 @@ def create_introducer_clients(config, main_tub, _introducer_factory=None):
             config.nickname,
             str(allmydata.__full_version__),
             str(_Client.OLDEST_SUPPORTED_VERSION),
-            node.get_app_versions(),
+            list(node.get_app_versions()),
             partial(_sequencer, config),
             introducer_cache_filepath,
         )

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -277,13 +277,8 @@ class _Config(object):
         self._basedir = abspath_expanduser_unicode(unicode(basedir))
         self._config_fname = config_fname
         self.config = configparser
-
-        nickname_utf8 = self.get_config("node", "nickname", "<unspecified>")
-        if isinstance(nickname_utf8, bytes):  # Python 2
-            self.nickname = nickname_utf8.decode("utf-8")
-        else:
-            self.nickname = nickname_utf8
-        assert type(self.nickname) is unicode
+        self.nickname = self.get_config("node", "nickname", u"<unspecified>")
+        assert isinstance(self.nickname, unicode)
 
     def validate(self, valid_config_sections):
         configutil.validate_config(self._config_fname, self.config, valid_config_sections)

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -311,7 +311,7 @@ class _Config(object):
                 return self.config.getboolean(section, option)
 
             item = self.config.get(section, option)
-            if option.endswith(".furl") and self._contains_unescaped_hash(item):
+            if option.endswith(".furl") and '#' in item:
                 raise UnescapedHashError(section, option, item)
 
             return item

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals
 from future.utils import PY2
 if PY2:
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
-from six import ensure_str
+from six import ensure_str, ensure_text
 
 import datetime
 import os.path
@@ -181,7 +181,7 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config=None):
 
     :returns: :class:`allmydata.node._Config` instance
     """
-    basedir = abspath_expanduser_unicode(ensure_str(basedir))
+    basedir = abspath_expanduser_unicode(ensure_text(basedir))
     if _valid_config is None:
         _valid_config = _common_valid_config()
 
@@ -283,7 +283,7 @@ class _Config(object):
             configparser (might be 'fake' if using in-memory data)
         """
         self.portnum_fname = portnum_fname
-        self._basedir = abspath_expanduser_unicode(ensure_str(basedir))
+        self._basedir = abspath_expanduser_unicode(ensure_text(basedir))
         self._config_fname = config_fname
         self.config = configparser
         self.nickname = self.get_config("node", "nickname", u"<unspecified>")

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -1,6 +1,8 @@
 """
 This module contains classes and functions to implement and manage
 a node for Tahoe-LAFS.
+
+Ported to Python 3.
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -424,17 +426,6 @@ class _Config(object):
         return abspath_expanduser_unicode(
             os.path.join(self._basedir, *args)
         )
-
-    @staticmethod
-    def _contains_unescaped_hash(item):
-        characters = iter(item)
-        for c in characters:
-            if c == '\\':
-                next(characters)
-            elif c == '#':
-                return True
-
-        return False
 
 
 def create_tub_options(config):

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -106,8 +106,8 @@ def formatTimeTahoeStyle(self, when):
     """
     d = datetime.datetime.utcfromtimestamp(when)
     if d.microsecond:
-        return d.isoformat(" ")[:-3]+"Z"
-    return d.isoformat(" ") + ".000Z"
+        return d.isoformat(ensure_str(" "))[:-3]+"Z"
+    return d.isoformat(ensure_str(" ")) + ".000Z"
 
 PRIV_README = """
 This directory contains files which contain private data for the Tahoe node,
@@ -161,6 +161,7 @@ def create_node_dir(basedir, readme_text):
     privdir = os.path.join(basedir, "private")
     if not os.path.exists(privdir):
         fileutil.make_dirs(privdir, 0o700)
+        readme_text = ensure_text(readme_text)
         with open(os.path.join(privdir, 'README'), 'w') as f:
             f.write(readme_text)
 

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -2,7 +2,14 @@
 This module contains classes and functions to implement and manage
 a node for Tahoe-LAFS.
 """
-from past.builtins import unicode
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from future.utils import PY2
+if PY2:
+    from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 from six import ensure_str
 
 import datetime
@@ -71,7 +78,7 @@ def _common_valid_config():
 
 # Add our application versions to the data that Foolscap's LogPublisher
 # reports.
-for thing, things_version in get_package_versions().items():
+for thing, things_version in list(get_package_versions().items()):
     app_versions.add_version(thing, things_version)
 
 # group 1 will be addr (dotted quad string), group 3 if any will be portnum (string)
@@ -172,7 +179,7 @@ def read_config(basedir, portnumfile, generated_files=[], _valid_config=None):
 
     :returns: :class:`allmydata.node._Config` instance
     """
-    basedir = abspath_expanduser_unicode(unicode(basedir))
+    basedir = abspath_expanduser_unicode(ensure_str(basedir))
     if _valid_config is None:
         _valid_config = _common_valid_config()
 
@@ -274,11 +281,11 @@ class _Config(object):
             configparser (might be 'fake' if using in-memory data)
         """
         self.portnum_fname = portnum_fname
-        self._basedir = abspath_expanduser_unicode(unicode(basedir))
+        self._basedir = abspath_expanduser_unicode(ensure_str(basedir))
         self._config_fname = config_fname
         self.config = configparser
         self.nickname = self.get_config("node", "nickname", u"<unspecified>")
-        assert isinstance(self.nickname, unicode)
+        assert isinstance(self.nickname, str)
 
     def validate(self, valid_config_sections):
         configutil.validate_config(self._config_fname, self.config, valid_config_sections)
@@ -363,8 +370,8 @@ class _Config(object):
                 raise MissingConfigEntry("The required configuration file %s is missing."
                                          % (quote_output(privname),))
             if isinstance(default, bytes):
-                default = unicode(default, "utf-8")
-            if isinstance(default, unicode):
+                default = str(default, "utf-8")
+            if isinstance(default, str):
                 value = default
             else:
                 value = default()
@@ -376,7 +383,7 @@ class _Config(object):
         config file that resides within the subdirectory named 'private'), and
         return it.
         """
-        if isinstance(value, unicode):
+        if isinstance(value, str):
             value = value.encode("utf-8")
         privname = os.path.join(self._basedir, "private", name)
         with open(privname, "wb") as f:
@@ -423,7 +430,7 @@ class _Config(object):
         characters = iter(item)
         for c in characters:
             if c == '\\':
-                characters.next()
+                next(characters)
             elif c == '#':
                 return True
 
@@ -531,12 +538,12 @@ def create_tub(tub_options, default_connection_handlers, foolscap_connection_han
         the new Tub via `Tub.setOption`
     """
     tub = Tub(**kwargs)
-    for (name, value) in tub_options.items():
+    for (name, value) in list(tub_options.items()):
         tub.setOption(name, value)
     handlers = default_connection_handlers.copy()
     handlers.update(handler_overrides)
     tub.removeAllConnectionHintHandlers()
-    for hint_type, handler_name in handlers.items():
+    for hint_type, handler_name in list(handlers.items()):
         handler = foolscap_connection_handlers.get(handler_name)
         if handler:
             tub.addConnectionHintHandler(hint_type, handler)
@@ -693,7 +700,7 @@ def create_main_tub(config, tub_options,
             else:
                 port_or_endpoint = port
             # Foolscap requires native strings:
-            if isinstance(port_or_endpoint, (bytes, unicode)):
+            if isinstance(port_or_endpoint, (bytes, str)):
                 port_or_endpoint = ensure_str(port_or_endpoint)
             tub.listenOn(port_or_endpoint)
         tub.setLocation(location)

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -112,11 +112,11 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_comment(self):
         """
-        An unescaped comment character (#) in a furl results in an
+        A comment character (#) in a furl results in an
         UnescapedHashError Failure.
         """
-        should_fail = [r"test#test", r"#testtest", r"test\\#test"]
-        should_not_fail = [r"test\#test", r"test\\\#test", r"testtest"]
+        should_fail = [r"test#test", r"#testtest", r"test\\#test", r"test\#test",
+                       r"test\\\#test"]
 
         basedir = "test_client.Basic.test_comment"
         os.mkdir(basedir)
@@ -127,16 +127,10 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
             fileutil.write(os.path.join(basedir, "tahoe.cfg"), config)
 
         for s in should_fail:
-            self.failUnless(_Config._contains_unescaped_hash(s))
             write_config(s)
             with self.assertRaises(UnescapedHashError) as ctx:
                 yield client.create_client(basedir)
             self.assertIn("[client]introducer.furl", str(ctx.exception))
-
-        for s in should_not_fail:
-            self.failIf(_Config._contains_unescaped_hash(s))
-            write_config(s)
-            yield client.create_client(basedir)
 
     def test_unreadable_config(self):
         if sys.platform == "win32":

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -39,7 +39,7 @@ from testtools.twistedsupport import (
 import allmydata
 import allmydata.util.log
 
-from allmydata.node import OldConfigError, UnescapedHashError, _Config, create_node_dir
+from allmydata.node import OldConfigError, UnescapedHashError, create_node_dir
 from allmydata.frontends.auth import NeedRootcapLookupScheme
 from allmydata.version_checks import (
     get_package_versions_string,

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -847,20 +847,3 @@ class CreateConnectionHandlers(unittest.TestCase):
             reactor, config, provider, provider
         )
         self.assertIs(default_handlers["tcp"], None)
-
-    def test_reveal_ip_tcp(self):
-        """
-        If reveal IP setting is false, TCP handler is not allowed.
-        """
-        config = config_from_string("", "", dedent("""
-        [node]
-        reveal-IP-address = False
-
-        [connections]
-        tcp = tcp
-        """))
-        reactor = object()  # it's not actually used?!
-        provider = FakeProvider()
-        with self.assertRaises(PrivacyError):
-            create_connection_handlers(reactor, config, provider, provider)
-

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -40,7 +40,6 @@ from allmydata.node import (
     _tub_portlocation,
     formatTimeTahoeStyle,
     UnescapedHashError,
-    PrivacyError,
 )
 from allmydata.introducer.server import create_introducer
 from allmydata import client

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -185,7 +185,6 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         """
         Hashes in furl options are not allowed, resulting in exception.
         """
-        escaped = "lalal\\#onohash"
         basedir = self.mktemp()
         fileutil.make_dirs(basedir)
         with open(os.path.join(basedir, 'tahoe.cfg'), 'wt') as f:
@@ -195,11 +194,6 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         config = read_config(basedir, "")
         with self.assertRaises(UnescapedHashError):
             config.get_config("node", "log_gatherer.furl")
-
-        with open(os.path.join(basedir, 'tahoe.cfg'), 'wt') as f:
-            f.write("[node]\n")
-            f.write("log_gatherer.furl = %s\n" % (escaped,))
-        self.assertEquals(config.get_config("node", "log_gatherer.furl"), escaped)
 
     def test_missing_config_item(self):
         """

--- a/src/allmydata/util/_python3.py
+++ b/src/allmydata/util/_python3.py
@@ -51,6 +51,7 @@ PORTED_MODULES = [
     "allmydata.interfaces",
     "allmydata.introducer.interfaces",
     "allmydata.monitor",
+    "allmydata.node",
     "allmydata.storage.common",
     "allmydata.storage.crawler",
     "allmydata.storage.expirer",


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3493#ticket

The tests ported to Python 3 don't have complete test coverage:

1. Some coverage was missing. This PR adds a few tests for some of that.
2. test_connections.py has some more coverage, but hasn't been ported yet. Likely other code paths have test coverage too.

But I think it's OK to mark it ported even without those extra test modules, since it's fairly limited code paths.