### PR TITLE
Remove mock usage from test_connections.py

### DIFF
--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -669,8 +669,8 @@ def create_connection_handlers(config, i2p_provider, tor_provider):
     # create that handler, so hints which want it will be ignored.
     handlers = {
         "tcp": _make_tcp_handler(),
-        "tor": tor_provider.get_tor_handler(),
-        "i2p": i2p_provider.get_i2p_handler(),
+        "tor": tor_provider.get_client_endpoint(),
+        "i2p": i2p_provider.get_client_endpoint(),
     }
     log.msg(
         format="built Foolscap connection handlers for: %(known_handlers)s",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -67,17 +67,6 @@ class CreateConnectionHandlersTests(SyncTestCase):
 
 class Tor(unittest.TestCase):
 
-    def test_default(self):
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.tor.default_socks",
-                        return_value=h1) as f:
-
-            config = config_from_string("fake.port", "no-basedir", BASECONFIG)
-            tor_provider = create_tor_provider(reactor, config)
-            h = tor_provider.get_tor_handler()
-        self.assertEqual(f.mock_calls, [mock.call()])
-        self.assertIdentical(h, h1)
-
     def _do_test_launch(self, executable):
         # the handler is created right away
         config = BASECONFIG+"[tor]\nlaunch = true\n"

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -189,21 +189,6 @@ class I2P(unittest.TestCase):
         self.assertEqual(f.mock_calls, [exp])
         self.assertIdentical(h, h1)
 
-    def test_launch_configdir(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.configdir = cfg\n",
-        )
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.i2p.launch",
-                        return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, config)
-            h = i2p_provider.get_i2p_handler()
-            exp = mock.call(i2p_configdir="cfg", i2p_binary=None)
-        self.assertEqual(f.mock_calls, [exp])
-        self.assertIdentical(h, h1)
-
     def test_launch_configdir_and_executable(self):
         config = config_from_string(
             "no-basedir",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -159,23 +159,6 @@ class Tor(unittest.TestCase):
 
 class I2P(unittest.TestCase):
 
-    def test_samport(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG + "[i2p]\nsam.port = tcp:localhost:1234\n",
-        )
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.i2p.sam_endpoint",
-                        return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, config)
-            h = i2p_provider.get_i2p_handler()
-
-        self.assertEqual(len(f.mock_calls), 1)
-        ep = f.mock_calls[0][1][0]
-        self.assertIsInstance(ep, endpoints.TCP4ClientEndpoint)
-        self.assertIdentical(h, h1)
-
     def test_samport_and_launch(self):
         config = config_from_string(
             "no-basedir",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -212,16 +212,6 @@ class Tor(unittest.TestCase):
 
 class I2P(unittest.TestCase):
 
-    def test_disabled(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG + "[i2p]\nenabled = false\n",
-        )
-        i2p_provider = create_i2p_provider(None, config)
-        h = i2p_provider.get_i2p_handler()
-        self.assertEqual(h, None)
-
     def test_unimportable(self):
         config = config_from_string(
             "fake.port",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -67,16 +67,6 @@ class CreateConnectionHandlersTests(SyncTestCase):
 
 class Tor(unittest.TestCase):
 
-    def test_disabled(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG + "[tor]\nenabled = false\n",
-        )
-        tor_provider = create_tor_provider(reactor, config)
-        h = tor_provider.get_tor_handler()
-        self.assertEqual(h, None)
-
     def test_unimportable(self):
         with mock.patch("allmydata.util.tor_provider._import_tor",
                         return_value=None):

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -103,9 +103,6 @@ class Tor(unittest.TestCase):
         cfs.assert_called_with(reactor, "ep_desc")
         self.assertIs(cep, tcep)
 
-    def test_launch(self):
-        self._do_test_launch(None)
-
     def test_launch_executable(self):
         self._do_test_launch("/special/tor")
 

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -212,18 +212,6 @@ class Tor(unittest.TestCase):
 
 class I2P(unittest.TestCase):
 
-    def test_unimportable(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG,
-        )
-        with mock.patch("allmydata.util.i2p_provider._import_i2p",
-                        return_value=None):
-            i2p_provider = create_i2p_provider(reactor, config)
-            h = i2p_provider.get_i2p_handler()
-        self.assertEqual(h, None)
-
     def test_default(self):
         config = config_from_string("fake.port", "no-basedir", BASECONFIG)
         h1 = mock.Mock()

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -67,14 +67,6 @@ class CreateConnectionHandlersTests(SyncTestCase):
 
 class Tor(unittest.TestCase):
 
-    def test_unimportable(self):
-        with mock.patch("allmydata.util.tor_provider._import_tor",
-                        return_value=None):
-            config = config_from_string("fake.port", "no-basedir", BASECONFIG)
-            tor_provider = create_tor_provider(reactor, config)
-            h = tor_provider.get_tor_handler()
-        self.assertEqual(h, None)
-
     def test_default(self):
         h1 = mock.Mock()
         with mock.patch("foolscap.connections.tor.default_socks",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -159,16 +159,6 @@ class Tor(unittest.TestCase):
 
 class I2P(unittest.TestCase):
 
-    def test_default(self):
-        config = config_from_string("fake.port", "no-basedir", BASECONFIG)
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.i2p.default",
-                        return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, config)
-            h = i2p_provider.get_i2p_handler()
-        self.assertEqual(f.mock_calls, [mock.call(reactor, keyfile=None)])
-        self.assertIdentical(h, h1)
-
     def test_samport(self):
         config = config_from_string(
             "fake.port",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -174,21 +174,6 @@ class I2P(unittest.TestCase):
             str(ctx.exception)
         )
 
-    def test_launch(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG + "[i2p]\nlaunch = true\n",
-        )
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.i2p.launch",
-                        return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, config)
-            h = i2p_provider.get_i2p_handler()
-            exp = mock.call(i2p_configdir=None, i2p_binary=None)
-        self.assertEqual(f.mock_calls, [exp])
-        self.assertIdentical(h, h1)
-
     def test_launch_executable(self):
         config = config_from_string(
             "fake.port",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -141,22 +141,6 @@ class Tor(unittest.TestCase):
             str(ctx.exception)
         )
 
-    def test_controlport(self):
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.tor.control_endpoint",
-                        return_value=h1) as f:
-            config = config_from_string(
-                "fake.port",
-                "no-basedir",
-                BASECONFIG + "[tor]\ncontrol.port = tcp:localhost:1234\n",
-            )
-            tor_provider = create_tor_provider(reactor, config)
-            h = tor_provider.get_tor_handler()
-            self.assertEqual(len(f.mock_calls), 1)
-            ep = f.mock_calls[0][1][0]
-            self.assertIsInstance(ep, endpoints.TCP4ClientEndpoint)
-            self.assertIdentical(h, h1)
-
 class I2P(unittest.TestCase):
 
     def test_samport_and_launch(self):

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -189,22 +189,6 @@ class I2P(unittest.TestCase):
         self.assertEqual(f.mock_calls, [exp])
         self.assertIdentical(h, h1)
 
-    def test_launch_configdir_and_executable(self):
-        config = config_from_string(
-            "no-basedir",
-            "fake.port",
-            BASECONFIG + "[i2p]\nlaunch = true\n" +
-            "i2p.executable = i2p\n" + "i2p.configdir = cfg\n",
-        )
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.i2p.launch",
-                        return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, config)
-            h = i2p_provider.get_i2p_handler()
-            exp = mock.call(i2p_configdir="cfg", i2p_binary="i2p")
-        self.assertEqual(f.mock_calls, [exp])
-        self.assertIdentical(h, h1)
-
     def test_configdir(self):
         config = config_from_string(
             "fake.port",

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -1,8 +1,6 @@
-import mock
 
 from twisted.trial import unittest
 from twisted.internet import reactor
-from twisted.internet.interfaces import IStreamClientEndpoint
 
 from foolscap.connections import tcp
 
@@ -65,48 +63,6 @@ class CreateConnectionHandlersTests(SyncTestCase):
 
 
 class Tor(unittest.TestCase):
-
-    def test_socksport_unix_endpoint(self):
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.tor.socks_endpoint",
-                        return_value=h1) as f:
-            config = config_from_string(
-                "fake.port",
-                "no-basedir",
-                BASECONFIG + "[tor]\nsocks.port = unix:/var/lib/fw-daemon/tor_socks.socket\n",
-            )
-            tor_provider = create_tor_provider(reactor, config)
-            h = tor_provider.get_tor_handler()
-        self.assertTrue(IStreamClientEndpoint.providedBy(f.mock_calls[0][1][0]))
-        self.assertIdentical(h, h1)
-
-    def test_socksport_endpoint(self):
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.tor.socks_endpoint",
-                        return_value=h1) as f:
-            config = config_from_string(
-                "fake.port",
-                "no-basedir",
-                BASECONFIG + "[tor]\nsocks.port = tcp:127.0.0.1:1234\n",
-            )
-            tor_provider = create_tor_provider(reactor, config)
-            h = tor_provider.get_tor_handler()
-        self.assertTrue(IStreamClientEndpoint.providedBy(f.mock_calls[0][1][0]))
-        self.assertIdentical(h, h1)
-
-    def test_socksport_endpoint_otherhost(self):
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.tor.socks_endpoint",
-                        return_value=h1) as f:
-            config = config_from_string(
-                "no-basedir",
-                "fake.port",
-                BASECONFIG + "[tor]\nsocks.port = tcp:otherhost:1234\n",
-            )
-            tor_provider = create_tor_provider(reactor, config)
-            h = tor_provider.get_tor_handler()
-        self.assertTrue(IStreamClientEndpoint.providedBy(f.mock_calls[0][1][0]))
-        self.assertIdentical(h, h1)
 
     def test_socksport_bad_endpoint(self):
         config = config_from_string(

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -189,20 +189,6 @@ class I2P(unittest.TestCase):
         self.assertEqual(f.mock_calls, [exp])
         self.assertIdentical(h, h1)
 
-    def test_configdir(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG + "[i2p]\ni2p.configdir = cfg\n",
-        )
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.i2p.local_i2p",
-                        return_value=h1) as f:
-            i2p_provider = create_i2p_provider(None, config)
-            h = i2p_provider.get_i2p_handler()
-
-        self.assertEqual(f.mock_calls, [mock.call("cfg")])
-        self.assertIdentical(h, h1)
 
 class Connections(unittest.TestCase):
 

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -174,22 +174,6 @@ class I2P(unittest.TestCase):
             str(ctx.exception)
         )
 
-    def test_launch_executable(self):
-        config = config_from_string(
-            "fake.port",
-            "no-basedir",
-            BASECONFIG + "[i2p]\nlaunch = true\n" + "i2p.executable = i2p\n",
-        )
-        h1 = mock.Mock()
-        with mock.patch("foolscap.connections.i2p.launch",
-                        return_value=h1) as f:
-            i2p_provider = create_i2p_provider(reactor, config)
-            h = i2p_provider.get_i2p_handler()
-            exp = mock.call(i2p_configdir=None, i2p_binary="i2p")
-        self.assertEqual(f.mock_calls, [exp])
-        self.assertIdentical(h, h1)
-
-
 class Connections(unittest.TestCase):
 
     def setUp(self):

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -277,6 +277,20 @@ class Provider(unittest.TestCase):
         i2p.local_i2p.assert_called_with("configdir")
         self.assertIs(h, handler)
 
+    def test_handler_launch_executable(self):
+        i2p = mock.Mock()
+        handler = object()
+        i2p.launch = mock.Mock(return_value=handler)
+        reactor = object()
+
+        with mock_i2p(i2p):
+            p = i2p_provider.create(reactor,
+                                    FakeConfig(launch=True,
+                                               **{"i2p.executable": "myi2p"}))
+        h = p.get_i2p_handler()
+        self.assertIs(h, handler)
+        i2p.launch.assert_called_with(i2p_configdir=None, i2p_binary="myi2p")
+
     def test_handler_default(self):
         i2p = mock.Mock()
         handler = object()

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -349,6 +349,10 @@ class Provider(unittest.TestCase):
                 cfs2.assert_called_with(reactor, ep_desc)
 
     def test_handler_socks_endpoint(self):
+        """
+        If not configured otherwise, the Tor provider returns a Socks-based
+        handler.
+        """
         tor = mock.Mock()
         handler = object()
         tor.socks_endpoint = mock.Mock(return_value=handler)

--- a/src/allmydata/test/test_tor_provider.py
+++ b/src/allmydata/test/test_tor_provider.py
@@ -369,6 +369,46 @@ class Provider(unittest.TestCase):
         tor.socks_endpoint.assert_called_with(ep)
         self.assertIs(h, handler)
 
+    def test_handler_socks_unix_endpoint(self):
+        """
+        ``socks.port`` can be configured as a UNIX client endpoint.
+        """
+        tor = mock.Mock()
+        handler = object()
+        tor.socks_endpoint = mock.Mock(return_value=handler)
+        ep = object()
+        cfs = mock.Mock(return_value=ep)
+        reactor = object()
+
+        with mock_tor(tor):
+            p = tor_provider.create(reactor,
+                                    FakeConfig(**{"socks.port": "unix:path"}))
+            with mock.patch("allmydata.util.tor_provider.clientFromString", cfs):
+                h = p.get_tor_handler()
+        cfs.assert_called_with(reactor, "unix:path")
+        tor.socks_endpoint.assert_called_with(ep)
+        self.assertIs(h, handler)
+
+    def test_handler_socks_tcp_endpoint(self):
+        """
+        ``socks.port`` can be configured as a UNIX client endpoint.
+        """
+        tor = mock.Mock()
+        handler = object()
+        tor.socks_endpoint = mock.Mock(return_value=handler)
+        ep = object()
+        cfs = mock.Mock(return_value=ep)
+        reactor = object()
+
+        with mock_tor(tor):
+            p = tor_provider.create(reactor,
+                                    FakeConfig(**{"socks.port": "tcp:127.0.0.1:1234"}))
+            with mock.patch("allmydata.util.tor_provider.clientFromString", cfs):
+                h = p.get_tor_handler()
+        cfs.assert_called_with(reactor, "tcp:127.0.0.1:1234")
+        tor.socks_endpoint.assert_called_with(ep)
+        self.assertIs(h, handler)
+
     def test_handler_control_endpoint(self):
         tor = mock.Mock()
         handler = object()


### PR DESCRIPTION
https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3529

A lot of the tests in this module that were using mock were extremely redundant with tests in other modules so I did a lot of deleting.  Individual commits in this history of this branch explain which tests I decided the deleted tests were duplicates of.

I also moved or rewrote some tests that to put them in modules where they seemed to fit better.  I didn't try to make them stop using mock because that would have been harder.  There are tickets filed for removing mock usage from those other modules already so I'll fix them when I get to those tickets.
