### PR TITLE
Build docs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,6 +458,18 @@ jobs:
           command: |
             /tmp/venv/bin/tox -e typechecks
 
+  docs:
+    docker:
+      - <<: *DOCKERHUB_AUTH
+        image: "tahoelafsci/ubuntu:18.04-py3"
+
+    steps:
+      - "checkout"
+      - run:
+          name: "Build documentation"
+          command: |
+            /tmp/venv/bin/tox -e docs
+
   build-image: &BUILD_IMAGE
     # This is a template for a job to build a Docker image that has as much of
     # the setup as we can manage already done and baked in.  This cuts down on

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ workflows:
       - "typechecks":
           <<: *DOCKERHUB_CONTEXT
 
+      - "docs":
+          <<: *DOCKERHUB_CONTEXT
+
   images:
     # Build the Docker images used by the ci jobs.  This makes the ci jobs
     # faster and takes various spurious failures out of the critical path.


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3632.

We could just as well use readthedocs.org's "build pull requests" feature for this.  But it is not working yet for us, presumably because there are a few more buttons to click.