### PR TITLE
3782 Update references to the mailing list in documentation

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1188,7 +1188,7 @@ Precautions when Upgrading
 .. _`#1915`: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1915
 .. _`#1926`: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1926
 .. _`message to the tahoe-dev mailing list`:
-             https://tahoe-lafs.org/pipermail/tahoe-dev/2013-March/008096.html
+             https://lists.tahoe-lafs.org/pipermail/tahoe-dev/2013-March/008096.html
 
 
 Release 1.9.2 (2012-07-03)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1188,7 +1188,7 @@ Precautions when Upgrading
 .. _`#1915`: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1915
 .. _`#1926`: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1926
 .. _`message to the tahoe-dev mailing list`:
-             https://lists.tahoe-lafs.org/pipermail/tahoe-dev/2013-March/008096.html
+             https://lists.tahoe-lafs.org/pipermail/tahoe-dev/2013-March/008079.html
 
 
 Release 1.9.2 (2012-07-03)

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,8 @@ Before authoring or reviewing a patch, please familiarize yourself with the `Cod
 
 We would like to thank `Fosshost <https://fosshost.org>`__ for supporting us with hosting services. If your open source project needs help, you can apply for their support.
 
+We are grateful to `Oregon State University Open Source Lab <https://osuosl.org/>`__ for hosting tahoe-dev mailing list.
+
 ❓ FAQ
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Get involved with the Tahoe-LAFS community:
 
 -  Join our `weekly conference calls <https://www.tahoe-lafs.org/trac/tahoe-lafs/wiki/WeeklyMeeting>`__ with core developers and interested community members.
 
--  Subscribe to `the tahoe-dev mailing list <https://www.tahoe-lafs.org/cgi-bin/mailman/listinfo/tahoe-dev>`__, the community forum for discussion of Tahoe-LAFS design, implementation, and usage.
+-  Subscribe to `the tahoe-dev mailing list <https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev>`__, the community forum for discussion of Tahoe-LAFS design, implementation, and usage.
 
 🤗 Contributing
 ---------------

--- a/docs/Installation/install-tahoe.rst
+++ b/docs/Installation/install-tahoe.rst
@@ -65,4 +65,4 @@ If you are working on MacOS or a Linux distribution which does not have Tahoe-LA
 
 If you are looking to hack on the source code or run pre-release code, we recommend you install Tahoe-LAFS on a `virtualenv` instance. To learn more, see :doc:`install-on-linux`.    
 
-You can always write to the `tahoe-dev mailing list <https://tahoe-lafs.org/cgi-bin/mailman/listinfo/tahoe-dev>`_ or chat on the `Libera.chat IRC <irc://irc.libera.chat/%23tahoe-lafs>`_ if you are not able to get Tahoe-LAFS up and running on your deployment.
+You can always write to the `tahoe-dev mailing list <https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev>`_ or chat on the `Libera.chat IRC <irc://irc.libera.chat/%23tahoe-lafs>`_ if you are not able to get Tahoe-LAFS up and running on your deployment.

--- a/docs/historical/historical_known_issues.txt
+++ b/docs/historical/historical_known_issues.txt
@@ -177,7 +177,7 @@ mutable files, you may be able to avoid the potential for "rollback"
 failure.
 
 A future version of Tahoe will include a fix for this issue.  Here is
-[https://tahoe-lafs.org/pipermail/tahoe-dev/2008-May/000630.html the
+[https://lists.tahoe-lafs.org/pipermail/tahoe-dev/2008-May/000628.html the
 mailing list discussion] about how that future version will work.
 
 

--- a/docs/man/man1/tahoe.1
+++ b/docs/man/man1/tahoe.1
@@ -268,7 +268,7 @@ For known security issues see
 .PP
 Tahoe-LAFS home page: <https://tahoe-lafs.org/>
 .PP
-tahoe-dev mailing list: <https://tahoe-lafs.org/cgi-bin/mailman/listinfo/tahoe-dev>
+tahoe-dev mailing list: <https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev>
 .SH COPYRIGHT
 .PP
 Copyright \@ 2006\[en]2013 The Tahoe-LAFS Software Foundation

--- a/docs/release-checklist.rst
+++ b/docs/release-checklist.rst
@@ -178,8 +178,8 @@ Announcing the Release Candidate
 ````````````````````````````````
 
 The release-candidate should be announced by posting to the
-mailing-list (tahoe-dev@tahoe-lafs.org). For example:
-https://tahoe-lafs.org/pipermail/tahoe-dev/2020-October/009995.html
+mailing-list (tahoe-dev@lists.tahoe-lafs.org). For example:
+https://lists.tahoe-lafs.org/pipermail/tahoe-dev/2020-October/009978.html
 
 
 Is The Release Done Yet?

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -238,7 +238,7 @@ You can chat with other users of and hackers of this software on the
 #tahoe-lafs IRC channel at ``irc.libera.chat``, or on the `tahoe-dev mailing
 list`_.
 
-.. _tahoe-dev mailing list: https://tahoe-lafs.org/cgi-bin/mailman/listinfo/tahoe-dev
+.. _tahoe-dev mailing list: https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev
 
 
 Complain

--- a/misc/python3/depgraph.sh
+++ b/misc/python3/depgraph.sh
@@ -16,7 +16,7 @@ if git diff-index --quiet HEAD; then
 fi
 
 git config user.name 'Build Automation'
-git config user.email 'tahoe-dev@tahoe-lafs.org'
+git config user.email 'tahoe-dev@lists.tahoe-lafs.org'
 
 git add tahoe-deps.json tahoe-ported.json
 git commit -m "\

--- a/newsfragments/3782.documentation
+++ b/newsfragments/3782.documentation
@@ -1,0 +1,1 @@
+tahoe-dev mailing list is now at tahoe-dev@lists.tahoe-lafs.org.

--- a/relnotes.txt
+++ b/relnotes.txt
@@ -155,7 +155,7 @@ Planet Earth
 [4] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.15.1/COPYING.GPL
 [5] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.15.1/COPYING.TGPPL.rst
 [6] https://tahoe-lafs.readthedocs.org/en/tahoe-lafs-1.15.1/INSTALL.html
-[7] https://tahoe-lafs.org/cgi-bin/mailman/listinfo/tahoe-dev
+[7] https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev
 [8] https://tahoe-lafs.org/trac/tahoe-lafs/roadmap
 [9] https://github.com/tahoe-lafs/tahoe-lafs/blob/master/CREDITS
 [10] https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Dev

--- a/setup.py
+++ b/setup.py
@@ -359,7 +359,7 @@ setup(name="tahoe-lafs", # also set in __init__.py
       description='secure, decentralized, fault-tolerant file store',
       long_description=open('README.rst', 'r', encoding='utf-8').read(),
       author='the Tahoe-LAFS project',
-      author_email='tahoe-dev@tahoe-lafs.org',
+      author_email='tahoe-dev@lists.tahoe-lafs.org',
       url='https://tahoe-lafs.org/',
       license='GNU GPL', # see README.rst -- there is an alternative licence
       cmdclass={"update_version": UpdateVersion,


### PR DESCRIPTION
Ticket is https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3782.

New list is tahoe-dev@lists.tahoe-lafs.org, list info page is at https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev, and list     archives are now at https://lists.tahoe-lafs.org/pipermail/tahoe-dev/.  This PR changes all those references.
    
Message numbers in list archive did not remain stable during the migration, so updating references to list archive is not as simple as replacing `https://tahoe-lafs.org/` with `https://lists.tahoe-lafs.org/` and maybe setting up some redirects.  There are a couple of URLs like that in this change:

* https://tahoe-lafs.org/pipermail/tahoe-dev/2008-May/000630.html became https://lists.tahoe-lafs.org/pipermail/tahoe-dev/2008-May/000628.html
* https://tahoe-lafs.org/pipermail/tahoe-dev/2013-March/008096.html became  https://lists.tahoe-lafs.org/pipermail/tahoe-dev/2013-March/008096.html

We'll likely have to keep the archives at https://tahoe-lafs.org/pipermail/tahoe-dev/, because there are other places too (wiki, links elsewhere  in the internet).