### PR TITLE
Run `tox -e py-coverage` on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Display tool versions
         run: python misc/build_helpers/show-tool-versions.py
 
-      - name: Run "tox -e py27-coverage"
-        run: tox -e py27-coverage
+      - name: Run "tox -e py-coverage"
+        run: tox -e py-coverage
 
       - name: Upload eliot.log in case of failure
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3676.

We have been running `tox -e py27-coverage` on GitHub Actions even when we meant to run the tests with Python 3.6, which means we have been inadvertently running them with Python 2.7 instead.