### PR TITLE
Python 3 support complete, so removed warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,10 +56,10 @@ For more detailed instructions, read `docs/INSTALL.rst <docs/INSTALL.rst>`__ .
 
 Once tahoe --version works, see `docs/running.rst <docs/running.rst>`__ to learn how to set up your first Tahoe-LAFS node.
 
-🐍 `Python 3` Support 
+🐍 Python 3 Support 
 --------------------
 
-`Python 3` support has been introduced as from `Tahoe-LAFS 1.16.x` alongside `Python 2`. System admnistrators are advised to start running Tahoe on `Python 3` and should expect the drop of `Python 2` support any future version from now.  Please, feel free to file issues if you run into bugs while running Tahoe on `Python 3`.
+Python 3 support has been introduced starting with Tahoe-LAFS 1.16.0, alongside Python 2. System admnistrators are advised to start running Tahoe on Python 3 and should expect Python 2 support to be dropped in a future version.  Please, feel free to file issues if you run into bugs while running Tahoe on Python 3.
 
 
 🤖 Issues

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,11 @@ For more detailed instructions, read `docs/INSTALL.rst <docs/INSTALL.rst>`__ .
 
 Once tahoe --version works, see `docs/running.rst <docs/running.rst>`__ to learn how to set up your first Tahoe-LAFS node.
 
+🐍 `Python3` Support 
+--------------------
+
+`Python 3` support has been introduced as from ` Tahoe-LAFS 1.16.x` alongside `Python 2`. System admnistrators are advised to start runing Tahoe on `Python 3` and should expect the drop of `Python 2` support any future version from now.  Please, feel free to file issues if you run into bugs running Tahoe on `Python 3`.
+
 
 🤖 Issues
 ---------

--- a/README.rst
+++ b/README.rst
@@ -56,10 +56,10 @@ For more detailed instructions, read `docs/INSTALL.rst <docs/INSTALL.rst>`__ .
 
 Once tahoe --version works, see `docs/running.rst <docs/running.rst>`__ to learn how to set up your first Tahoe-LAFS node.
 
-🐍 `Python3` Support 
+🐍 `Python 3` Support 
 --------------------
 
-`Python 3` support has been introduced as from ` Tahoe-LAFS 1.16.x` alongside `Python 2`. System admnistrators are advised to start runing Tahoe on `Python 3` and should expect the drop of `Python 2` support any future version from now.  Please, feel free to file issues if you run into bugs running Tahoe on `Python 3`.
+`Python 3` support has been introduced as from `Tahoe-LAFS 1.16.x` alongside `Python 2`. System admnistrators are advised to start running Tahoe on `Python 3` and should expect the drop of `Python 2` support any future version from now.  Please, feel free to file issues if you run into bugs while running Tahoe on `Python 3`.
 
 
 🤖 Issues

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,9 @@ Once tahoe --version works, see `docs/running.rst <docs/running.rst>`__ to learn
 🐍 Python 3 Support 
 --------------------
 
-Python 3 support has been introduced starting with Tahoe-LAFS 1.16.0, alongside Python 2. System admnistrators are advised to start running Tahoe on Python 3 and should expect Python 2 support to be dropped in a future version.  Please, feel free to file issues if you run into bugs while running Tahoe on Python 3.
+Python 3 support has been introduced starting with Tahoe-LAFS 1.16.0, alongside Python 2.
+System administrators are advised to start running Tahoe on Python 3 and should expect Python 2 support to be dropped in a future version.
+Please, feel free to file issues if you run into bugs while running Tahoe on Python 3.
 
 
 🤖 Issues

--- a/src/allmydata/scripts/runner.py
+++ b/src/allmydata/scripts/runner.py
@@ -183,13 +183,8 @@ def _maybe_enable_eliot_logging(options, reactor):
     # Pass on the options so we can dispatch the subcommand.
     return options
 
-PYTHON_3_WARNING = ("Support for Python 3 is an incomplete work-in-progress."
-                    " Use at your own risk.")
 
 def run():
-    if six.PY3:
-        print(PYTHON_3_WARNING, file=sys.stderr)
-
     if sys.platform == "win32":
         from allmydata.windows.fixups import initialize
         initialize()

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -43,7 +43,6 @@ from allmydata.monitor import Monitor
 from allmydata.mutable.common import NotWriteableError
 from allmydata.mutable import layout as mutable_layout
 from allmydata.mutable.publish import MutableData
-from allmydata.scripts.runner import PYTHON_3_WARNING
 
 from foolscap.api import DeadReferenceError, fireEventually, flushEventualQueue
 from twisted.python.failure import Failure
@@ -2632,18 +2631,16 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
             newargs = ["--node-directory", self.getdir("client0"), verb] + list(args)
             return self.run_bintahoe(newargs, stdin=stdin, env=env)
 
-        def _check_succeeded(res, check_stderr=True):
+        def _check_succeeded(res):
             out, err, rc_or_sig = res
             self.failUnlessEqual(rc_or_sig, 0, str(res))
-            if check_stderr:
-                self.assertIn(err.strip(), (b"", PYTHON_3_WARNING.encode("ascii")))
 
         d.addCallback(_run_in_subprocess, "create-alias", "newalias")
         d.addCallback(_check_succeeded)
 
         STDIN_DATA = b"This is the file to upload from stdin."
         d.addCallback(_run_in_subprocess, "put", "-", "newalias:tahoe-file", stdin=STDIN_DATA)
-        d.addCallback(_check_succeeded, check_stderr=False)
+        d.addCallback(_check_succeeded)
 
         def _mv_with_http_proxy(ign):
             env = os.environ
@@ -2656,7 +2653,6 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
         def _check_ls(res):
             out, err, rc_or_sig = res
             self.failUnlessEqual(rc_or_sig, 0, str(res))
-            self.assertIn(err.strip(), (b"", PYTHON_3_WARNING.encode("ascii")))
             self.failUnlessIn(b"tahoe-moved", out)
             self.failIfIn(b"tahoe-file", out)
         d.addCallback(_check_ls)


### PR DESCRIPTION
`Python3` porting is complete so users should not be warned when running on a `python3 venv`

REQUIRED FOR : [`Tahoe-LAFS 1.16.0` Release](https://github.com/tahoe-lafs/tahoe-lafs/pull/1113)

Closes : https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3781