### PR TITLE
Use run instead of start for Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,7 +16,7 @@ RUN \
   mkdir /root/.tahoe-introducer; \
   mkdir /root/.tahoe-server;
 RUN /root/tahoe-lafs/venv/bin/tahoe create-introducer --location=tcp:introducer:3458 --port=tcp:3458 /root/.tahoe-introducer
-RUN /root/tahoe-lafs/venv/bin/tahoe start /root/.tahoe-introducer
+RUN /root/tahoe-lafs/venv/bin/tahoe run /root/.tahoe-introducer
 RUN /root/tahoe-lafs/venv/bin/tahoe create-node --location=tcp:server:3457 --port=tcp:3457 --introducer=$(cat /root/.tahoe-introducer/private/introducer.furl) /root/.tahoe-server
 RUN /root/tahoe-lafs/venv/bin/tahoe create-client --webport=3456 --introducer=$(cat /root/.tahoe-introducer/private/introducer.furl) --basedir=/root/.tahoe-client --shares-needed=1 --shares-happy=1 --shares-total=1
 VOLUME ["/root/.tahoe-client", "/root/.tahoe-server", "/root/.tahoe-introducer"]


### PR DESCRIPTION
Fixes starting up with docker-compose for local development.