### PR TITLE
Use version of foolscap with i2p support restored

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ install_requires = [
     # * foolscap >= 0.12.5 has ConnectionInfo and ReconnectionInfo
     # * foolscap >= 0.12.6 has an i2p.sam_endpoint() that takes kwargs
     # * foolscap 0.13.2 drops i2p support completely
-    # * foolscap >= 20.4 is necessary for Python 3
+    # * foolscap >= 21.7 is necessary for Python 3 with i2p support.
     "foolscap == 0.13.1 ; python_version < '3.0'",
-    "foolscap >= 20.4.0 ; python_version > '3.0'",
+    "foolscap >= 21.7.0 ; python_version > '3.0'",
 
     # * cryptography 2.6 introduced some ed25519 APIs we rely on.  Note that
     #   Twisted[conch] also depends on cryptography and Twisted[tls]


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3686

Proving this _works_ will be a follow-up: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3743