### PR TITLE
HTTP immutable storage APIs, continued

### DIFF
--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -161,7 +161,7 @@ class StorageClientImmutables(object):
     APIs for interacting with immutables.
     """
 
-    def __init__(self, client):  # type: (StorageClient) -> None
+    def __init__(self, client: StorageClient):
         self._client = client
 
     @inlineCallbacks
@@ -207,6 +207,27 @@ class StorageClientImmutables(object):
                 allocated=decoded_response["allocated"],
             )
         )
+
+    @inlineCallbacks
+    def abort_upload(
+        self, storage_index: bytes, share_number: int, upload_secret: bytes
+    ) -> Deferred[None]:
+        """Abort the upload."""
+        url = self._client.relative_url(
+            "/v1/immutable/{}/{}/abort".format(_encode_si(storage_index), share_number)
+        )
+        response = yield self._client.request(
+            "PUT",
+            url,
+            upload_secret=upload_secret,
+        )
+
+        if response.code == http.OK:
+            return
+        else:
+            raise ClientException(
+                response.code,
+            )
 
     @inlineCallbacks
     def write_share_chunk(

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -182,10 +182,7 @@ class UploadsInProgress(object):
         If the given upload doesn't exist at all, nothing happens.
         """
         if storage_index in self._uploads:
-            try:
-                in_progress = self._uploads[storage_index]
-            except KeyError:
-                return
+            in_progress = self._uploads[storage_index]
             # For pre-existing upload, make sure password matches.
             if share_number in in_progress.upload_secrets and not timing_safe_compare(
                 in_progress.upload_secrets[share_number], upload_secret

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -167,8 +167,8 @@ class UploadsInProgress(object):
         self, storage_index: bytes, share_number: int, upload_secret: bytes
     ) -> BucketWriter:
         """Get the given in-progress immutable share upload."""
+        self.validate_upload_secret(storage_index, share_number, upload_secret)
         try:
-            # TODO 3877 check the upload secret matches given one
             return self._uploads[storage_index].shares[share_number]
         except (KeyError, IndexError):
             raise _HTTPError(http.NOT_FOUND)
@@ -344,8 +344,6 @@ class HTTPServer(object):
             return b""
 
         offset = content_range.start
-
-        # TODO 3877 test for checking upload secret
 
         # TODO limit memory usage
         # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3872

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1059,7 +1059,8 @@ class _HTTPBucketWriter(object):
     finished = attr.ib(type=bool, default=False)
 
     def abort(self):
-        pass  # TODO in later ticket
+        return self.client.abort_upload(self.storage_index, self.share_number,
+                                        self.upload_secret)
 
     @defer.inlineCallbacks
     def write(self, offset, data):

--- a/src/allmydata/test/test_istorageserver.py
+++ b/src/allmydata/test/test_istorageserver.py
@@ -176,8 +176,9 @@ class IStorageServerImmutableAPIsTestsMixin(object):
             canary=Referenceable(),
         )
 
-        # Bucket 1 is fully written in one go.
-        yield allocated[0].callRemote("write", 0, b"1" * 1024)
+        # Bucket 1 get some data written (but not all, or HTTP implicitly
+        # finishes the upload)
+        yield allocated[0].callRemote("write", 0, b"1" * 1023)
 
         # Disconnect or abort, depending on the test:
         yield abort_or_disconnect(allocated[0])
@@ -1156,7 +1157,6 @@ class HTTPImmutableAPIsTests(
 
     # These will start passing in future PRs as HTTP protocol is implemented.
     SKIP_TESTS = {
-        "test_abort",
         "test_add_lease_renewal",
         "test_add_new_lease",
         "test_advise_corrupt_share",

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -934,7 +934,8 @@ class ImmutableHTTPAPITests(SyncTestCase):
 
     def test_unknown_aborts(self):
         """
-        Aborting aborts with unknown storage index or share number will 404.
+        Aborting uploads with an unknown storage index or share number will
+        result 404 HTTP response code.
         """
         (upload_secret, _, storage_index, _) = self.create_upload({1}, 100)
 

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -474,6 +474,21 @@ class ImmutableHTTPAPITests(SyncTestCase):
             )
             self.assertEqual(downloaded, expected_data[offset : offset + length])
 
+    def test_write_with_wrong_upload_key(self):
+        """A write with the wrong upload key fails."""
+        (upload_secret, _, storage_index, _) = self.create_upload({1}, 100)
+        with self.assertRaises(ClientException) as e:
+            result_of(
+                self.imm_client.write_share_chunk(
+                    storage_index,
+                    1,
+                    upload_secret + b"X",
+                    0,
+                    b"123",
+                )
+            )
+        self.assertEqual(e.exception.args[0], http.UNAUTHORIZED)
+
     def test_allocate_buckets_second_time_wrong_upload_key(self):
         """
         If allocate buckets endpoint is called second time with wrong upload

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -489,7 +489,10 @@ class ImmutableHTTPAPITests(SyncTestCase):
             self.assertEqual(downloaded, expected_data[offset : offset + length])
 
     def test_write_with_wrong_upload_key(self):
-        """A write with the wrong upload key fails."""
+        """
+        A write with an upload key that is different than the original upload
+        key will fail.
+        """
         (upload_secret, _, storage_index, _) = self.create_upload({1}, 100)
         with assert_fails_with_http_code(self, http.UNAUTHORIZED):
             result_of(


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3877

* Add abort API
* Clean up the code and tests a bunch to make future functionality easier to add, and remove duplication
* Fix bug where timed out bucket wasn't removed
* Fix bug where writes didn't authenticate(!) 
* Fix test bug where a (wrong) assertion was never reached