### PR TITLE
3663 Add a "make livehtml" rule for building documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -214,3 +214,7 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+.PHONY: livehtml
+livehtml:
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/newsfragments/3663.other
+++ b/newsfragments/3663.other
@@ -1,0 +1,1 @@
+You can run `make livehtml` in docs directory to invoke sphinx-autobuild.


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3663.

I found that [sphinx-autobuild](https://github.com/executablebooks/sphinx-autobuild) is very nifty to have when editing documentation: it lets us preview changes to documentation locally, right in a web browser.  This PR will add a `make livehtml` rule which will invoke sphinx-autobuild.