### PR TITLE
3665 Remove docutils pin from tox `docs` env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -224,11 +224,8 @@ commands =
 # your web browser.
 
 [testenv:docs]
-# we pin docutils because of https://sourceforge.net/p/docutils/bugs/301/
-# which asserts when it reads links to .svg files (e.g. about.rst)
 deps =
      sphinx
-     docutils==0.12
      recommonmark
      sphinx_rtd_theme
 # normal install is not needed for docs, and slows things down


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3665