### PR TITLE
Use forked release of txi2p

### DIFF
--- a/newsfragments/3633.installation
+++ b/newsfragments/3633.installation
@@ -1,0 +1,1 @@
+Tahoe-LAFS now uses a forked version of txi2p (named txi2p-tahoe) with Python 3 support.

--- a/setup.py
+++ b/setup.py
@@ -151,8 +151,10 @@ tor_requires = [
 ]
 
 i2p_requires = [
-    # txi2p has Python 3 support, but it's unreleased: https://github.com/str4d/txi2p/issues/10.
-    "txi2p; python_version < '3.0'",
+    # txi2p has Python 3 support, but it's unreleased (see
+    # https://github.com/str4d/txi2p/issues/10). We could use a fork until
+    # txi2p's maintainers are back in action.
+    "txi2p-tahoe",
 ]
 
 if len(sys.argv) > 1 and sys.argv[1] == '--fakedependency':

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ i2p_requires = [
     # txi2p has Python 3 support, but it's unreleased (see
     # https://github.com/str4d/txi2p/issues/10). We could use a fork until
     # txi2p's maintainers are back in action.
-    "txi2p-tahoe",
+    "txi2p-tahoe >= 0.3.5",
 ]
 
 if len(sys.argv) > 1 and sys.argv[1] == '--fakedependency':

--- a/setup.py
+++ b/setup.py
@@ -151,10 +151,13 @@ tor_requires = [
 ]
 
 i2p_requires = [
-    # txi2p has Python 3 support, but it's unreleased (see
-    # https://github.com/str4d/txi2p/issues/10). We could use a fork until
-    # txi2p's maintainers are back in action.
-    "txi2p-tahoe >= 0.3.5",
+    # txi2p has Python 3 support in master branch, but it has not been
+    # released -- see https://github.com/str4d/txi2p/issues/10.  We
+    # could use a fork for Python 3 until txi2p's maintainers are back
+    # in action.  For Python 2, we could continue using the txi2p
+    # version about which no one has complained to us so far.
+    "txi2p; python_version < '3.0'",
+    "txi2p-tahoe >= 0.3.5; python_version > '3.0'",
 ]
 
 if len(sys.argv) > 1 and sys.argv[1] == '--fakedependency':


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3633.

This uses [txi2p-tahoe](https://pypi.org/project/txi2p-tahoe/) fork of txi2p, the sources for which are in [my fork of txi2p](https://github.com/sajith/txi2p).  We probably should have some sort of plan for the long-term maintenance of the fork before going ahead with this idea; this PR is mainly to prove that forking txi2p is viable.