### PR TITLE
Reduce implementation-dependency of `IStorageServer`

### DIFF
--- a/newsfragments/3779.bugfix
+++ b/newsfragments/3779.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where share corruption events were not recorded on Windows.

--- a/newsfragments/3779.bugfix
+++ b/newsfragments/3779.bugfix
@@ -1,1 +1,1 @@
-Fixed bug where share corruption events were not recorded on Windows.
+Fixed bug where share corruption events were not logged on storage servers running on Windows.

--- a/src/allmydata/immutable/downloader/share.py
+++ b/src/allmydata/immutable/downloader/share.py
@@ -475,7 +475,9 @@ class Share(object):
         # there was corruption somewhere in the given range
         reason = "corruption in share[%d-%d): %s" % (start, start+offset,
                                                      str(f.value))
-        self._rref.callRemoteOnly("advise_corrupt_share", reason.encode("utf-8"))
+        self._rref.callRemote(
+            "advise_corrupt_share", reason.encode("utf-8")
+        ).addErrback(log.err)
 
     def _satisfy_block_hash_tree(self, needed_hashes):
         o_bh = self.actual_offsets["block_hashes"]

--- a/src/allmydata/immutable/downloader/share.py
+++ b/src/allmydata/immutable/downloader/share.py
@@ -477,7 +477,7 @@ class Share(object):
                                                      str(f.value))
         self._rref.callRemote(
             "advise_corrupt_share", reason.encode("utf-8")
-        ).addErrback(log.err)
+        ).addErrback(log.err, "Error from remote call to advise_corrupt_share")
 
     def _satisfy_block_hash_tree(self, needed_hashes):
         o_bh = self.actual_offsets["block_hashes"]

--- a/src/allmydata/immutable/layout.py
+++ b/src/allmydata/immutable/layout.py
@@ -254,7 +254,7 @@ class WriteBucketProxy(object):
         return d
 
     def abort(self):
-        self._rref.callRemote("abort").addErrback(log.err)
+        self._rref.callRemote("abort").addErrback(log.err, "Error from remote call to abort an immutable write bucket")
 
     def get_servername(self):
         return self._server.get_name()

--- a/src/allmydata/immutable/layout.py
+++ b/src/allmydata/immutable/layout.py
@@ -15,7 +15,7 @@ from zope.interface import implementer
 from twisted.internet import defer
 from allmydata.interfaces import IStorageBucketWriter, IStorageBucketReader, \
      FileTooLargeError, HASH_SIZE
-from allmydata.util import mathutil, observer, pipeline
+from allmydata.util import mathutil, observer, pipeline, log
 from allmydata.util.assertutil import precondition
 from allmydata.storage.server import si_b2a
 
@@ -254,8 +254,7 @@ class WriteBucketProxy(object):
         return d
 
     def abort(self):
-        return self._rref.callRemoteOnly("abort")
-
+        self._rref.callRemote("abort").addErrback(log.err)
 
     def get_servername(self):
         return self._server.get_name()

--- a/src/allmydata/storage/server.py
+++ b/src/allmydata/storage/server.py
@@ -708,8 +708,10 @@ class StorageServer(service.MultiService, Referenceable):
         now = time_format.iso_utc(sep="T")
         si_s = si_b2a(storage_index)
         # windows can't handle colons in the filename
-        fn = os.path.join(self.corruption_advisory_dir,
-                          "%s--%s-%d" % (now, str(si_s, "utf-8"), shnum)).replace(":","")
+        fn = os.path.join(
+            self.corruption_advisory_dir,
+            ("%s--%s-%d" % (now, str(si_s, "utf-8"), shnum)).replace(":","")
+        )
         with open(fn, "w") as f:
             f.write("report: Share Corruption\n")
             f.write("type: %s\n" % bytes_to_native_str(share_type))

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1009,10 +1009,10 @@ class _StorageServer(object):
             shnum,
             reason,
     ):
-        return self._rref.callRemoteOnly(
+        self._rref.callRemote(
             "advise_corrupt_share",
             share_type,
             storage_index,
             shnum,
             reason,
-        )
+        ).addErrback(log.err)

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1015,4 +1015,4 @@ class _StorageServer(object):
             storage_index,
             shnum,
             reason,
-        ).addErrback(log.err)
+        ).addErrback(log.err, "Error from remote call to advise_corrupt_share")

--- a/src/allmydata/test/mutable/util.py
+++ b/src/allmydata/test/mutable/util.py
@@ -96,8 +96,14 @@ class FakeStorage(object):
         shares[shnum] = f.getvalue()
 
 
+# This doesn't actually implement the whole interface, but adding a commented
+# interface implementation annotation for grepping purposes.
+#@implementer(RIStorageServer)
 class FakeStorageServer(object):
-
+    """
+    A fake Foolscap remote object, implemented by overriding callRemote() to
+    call local methods.
+    """
     def __init__(self, peerid, storage):
         self.peerid = peerid
         self.storage = storage

--- a/src/allmydata/test/test_upload.py
+++ b/src/allmydata/test/test_upload.py
@@ -122,7 +122,15 @@ class SetDEPMixin(object):
              }
         self.node.encoding_params = p
 
+
+# This doesn't actually implement the whole interface, but adding a commented
+# interface implementation annotation for grepping purposes.
+#@implementer(RIStorageServer)
 class FakeStorageServer(object):
+    """
+    A fake Foolscap remote object, implemented by overriding callRemote() to
+    call local methods.
+    """
     def __init__(self, mode, reactor=None):
         self.mode = mode
         self.allocated = []


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3779

Left in the so-called "pipeline" code, since it's not clear if it's needed or not.

**Update:** Also fixed a pre-existing bug in remote_advise_corrupt_share that was exposed by the changes.