### PR TITLE
3745 Remove unnecessary `whitelist_externals` from Tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -137,8 +137,6 @@ deps =
      pylint < 2.5
 # On macOS, git inside of towncrier needs $HOME.
 passenv = HOME
-whitelist_externals =
-         /bin/mv
 setenv =
 	 # If no positional arguments are given, try to run the checks on the
 	 # entire codebase, including various pieces of supporting code.
@@ -179,7 +177,6 @@ commands = mypy src
 
 [testenv:draftnews]
 passenv = TAHOE_LAFS_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
-whitelist_externals = mv
 deps =
     # see comment in [testenv] about "certifi"
     certifi
@@ -190,7 +187,6 @@ commands =
 [testenv:news]
 passenv = TAHOE_LAFS_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
 whitelist_externals =
-    mv
     git
 deps =
     # see comment in [testenv] about "certifi"    


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3745.