### PR TITLE
Make the HTTP version test more robust

### DIFF
--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -64,14 +64,21 @@ class HTTPTests(TestCase):
         """
         The client can return the version.
 
-        We ignore available disk space since that might change across calls.
+        We ignore available disk space and max immutable share size, since that
+        might change across calls.
         """
         version = yield self.client.get_version()
         version[b"http://allmydata.org/tahoe/protocols/storage/v1"].pop(
             b"available-space"
         )
+        version[b"http://allmydata.org/tahoe/protocols/storage/v1"].pop(
+            b"maximum-immutable-share-size"
+        )
         expected_version = self.storage_server.remote_get_version()
         expected_version[b"http://allmydata.org/tahoe/protocols/storage/v1"].pop(
             b"available-space"
+        )
+        expected_version[b"http://allmydata.org/tahoe/protocols/storage/v1"].pop(
+            b"maximum-immutable-share-size"
         )
         self.assertEqual(version, expected_version)

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -63,7 +63,15 @@ class HTTPTests(TestCase):
     def test_version(self):
         """
         The client can return the version.
+
+        We ignore available disk space since that might change across calls.
         """
         version = yield self.client.get_version()
+        version[b"http://allmydata.org/tahoe/protocols/storage/v1"].pop(
+            b"available-space"
+        )
         expected_version = self.storage_server.remote_get_version()
+        expected_version[b"http://allmydata.org/tahoe/protocols/storage/v1"].pop(
+            b"available-space"
+        )
         self.assertEqual(version, expected_version)


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3850

(I can't prove this'll fix it, but it seems the likely reason.)