### PR TITLE
Disallow conflicting overlapping writes when doing an immutable upload

### DIFF
--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -499,6 +499,18 @@ The server must recognize when all of the data has been received and mark the sh
 (which it can do because it was informed of the size when the storage index was initialized).
 
 * When a chunk that does not complete the share is successfully uploaded the response is ``OK``.
+  The response body indicates the range of share data that has yet to be uploaded.
+  That is::
+
+    { "required":
+      [ { "begin": <byte position, inclusive>
+        , "end":   <byte position, exclusive>
+        }
+      ,
+      ...
+      ]
+    }
+
 * When the chunk that completes the share is successfully uploaded the response is ``CREATED``.
 * If the *Content-Range* for a request covers part of the share that has already,
   and the data does not match already written data,

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -497,22 +497,26 @@ If any one of these requests fails then at most 128KiB of upload work needs to b
 
 The server must recognize when all of the data has been received and mark the share as complete
 (which it can do because it was informed of the size when the storage index was initialized).
-Clients should upload chunks in re-assembly order.
 
 * When a chunk that does not complete the share is successfully uploaded the response is ``OK``.
 * When the chunk that completes the share is successfully uploaded the response is ``CREATED``.
-* If the *Content-Range* for a request covers part of the share that has already been uploaded the response is ``CONFLICT``.
-  The response body indicates the range of share data that has yet to be uploaded.
-  That is::
+* If the *Content-Range* for a request covers part of the share that has already,
+  and the data does not match already written data,
+  the response is ``CONFLICT``.
+  At this point the only thing to do is abort the upload and start from scratch (see below).
 
-    { "required":
-      [ { "begin": <byte position, inclusive>
-        , "end":   <byte position, exclusive>
-        }
-      ,
-      ...
-      ]
-    }
+``PUT /v1/immutable/:storage_index/:share_number/abort``
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+This cancels an *in-progress* upload.
+
+The response code:
+
+* When the upload is still in progress and therefore the abort has succeeded,
+  the response is ``OK``.
+  Future uploads can start from scratch with no pre-existing upload state stored on the server.
+* If the uploaded has already finished, the response is 405 (Method Not Allowed)
+  and no change is made.
 
 
 ``POST /v1/immutable/:storage_index/:share_number/corrupt``

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -506,7 +506,7 @@ The server must recognize when all of the data has been received and mark the sh
   At this point the only thing to do is abort the upload and start from scratch (see below).
 
 ``PUT /v1/immutable/:storage_index/:share_number/abort``
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 This cancels an *in-progress* upload.
 

--- a/newsfragments/3801.bugfix
+++ b/newsfragments/3801.bugfix
@@ -1,0 +1,1 @@
+When uploading an immutable, overlapping writes that include conflicting data are rejected. In practice, this likely didn't happen in real-world usage.

--- a/nix/collections-extended.nix
+++ b/nix/collections-extended.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "collections-extended";
+  version = "1.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0lb69x23asd68n0dgw6lzxfclavrp2764xsnh45jm97njdplznkw";
+  };
+
+  # Tests aren't in tarball, for 1.0.3 at least.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/mlenzen/collections-extended;
+    description = "Extra Python Collections - bags (multisets), setlists (unique list / indexed set), RangeMap and IndexedDict";
+    license = licenses.asl20;
+  };
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -18,6 +18,9 @@ self: super: {
 
       # Need a newer version of Twisted, too.
       twisted = python-super.callPackage ./twisted.nix { };
+
+      # collections-extended is not part of nixpkgs at this time.
+      collections-extended = python-super.callPackage ./collections-extended.nix
     };
   };
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -20,7 +20,7 @@ self: super: {
       twisted = python-super.callPackage ./twisted.nix { };
 
       # collections-extended is not part of nixpkgs at this time.
-      collections-extended = python-super.callPackage ./collections-extended.nix
+      collections-extended = python-super.callPackage ./collections-extended.nix { };
     };
   };
 }

--- a/nix/tahoe-lafs.nix
+++ b/nix/tahoe-lafs.nix
@@ -97,7 +97,7 @@ EOF
     setuptoolsTrial pyasn1 zope_interface
     service-identity pyyaml magic-wormhole treq
     eliot autobahn cryptography netifaces setuptools
-    future pyutil distro configparser
+    future pyutil distro configparser collections-extended
   ];
 
   checkInputs = with python.pkgs; [

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,9 @@ install_requires = [
 
     # Backported configparser for Python 2:
     "configparser ; python_version < '3.0'",
+
+    # For the RangeMap datastructure.
+    "collections-extended",
 ]
 
 setup_requires = [

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -53,6 +53,14 @@ LeaseRenewSecret = Hash # used to protect lease renewal requests
 LeaseCancelSecret = Hash # was used to protect lease cancellation requests
 
 
+class DataTooLargeError(Exception):
+    """The write went past the expected size of the bucket."""
+
+
+class ConflictingWriteError(Exception):
+    """Two writes happened to same immutable with different data."""
+
+
 class RIBucketWriter(RemoteInterface):
     """ Objects of this kind live on the server side. """
     def write(offset=Offset, data=ShareData):

--- a/src/allmydata/storage/common.py
+++ b/src/allmydata/storage/common.py
@@ -14,7 +14,7 @@ import os.path
 from allmydata.util import base32
 
 # Backwards compatibility.
-from allmydata.interfaces import DataTooLargeError
+from allmydata.interfaces import DataTooLargeError  # noqa: F401
 
 class UnknownMutableContainerVersionError(Exception):
     pass

--- a/src/allmydata/storage/common.py
+++ b/src/allmydata/storage/common.py
@@ -13,8 +13,9 @@ if PY2:
 import os.path
 from allmydata.util import base32
 
-class DataTooLargeError(Exception):
-    pass
+# Backwards compatibility.
+from allmydata.interfaces import DataTooLargeError
+
 class UnknownMutableContainerVersionError(Exception):
     pass
 class UnknownImmutableContainerVersionError(Exception):

--- a/src/allmydata/test/test_istorageserver.py
+++ b/src/allmydata/test/test_istorageserver.py
@@ -248,12 +248,11 @@ class IStorageServerImmutableAPIsTestsMixin(object):
             (yield buckets[2].callRemote("read", 0, 1024)), b"3" * 512 + b"4" * 512
         )
 
-    @skipIf(True, "https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3801")
     def test_overlapping_writes(self):
         """
-        The policy for overlapping writes is TBD:
-        https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3801
+        Overlapping writes in immutable uploads fail with ``OverlappingWriteError``.
         """
+        1/0
 
 
 class _FoolscapMixin(SystemTestMixin):


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3801

Additionally, this defines the equivalent of `RIBucketWriter.abort()` in the HTTP protocol, since if somehow there are conflicting writes the only reasonable thing to do is start from scratch, so that needs to be exposed (plus some existing code assumes aborts are possible.)

The followup, https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3793, will then make BucketWriter persist for more than one Foolscap connection, so that:

1. Multiple Foolscap connections can write (not likely in practice).
2. Parallel HTTP uploads can write.