### PR TITLE
3616 Run coverage tests with Python 3.6 on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: "Report Coverage to Coveralls"
         run: |
           pip3 install --upgrade coveralls==3.0.1
-          python3 -m coveralls
+          python3 -m coveralls --verbose
         env:
           # Some magic value required for some magic reason.
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -152,7 +152,7 @@ jobs:
       - name: "Indicate completion to coveralls.io"
         run: |
           pip3 install --upgrade coveralls==3.0.1
-          python3 -m coveralls --finish
+          python3 -m coveralls --verbose --finish
         env:
           # Some magic value required for some magic reason.
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         os:
           - macos-latest
           - windows-latest
+          - ubuntu-latest
         python-version:
           - 2.7
           - 3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           # Do not run coverage tests with Python 3.6 on Windows for
           # now.  They will fail.  Dealing with them separately would
           # be simpler.
+          #
+          # XXX: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3669
+          # should track the effort to add Windows to the test matrix.
           - python-version: 3.6
             os: windows-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,17 @@ jobs:
           - ubuntu-latest
         python-version:
           - 2.7
-          - 3.6
+
+        # Also run coverage tests with Python 3.6.  Expect failures on
+        # Windows, until we've had a chance to deal with them.
+        include:
+          - python-version: 3.6
+            os:
+              - macos-latest
+              - ubuntu-latest
+          - python-version: 3.6
+            os: windows-latest
+            experimental: true
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - windows-latest
         python-version:
           - 2.7
+          - 3.6
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: "Report Coverage to Coveralls"
         run: |
           pip3 install --upgrade coveralls==3.0.1
-          python3 -m coveralls --verbose
+          python3 -m coveralls
         env:
           # Some magic value required for some magic reason.
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -152,7 +152,7 @@ jobs:
       - name: "Indicate completion to coveralls.io"
         run: |
           pip3 install --upgrade coveralls==3.0.1
-          python3 -m coveralls --verbose --finish
+          python3 -m coveralls --finish
         env:
           # Some magic value required for some magic reason.
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,13 @@ jobs:
           - ubuntu-latest
         python-version:
           - 2.7
-
-        # Also run coverage tests with Python 3.6.  Expect failures on
-        # Windows, until we've had a chance to deal with them.
-        include:
-          - python-version: 3.6
-            os:
-              - macos-latest
-              - ubuntu-latest
+          - 3.6
+        exclude:
+          # Do not run coverage tests with Python 3.6 on Windows for
+          # now.  They will fail.  Dealing with them separately would
+          # be simpler.
           - python-version: 3.6
             os: windows-latest
-            experimental: true
 
     steps:
 


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3616.  

We send coverage data to coveralls.io only from coverage tests running on GitHub Actions.  On GitHub Actions, we run coverage tests only with Python 2.7.  This PR will also run coverage tests using Python 3.6, thus giving us even more coverage reports.  It will also add `ubuntu-latest` to the matrix, because we can never have too little coverage data. ;-)

This PR supersedes PR #986, which has been split into two: #1021, which updated coveralls version for all jobs, and then this one.