### PR TITLE
Limit Pickle protocol to version supported by Python 2

### DIFF
--- a/misc/operations_helpers/cpu-watcher.tac
+++ b/misc/operations_helpers/cpu-watcher.tac
@@ -201,7 +201,9 @@ class CPUWatcher(service.MultiService, resource.Resource, Referenceable):
                 log.msg("error reading process %s (%s), ignoring" % (pid, name))
                 log.err()
         try:
-            pickle.dump(self.history, open("history.pickle.tmp", "wb"))
+            # Newer protocols won't work in Python 2; when it is dropped,
+            # protocol v4 can be used (added in Python 3.4).
+            pickle.dump(self.history, open("history.pickle.tmp", "wb"), protocol=2)
             os.rename("history.pickle.tmp", "history.pickle")
         except:
             pass

--- a/src/allmydata/storage/crawler.py
+++ b/src/allmydata/storage/crawler.py
@@ -252,7 +252,9 @@ class ShareCrawler(service.MultiService):
         self.state["last-complete-prefix"] = last_complete_prefix
         tmpfile = self.statefile + ".tmp"
         with open(tmpfile, "wb") as f:
-            pickle.dump(self.state, f)
+            # Newer protocols won't work in Python 2; when it is dropped,
+            # protocol v4 can be used (added in Python 3.4).
+            pickle.dump(self.state, f, protocol=2)
         fileutil.move_into_place(tmpfile, self.statefile)
 
     def startService(self):

--- a/src/allmydata/storage/expirer.py
+++ b/src/allmydata/storage/expirer.py
@@ -95,7 +95,9 @@ class LeaseCheckingCrawler(ShareCrawler):
         if not os.path.exists(self.historyfile):
             history = {} # cyclenum -> dict
             with open(self.historyfile, "wb") as f:
-                pickle.dump(history, f)
+                # Newer protocols won't work in Python 2; when it is dropped,
+                # protocol v4 can be used (added in Python 3.4).
+                pickle.dump(history, f, protocol=2)
 
     def create_empty_cycle_dict(self):
         recovered = self.create_empty_recovered_dict()
@@ -319,7 +321,9 @@ class LeaseCheckingCrawler(ShareCrawler):
             oldcycles = sorted(history.keys())
             del history[oldcycles[0]]
         with open(self.historyfile, "wb") as f:
-            pickle.dump(history, f)
+            # Newer protocols won't work in Python 2; when it is dropped,
+            # protocol v4 can be used (added in Python 3.4).
+            pickle.dump(history, f, protocol=2)
 
     def get_state(self):
         """In addition to the crawler state described in


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3741

Lacking this, downgrading nodes from Python 3 to Python 2 fails due to wrong pickle version.