### PR TITLE
CBOR refactor for HTTP storage protocol

### DIFF
--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -123,7 +123,11 @@ class StorageClient(object):
         # If there's a request message, serialize it and set the Content-Type
         # header:
         if message_to_serialize is not None:
-            assert "data" not in kwargs
+            if "data" in kwargs:
+                raise TypeError(
+                    "Can't use both `message_to_serialize` and `data` "
+                    "as keyword arguments at the same time"
+                )
             kwargs["data"] = dumps(message_to_serialize)
             headers.addRawHeader("Content-Type", CBOR_MIME_TYPE)
 

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -32,6 +32,7 @@ import attr
 from cbor2 import loads, dumps
 from collections_extended import RangeMap
 from werkzeug.datastructures import Range, ContentRange
+from werkzeug.http import parse_options_header
 from twisted.web.http_headers import Headers
 from twisted.web import http
 from twisted.internet.defer import inlineCallbacks, returnValue, fail, Deferred
@@ -58,7 +59,10 @@ class ClientException(Exception):
 def _decode_cbor(response):
     """Given HTTP response, return decoded CBOR body."""
     if response.code > 199 and response.code < 300:
-        if response.headers.getRawHeaders("content-type") == ["application/cbor"]:
+        content_type = parse_options_header(
+            (response.headers.getRawHeaders("content-type") or [None])[0]
+        )[0]
+        if content_type == "application/cbor":
             # TODO limit memory usage
             # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3872
             return treq.content(response).addCallback(loads)

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -19,7 +19,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue, fail, Deferred
 from hyperlink import DecodedURL
 import treq
 
-from .http_common import swissnum_auth_header, Secrets, get_content_type
+from .http_common import swissnum_auth_header, Secrets, get_content_type, CBOR_MIME_TYPE
 from .common import si_b2a
 
 
@@ -40,7 +40,7 @@ def _decode_cbor(response):
     """Given HTTP response, return decoded CBOR body."""
     if response.code > 199 and response.code < 300:
         content_type = get_content_type(response.headers)
-        if content_type == "application/cbor":
+        if content_type == CBOR_MIME_TYPE:
             # TODO limit memory usage
             # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3872
             return treq.content(response).addCallback(loads)
@@ -186,7 +186,7 @@ class StorageClientImmutables(object):
             lease_cancel_secret=lease_cancel_secret,
             upload_secret=upload_secret,
             data=message,
-            headers=Headers({"content-type": ["application/cbor"]}),
+            headers=Headers({"content-type": [CBOR_MIME_TYPE]}),
         )
         decoded_response = yield _decode_cbor(response)
         returnValue(
@@ -362,7 +362,7 @@ class StorageClientImmutables(object):
             "POST",
             url,
             data=message,
-            headers=Headers({"content-type": ["application/cbor"]}),
+            headers=Headers({"content-type": [CBOR_MIME_TYPE]}),
         )
         if response.code == http.OK:
             return

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -2,27 +2,8 @@
 HTTP client that talks to the HTTP storage server.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from future.utils import PY2
-
-if PY2:
-    # fmt: off
-    from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
-    # fmt: on
-    from collections import defaultdict
-
-    Optional = Set = defaultdict(
-        lambda: None
-    )  # some garbage to just make this module import
-else:
-    # typing module not available in Python 2, and we only do type checking in
-    # Python 3 anyway.
-    from typing import Union, Set, Optional
-    from treq.testing import StubTreq
+from typing import Union, Set, Optional
+from treq.testing import StubTreq
 
 from base64 import b64encode
 

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -99,6 +99,8 @@ class StorageClient(object):
         into corresponding HTTP headers.
         """
         headers = self._get_headers(headers)
+
+        # Add secrets:
         for secret, value in [
             (Secrets.LEASE_RENEW, lease_renew_secret),
             (Secrets.LEASE_CANCEL, lease_cancel_secret),
@@ -110,6 +112,10 @@ class StorageClient(object):
                 "X-Tahoe-Authorization",
                 b"%s %s" % (secret.value.encode("ascii"), b64encode(value).strip()),
             )
+
+        # Note we can accept CBOR:
+        headers.addRawHeader("Accept", CBOR_MIME_TYPE)
+
         return self._treq.request(method, url, headers=headers, **kwargs)
 
 

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -13,14 +13,13 @@ import attr
 from cbor2 import loads, dumps
 from collections_extended import RangeMap
 from werkzeug.datastructures import Range, ContentRange
-from werkzeug.http import parse_options_header
 from twisted.web.http_headers import Headers
 from twisted.web import http
 from twisted.internet.defer import inlineCallbacks, returnValue, fail, Deferred
 from hyperlink import DecodedURL
 import treq
 
-from .http_common import swissnum_auth_header, Secrets
+from .http_common import swissnum_auth_header, Secrets, get_content_type
 from .common import si_b2a
 
 
@@ -40,9 +39,7 @@ class ClientException(Exception):
 def _decode_cbor(response):
     """Given HTTP response, return decoded CBOR body."""
     if response.code > 199 and response.code < 300:
-        content_type = parse_options_header(
-            (response.headers.getRawHeaders("content-type") or [None])[0]
-        )[0]
+        content_type = get_content_type(response.headers)
         if content_type == "application/cbor":
             # TODO limit memory usage
             # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3872

--- a/src/allmydata/storage/http_common.py
+++ b/src/allmydata/storage/http_common.py
@@ -9,6 +9,8 @@ from typing import Optional
 from werkzeug.http import parse_options_header
 from twisted.web.http_headers import Headers
 
+CBOR_MIME_TYPE = "application/cbor"
+
 
 def get_content_type(headers: Headers) -> Optional[str]:
     """

--- a/src/allmydata/storage/http_common.py
+++ b/src/allmydata/storage/http_common.py
@@ -1,15 +1,24 @@
 """
 Common HTTP infrastructure for the storge server.
 """
-from future.utils import PY2
-
-if PY2:
-    # fmt: off
-    from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
-    # fmt: on
 
 from enum import Enum
 from base64 import b64encode
+from typing import Optional
+
+from werkzeug.http import parse_options_header
+from twisted.web.http_headers import Headers
+
+
+def get_content_type(headers: Headers) -> Optional[str]:
+    """
+    Get the content type from the HTTP ``Content-Type`` header.
+
+    Returns ``None`` if no content-type was set.
+    """
+    values = headers.getRawHeaders("content-type") or [None]
+    content_type = parse_options_header(values[0])[0] or None
+    return content_type
 
 
 def swissnum_auth_header(swissnum):  # type: (bytes) -> bytes

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -23,7 +23,7 @@ from werkzeug.datastructures import ContentRange
 from cbor2 import dumps, loads
 
 from .server import StorageServer
-from .http_common import swissnum_auth_header, Secrets, get_content_type
+from .http_common import swissnum_auth_header, Secrets, get_content_type, CBOR_MIME_TYPE
 from .common import si_a2b
 from .immutable import BucketWriter, ConflictingWriteError
 from ..util.hashutil import timing_safe_compare
@@ -254,11 +254,12 @@ class HTTPServer(object):
 
         Also sets the appropriate ``Content-Type`` header on the response.
         """
-        cbor_mime = "application/cbor"
-        accept_headers = request.requestHeaders.getRawHeaders("accept") or [cbor_mime]
+        accept_headers = request.requestHeaders.getRawHeaders("accept") or [
+            CBOR_MIME_TYPE
+        ]
         accept = parse_accept_header(accept_headers[0])
-        if accept.best == cbor_mime:
-            request.setHeader("Content-Type", cbor_mime)
+        if accept.best == CBOR_MIME_TYPE:
+            request.setHeader("Content-Type", CBOR_MIME_TYPE)
             # TODO if data is big, maybe want to use a temporary file eventually...
             # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3872
             return dumps(data)
@@ -272,7 +273,7 @@ class HTTPServer(object):
         Read encoded request body data, decoding it with CBOR by default.
         """
         content_type = get_content_type(request.requestHeaders)
-        if content_type == "application/cbor":
+        if content_type == CBOR_MIME_TYPE:
             # TODO limit memory usage, client could send arbitrarily large data...
             # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3872
             return loads(request.content.read())

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -249,7 +249,10 @@ class HTTPServer(object):
 
     def _send_encoded(self, request, data):
         """
-        Return encoded data as the HTTP body response, by default using CBOR.
+        Return encoded data suitable for writing as the HTTP body response, by
+        default using CBOR.
+
+        Also sets the appropriate ``Content-Type`` header on the response.
         """
         cbor_mime = "application/cbor"
         accept_headers = request.requestHeaders.getRawHeaders("accept") or [cbor_mime]

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -49,7 +49,27 @@ from ..storage.http_client import (
     StorageClientGeneral,
     _encode_si,
 )
+from ..storage.http_common import get_content_type
 from ..storage.common import si_b2a
+
+
+class HTTPUtilities(SyncTestCase):
+    """Tests for HTTP common utilities."""
+
+    def test_get_content_type(self):
+        """``get_content_type()`` extracts the content-type from the header."""
+
+        def assert_header_values_result(values, expected_content_type):
+            headers = Headers()
+            if values:
+                headers.setRawHeaders("Content-Type", values)
+            content_type = get_content_type(headers)
+            self.assertEqual(content_type, expected_content_type)
+
+        assert_header_values_result(["text/html"], "text/html")
+        assert_header_values_result([], None)
+        assert_header_values_result(["text/plain", "application/json"], "text/plain")
+        assert_header_values_result(["text/html;encoding=utf-8"], "text/html")
 
 
 def _post_process(params):

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -358,6 +358,17 @@ class GenericHTTPAPITests(SyncTestCase):
         with assert_fails_with_http_code(self, http.UNAUTHORIZED):
             result_of(client.get_version())
 
+    def test_unsupported_mime_type(self):
+        """
+        The client can request mime types other than CBOR, and if they are
+        unsupported a NOT ACCEPTABLE (406) error will be returned.
+        """
+        client = StorageClientGeneral(
+            StorageClientWithHeadersOverride(self.http.client, {"accept": "image/gif"})
+        )
+        with assert_fails_with_http_code(self, http.NOT_ACCEPTABLE):
+            result_of(client.get_version())
+
     def test_version(self):
         """
         The client can return the version.


### PR DESCRIPTION
Add support for relevant HTTP headers, and centralize the logic.

Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3881