### PR TITLE
Move IRC from freenode.net to libera.chat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ You can find the full Tahoe-LAFS documentation at our `documentation site <http:
 
 Get involved with the Tahoe-LAFS community:
 
--  Chat with Tahoe-LAFS developers at #tahoe-lafs chat on irc.freenode.net or `Slack <https://join.slack.com/t/tahoe-lafs/shared_invite/zt-jqfj12r5-ZZ5z3RvHnubKVADpP~JINQ>`__.
+-  Chat with Tahoe-LAFS developers at #tahoe-lafs chat on irc.libera.chat or `Slack <https://join.slack.com/t/tahoe-lafs/shared_invite/zt-jqfj12r5-ZZ5z3RvHnubKVADpP~JINQ>`__.
 
 -  Join our `weekly conference calls <https://www.tahoe-lafs.org/trac/tahoe-lafs/wiki/WeeklyMeeting>`__ with core developers and interested community members.
 

--- a/newsfragments/3721.documentation
+++ b/newsfragments/3721.documentation
@@ -1,0 +1,1 @@
+Our IRC channel, #tahoe-lafs, has been moved to irc.libera.chat.


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3721.

Leaving Slack alone, assuming that it will be re-bridged correctly.