### PR TITLE
Fix unicode version breakage

### DIFF
--- a/newsfragments/3509.bugfix
+++ b/newsfragments/3509.bugfix
@@ -1,0 +1,1 @@
+Fix regression that broke flogtool results on Python 2.

--- a/newsfragments/3510.bugfix
+++ b/newsfragments/3510.bugfix
@@ -1,0 +1,1 @@
+Fix a logging regression on Python 2 involving unicode strings.

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -79,9 +79,9 @@ def _common_valid_config():
     })
 
 # Add our application versions to the data that Foolscap's LogPublisher
-# reports.
+# reports. Foolscap requires native strings.
 for thing, things_version in list(get_package_versions().items()):
-    app_versions.add_version(thing, things_version)
+    app_versions.add_version(ensure_str(thing), ensure_str(things_version))
 
 # group 1 will be addr (dotted quad string), group 3 if any will be portnum (string)
 ADDR_RE = re.compile("^([1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*)(:([1-9][0-9]*))?$")

--- a/src/allmydata/test/test_log.py
+++ b/src/allmydata/test/test_log.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from future.utils import PY2
+from future.utils import PY2, native_str
 if PY2:
     from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 
@@ -154,3 +154,17 @@ class Log(unittest.TestCase):
         obj.log("four")
         self.assertEqual([m[2] for m in self.messages],
                          ["grand", "par1", "par2", "msg1", "msg1"])
+
+    def test_native_string_keys(self):
+        """Keyword argument keys are all native strings."""
+        class LoggingObject17(tahoe_log.PrefixingLogMixin):
+            pass
+
+        obj = LoggingObject17()
+        # Native string by default:
+        obj.log(hello="world")
+        # Will be Unicode on Python 2:
+        obj.log(**{"my": "message"})
+        for message in self.messages:
+            for k in message[-1].keys():
+                self.assertIsInstance(k, native_str)

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from future.utils import PY2
+from future.utils import PY2, native_str
 if PY2:
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 
@@ -46,6 +46,7 @@ from allmydata.node import (
     _tub_portlocation,
     formatTimeTahoeStyle,
     UnescapedHashError,
+    get_app_versions,
 )
 from allmydata.introducer.server import create_introducer
 from allmydata import client
@@ -99,6 +100,16 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         # try to bind the port.  We'll use a low-numbered one that's likely to
         # conflict with another service to prove it.
         self._available_port = 22
+
+    def test_application_versions(self):
+        """
+        Application versions should all have the same type, the native string.
+
+        This test is due to the Foolscap limitations, if Foolscap is fixed or
+        removed it can be deleted.
+        """
+        app_types = set(type(o) for o in get_app_versions())
+        self.assertEqual(app_types, {native_str})
 
     def _test_location(
             self,

--- a/src/allmydata/util/log.py
+++ b/src/allmydata/util/log.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 from future.utils import PY2
 if PY2:
     from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
+from six import ensure_str
 
 from pyutil import nummedobj
 
@@ -55,6 +56,7 @@ class LogMixin(object):
             pmsgid = self._parentmsgid
             if pmsgid is None:
                 pmsgid = self._grandparentmsgid
+        kwargs = {ensure_str(k): v for (k, v) in kwargs.items()}
         msgid = log.msg(msg, facility=facility, parent=pmsgid, *args, **kwargs)
         if self._parentmsgid is None:
             self._parentmsgid = msgid


### PR DESCRIPTION
Fix https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3509
Fix https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3510

(Was supposed to be two branches, but I pushed to wrong branch by mistake...)

Note that I was not able to reproduce 3510 due to unrelated issues, so I can't promise this fixes it... I am also confused why this happens at all, since Foolscap `Event` type sent in `RILogObserver` claims to be dict mapping `Any()` to `Any()`.