### PR TITLE
3777.gbs immutable download spec improvements

### DIFF
--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -509,28 +509,21 @@ For example::
 
   [1, 5]
 
-``GET /v1/immutable/:storage_index?share=:s0&share=:sN&offset=o1&size=z0&offset=oN&size=zN``
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+``GET /v1/immutable/:storage_index/:share_number?offset=:offset&length=:length
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-Read data from the indicated immutable shares.
-If ``share`` query parameters are given, selecte only those shares for reading.
-Otherwise, select all shares present.
-If ``size`` and ``offset`` query parameters are given,
-only the portions thus identified of the selected shares are returned.
-Otherwise, all data is from the selected shares is returned.
+Read a contiguous sequence of bytes from one share in one bucket.
+If the ``offset`` query parameter is given then it is interpreted as a base 10 representation of an integer giving the position at which to begin reading.
+If it is not given then begin reading at the beginning of the share.
+If the ``length`` query parameter is given then it is interpreted as a base 10 representation of an integer giving the maximum number of bytes to read and return.
+If it is not given then bytes will be read until the end of the share is reached.
 
-The response body contains a mapping giving the read data.
-For example::
-
-  {
-      3: ["foo", "bar"],
-      7: ["baz", "quux"]
-  }
+The response body is the raw share data (i.e., ``application/octet-stream``).
 
 Discussion
 ``````````
 
-Offset and size of the requested data are specified here as query arguments.
+Offset and length of the requested data are specified here as query arguments.
 Instead, this information could be present in a ``Range`` header in the request.
 This is the more obvious choice and leverages an HTTP feature built for exactly this use-case.
 However, HTTP requires that the ``Content-Type`` of the response to "range requests" be ``multipart/...``.

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -539,24 +539,20 @@ For example::
 
   [1, 5]
 
-``GET /v1/immutable/:storage_index/:share_number?offset=:offset&length=:length
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+``GET /v1/immutable/:storage_index/:share_number
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Read a contiguous sequence of bytes from one share in one bucket.
-If the ``offset`` query parameter is given then it is interpreted as a base 10 representation of an integer giving the position at which to begin reading.
-If it is not given then begin reading at the beginning of the share.
-If the ``length`` query parameter is given then it is interpreted as a base 10 representation of an integer giving the maximum number of bytes to read and return.
-If it is not given then bytes will be read until the end of the share is reached.
-
 The response body is the raw share data (i.e., ``application/octet-stream``).
+The ``Range`` header may be used to request exactly one ``bytes`` range.
+Interpretation and response behavior is as specified in RFC 7233 § 4.1.
+Multiple ranges in a single request are *not* supported.
 
 Discussion
 ``````````
 
-Offset and length of the requested data are specified here as query arguments.
-Instead, this information could be present in a ``Range`` header in the request.
-This is the more obvious choice and leverages an HTTP feature built for exactly this use-case.
-However, HTTP requires that the ``Content-Type`` of the response to "range requests" be ``multipart/...``.
+Multiple ``bytes`` ranges are not supported.
+HTTP requires that the ``Content-Type`` of the response in that case be ``multipart/...``.
 The ``multipart`` major type brings along string sentinel delimiting as a means to frame the different response parts.
 There are many drawbacks to this framing technique:
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -534,6 +534,15 @@ There are many drawbacks to this framing technique:
 2. It is resource-intensive to parse.
 3. It is complex to parse safely [#]_ [#]_ [#]_ [#]_.
 
+A previous revision of this specification allowed requesting one or more contiguous sequences from one or more shares.
+This *superficially* mirrored the Foolscap based interface somewhat closely.
+The interface was simplified to this version because this version is all that is required to let clients retrieve any desired information.
+It only requires that the client issue multiple requests.
+This can be done with pipelining or parallel requests to avoid an additional latency penalty.
+In the future,
+if there are performance goals,
+benchmarks can demonstrate whether they are achieved by a more complicated interface or some other change.
+
 Mutable
 -------
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -539,8 +539,8 @@ For example::
 
   [1, 5]
 
-``GET /v1/immutable/:storage_index/:share_number
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+``GET /v1/immutable/:storage_index/:share_number``
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Read a contiguous sequence of bytes from one share in one bucket.
 The response body is the raw share data (i.e., ``application/octet-stream``).

--- a/newsfragments/3777.documentation
+++ b/newsfragments/3777.documentation
@@ -1,0 +1,1 @@
+The Great Black Swamp proposed specification now has a simplified interface for reading data from immutable shares.


### PR DESCRIPTION
https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3777

I opted to simplify the interface.  The points on the ticket about how shoving all of this complexity into a single HTTP request don't really make sense are pretty compelling.  I read enough of the immutable downloader code to convince myself that it only *actually* wants to read one region at a time anyway (that is, there is no client logic that would change from 1 request to N requests as a result of this interface change).  Maybe some *other* code could have a good reason for reading from multiple regions but we can cross that bridge when we get to it.

There's a note on the ticket about how the same may apply to the mutable download interface.  It ... may.  I haven't spent enough time with the implementation of mutables to be sure one way or the other, though.  Does the client really need to read from two different shares at once?  Does it need to read from two different regions of those shares?  I'm not sure...  It is maybe noteworthy that Tahoe makes a single `testv_and_readv_and_writev` atomic.  Does that matter?  Again, I'm not sure...