### PR TITLE
Use `sphinx_rtd_theme` when building docs locally

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark']
+extensions = ['recommonmark', 'sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -107,7 +107,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/tox.ini
+++ b/tox.ini
@@ -230,6 +230,7 @@ deps =
      sphinx
      docutils==0.12
      recommonmark
+     sphinx_rtd_theme
 # normal install is not needed for docs, and slows things down
 skip_install = True
 commands =


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3631.

Default theme that Sphinx uses is not consistent with what we have at https://tahoe-lafs.readthedocs.io.  Using the same theme as readthedocs.org might help a little bit more when we preview changes to docs locally.

Screenshots below, to show just what it is that I am talking about. :-)

---

Before:

![image](https://user-images.githubusercontent.com/23618/110536288-4a7a4c00-80ef-11eb-9f3f-d64e94c72238.png)

----

After:

![image](https://user-images.githubusercontent.com/23618/110542245-cfb52f00-80f6-11eb-8b30-70d56336d383.png)