### PR TITLE
3591 Use pip cache in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: pip cache
+      - name: Use pip cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
@@ -135,7 +135,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: pip cache
+      - name: Use pip cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
@@ -200,7 +200,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: pip cache
+      - name: Use pip cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Get pip cache directory
         id: pip-cache
         run: |
+          pip --version
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Use pip cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python packages
-        run: |
-          pip install --upgrade codecov tox setuptools pip
-          pip list
-
       - name: Get pip cache directory
         id: pip-cache
         run: |
@@ -58,6 +53,11 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade codecov tox setuptools pip
+          pip list
 
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py
@@ -125,11 +125,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python packages
-        run: |
-          pip install --upgrade tox pip
-          pip list
-
       - name: Get pip cache directory
         id: pip-cache
         run: |
@@ -142,6 +137,11 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade tox pip
+          pip list
 
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py
@@ -190,11 +190,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python packages
-        run: |
-          pip install --upgrade tox pip
-          pip list
-
       - name: Get pip cache directory
         id: pip-cache
         run: |
@@ -207,6 +202,11 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade tox pip
+          pip list
 
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Get pip cache directory
         id: pip-cache
         run: |
-          pip --version
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Use pip cache
@@ -194,6 +193,7 @@ jobs:
       - name: Get pip cache directory
         id: pip-cache
         run: |
+          pip --version
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Use pip cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade codecov tox setuptools
+          pip install --upgrade codecov tox setuptools pip
           pip list
 
       - name: Display tool versions
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade tox
+          pip install --upgrade tox pip
           pip list
 
       - name: Display tool versions
@@ -166,7 +166,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade tox
+          pip install --upgrade tox pip
           pip list
 
       - name: Display tool versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,19 @@ jobs:
           pip install --upgrade codecov tox setuptools pip
           pip list
 
+      - name: Get pip cache directory
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py
 
@@ -117,6 +130,19 @@ jobs:
           pip install --upgrade tox pip
           pip list
 
+      - name: Get pip cache directory
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py
 
@@ -168,6 +194,19 @@ jobs:
         run: |
           pip install --upgrade tox pip
           pip list
+
+      - name: Get pip cache directory
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade codecov tox setuptools pip
+          pip install --upgrade codecov tox setuptools
           pip list
 
       - name: Display tool versions
@@ -145,7 +145,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade tox pip
+          pip install --upgrade tox
           pip list
 
       - name: Display tool versions
@@ -210,7 +210,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install --upgrade tox pip
+          pip install --upgrade tox
           pip list
 
       - name: Display tool versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,12 @@ jobs:
         with:
           args: install vcpython27
 
+      # See https://github.com/actions/checkout. A fetch-depth of 0
+      # fetches all tags and branches.
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
-
-      - name: Fetch all history for all tags and branches
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
@@ -121,9 +122,8 @@ jobs:
 
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
-
-      - name: Fetch all history for all tags and branches
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
@@ -186,9 +186,8 @@ jobs:
 
       - name: Check out Tahoe-LAFS sources
         uses: actions/checkout@v2
-
-      - name: Fetch all history for all tags and branches
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # We need "pip cache dir", which became a thing in pip v20.1+.
+      # At the time of writing this, GitHub Actions offers pip v20.3.3
+      # for both ubuntu-latest and windows-latest, and pip v20.3.1 for
+      # macos-latest.  Those are sufficiently recent pip versions that
+      # have "cache dir" sub-command.
       - name: Get pip cache directory
         id: pip-cache
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # We need "pip cache dir", which became a thing in pip v20.1+.
-      # At the time of writing this, GitHub Actions offers pip v20.3.3
-      # for both ubuntu-latest and windows-latest, and pip v20.3.1 for
-      # macos-latest.  Those are sufficiently recent pip versions that
-      # have "cache dir" sub-command.
+      # To use pip caching with GitHub Actions in an OS-independent
+      # manner, we need `pip cache dir` command, which became
+      # available since pip v20.1+.  At the time of writing this,
+      # GitHub Actions offers pip v20.3.3 for both ubuntu-latest and
+      # windows-latest, and pip v20.3.1 for macos-latest.
       - name: Get pip cache directory
         id: pip-cache
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
 
+      # See https://github.com/actions/cache
       - name: Use pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,6 @@ jobs:
       - name: Get pip cache directory
         id: pip-cache
         run: |
-          pip --version
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Use pip cache


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3591.

Some notes:

* We're using [actions/cache](https://github.com/actions/cache/blob/main/examples.md#python---pip) here.  Python-specific caching action requires pip 20.1+ because it implements `pip cache dir` command to get pip's cache directory in an OS-independent manner.  There's no perceivable overall speedup in CI completion time because of caching (possibly because we're in a noisy shared environment), but we'd be hammering pypi much less often than before, which is nice.

* Since we have steps containing `pip install --upgrade codecov tox setuptools`, we'd be still downloading some packages from PyPI.  We probably can do a `pip install codecov tox setuptools` instead, thus using cached versions of those packages, but I guess tracking their latest versions could be useful, because any breakage with them would surface early on.

* Piggy-backing on this PR is the removal of `git fetch --prune --unshallow` step, and addition of `fetch-depth: 0` parameter to `actions/checkout`.   Step with the former usually takes 10-20s, so avoiding that is nice.

What's the point of doing some (allegedly) pointless caching without some (almost pointless) numbers?  Well, we do have some numbers!

There's some meaningful difference in "installing Python packages" step, where we do a `pip install --upgrade codecov tox setuptools` for coverage tests, and `pip install --upgrade tox` for integration and packaging tests.  Comparing the tip of this PR branch (where caching enabled) versus base of this branch (where caching action is essentially a no-op):

| installing packages   | without caching | with caching |
:-----------------------|-----------------|--------------|
| coverage (macos)      | 1m 24s          | 12s          |
| coverage (windows)    | 21s             | 19s          |
| integration (macos)   | 11s             | 6s           |
| integration (windows) | 21s             | 9s           |
| packaging (macos)     | 45s             | 6s           |
| packaging (windows)   | 20s             | 9s           |
| packaging (ubuntu)    | 9s              | 6s           |

And here are the overall CI completion times, which are kind of all over the place:

|                       | without caching | with caching |
|-----------------------|-----------------|--------------|
| coverage (macos)      | 18m 57s         | 13m 55s      |
| coverage (windows)    | 14m 3s          | 16m 43s      |
| integration (macos)   | 4m 33s          | 3m 23s       |
| integration (windows) | 6m 34s          | 5m 26s       |
| packaging (macos)     | 3m 56s          | 5m 20s       |
| packaging (windows)   | 6m 9s           | 5m 59s       |
| packaging (ubuntu)    | 1m 40s          | 1m 28s       |

Looks like the time-consuming step is the actual running of tests.