### PR TITLE
HTTP API can list storage index shares

### DIFF
--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -635,6 +635,9 @@ indicated storage index. For example::
 
   [1, 5]
 
+An unknown storage index results in empty list, so that lack of existence of
+storage index is not leaked.
+
 ``GET /v1/immutable/:storage_index/:share_number``
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -630,8 +630,8 @@ Reading
 ``GET /v1/immutable/:storage_index/shares``
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-Retrieve a list indicating all shares available for the indicated storage index.
-For example::
+Retrieve a list (semantically, a set) indicating all shares available for the
+indicated storage index. For example::
 
   [1, 5]
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -635,8 +635,7 @@ indicated storage index. For example::
 
   [1, 5]
 
-An unknown storage index results in empty list, so that lack of existence of
-storage index is not leaked.
+An unknown storage index results in an empty list.
 
 ``GET /v1/immutable/:storage_index/:share_number``
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -238,7 +238,7 @@ class StorageClientImmutables(object):
             raise ClientException(
                 response.code,
             )
-        body = loads((yield response.content()))
+        body = yield _decode_cbor(response)
         remaining = RangeMap()
         for chunk in body["required"]:
             remaining.set(True, chunk["begin"], chunk["end"])
@@ -293,8 +293,8 @@ class StorageClientImmutables(object):
             url,
         )
         if response.code == http.OK:
-            body = yield response.content()
-            returnValue(set(loads(body)))
+            body = yield _decode_cbor(response)
+            returnValue(set(body))
         else:
             raise ClientException(
                 response.code,

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -136,6 +136,7 @@ class UploadProgress(object):
     """
     Progress of immutable upload, per the server.
     """
+
     # True when upload has finished.
     finished = attr.ib(type=bool)
     # Remaining ranges to upload.
@@ -221,7 +222,7 @@ class StorageClientImmutables(object):
             headers=Headers(
                 {
                     "content-range": [
-                        ContentRange("bytes", offset, offset+len(data)).to_header()
+                        ContentRange("bytes", offset, offset + len(data)).to_header()
                     ]
                 }
             ),
@@ -268,16 +269,32 @@ class StorageClientImmutables(object):
             "GET",
             url,
             headers=Headers(
-                {
-                    "range": [
-                        Range("bytes", [(offset, offset + length)]).to_header()
-                    ]
-                }
+                {"range": [Range("bytes", [(offset, offset + length)]).to_header()]}
             ),
         )
         if response.code == http.PARTIAL_CONTENT:
             body = yield response.content()
             returnValue(body)
+        else:
+            raise ClientException(
+                response.code,
+            )
+
+    @inlineCallbacks
+    def list_shares(self, storage_index):  # type: (bytes,) -> Deferred[Set[int]]
+        """
+        Return the set of shares for a given storage index.
+        """
+        url = self._client._url(
+            "/v1/immutable/{}/shares".format(_encode_si(storage_index))
+        )
+        response = yield self._client._request(
+            "GET",
+            url,
+        )
+        if response.code == http.OK:
+            body = yield response.content()
+            returnValue(set(loads(body)))
         else:
             raise ClientException(
                 response.code,

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -266,8 +266,6 @@ class HTTPServer(object):
         List shares for the given storage index.
         """
         storage_index = si_a2b(storage_index.encode("ascii"))
-
-        # TODO in future ticket, handle KeyError as 404
         share_numbers = list(self._storage_server.get_buckets(storage_index).keys())
         return self._cbor(request, share_numbers)
 

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -258,6 +258,22 @@ class HTTPServer(object):
     @_authorized_route(
         _app,
         set(),
+        "/v1/immutable/<string:storage_index>/shares",
+        methods=["GET"],
+    )
+    def list_shares(self, request, authorization, storage_index):
+        """
+        List shares for the given storage index.
+        """
+        storage_index = si_a2b(storage_index.encode("ascii"))
+
+        # TODO in future ticket, handle KeyError as 404
+        share_numbers = list(self._storage_server.get_buckets(storage_index).keys())
+        return self._cbor(request, share_numbers)
+
+    @_authorized_route(
+        _app,
+        set(),
         "/v1/immutable/<string:storage_index>/<int:share_number>",
         methods=["GET"],
     )

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1073,7 +1073,7 @@ class _HTTPBucketWriter(object):
 @attr.s
 class _HTTPBucketReader(object):
     """
-    Emulate a ``RIBucketReader``.
+    Emulate a ``RIBucketReader``, but use HTTP protocol underneath.
     """
     client = attr.ib(type=StorageClientImmutables)
     storage_index = attr.ib(type=bytes)

--- a/src/allmydata/test/test_istorageserver.py
+++ b/src/allmydata/test/test_istorageserver.py
@@ -1149,8 +1149,6 @@ class HTTPImmutableAPIsTests(
         "test_get_buckets_skips_unfinished_buckets",
         "test_matching_overlapping_writes",
         "test_non_matching_overlapping_writes",
-        "test_read_bucket_at_offset",
-        "test_written_shares_are_readable",
         "test_written_shares_are_allocated",
     }
 

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -413,6 +413,14 @@ class ImmutableHTTPAPITests(SyncTestCase):
         # Now shares 1 and 3 exist:
         self.assertEqual(result_of(im_client.list_shares(storage_index)), {1, 3})
 
+    def test_list_shares_unknown_storage_index(self):
+        """
+        Listing unknown storage index's shares results in empty list of shares.
+        """
+        im_client = StorageClientImmutables(self.http.client)
+        storage_index = b"".join(bytes([i]) for i in range(16))
+        self.assertEqual(result_of(im_client.list_shares(storage_index)), set())
+
     def test_multiple_shares_uploaded_to_different_place(self):
         """
         If a storage index has multiple shares, uploads to different shares are


### PR DESCRIPTION
Follow-up to #1176, review that first.

This enables more IStorageServer compliance, in particular it enables reading shares.

Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3871