### PR TITLE
Mutable storage HTTP API, part 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,6 @@ workflows:
           {}
       - "pyinstaller":
           {}
-      - "deprecations":
-          {}
       - "c-locale":
           {}
       # Any locale other than C or UTF-8.
@@ -296,20 +294,6 @@ jobs:
       <<: *UTF_8_ENVIRONMENT
       # aka "Latin 1"
       LANG: "en_US.ISO-8859-1"
-
-
-  deprecations:
-    <<: *DEBIAN
-
-    environment:
-      <<: *UTF_8_ENVIRONMENT
-      # Select the deprecations tox environments.
-      TAHOE_LAFS_TOX_ENVIRONMENT: "deprecations,upcoming-deprecations"
-      # Put the logs somewhere we can report them.
-      TAHOE_LAFS_WARNINGS_LOG: "/tmp/artifacts/deprecation-warnings.log"
-      # The deprecations tox environments don't do coverage measurement.
-      UPLOAD_COVERAGE: ""
-
 
   integration:
     <<: *DEBIAN

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -743,11 +743,15 @@ For example::
 
   [1, 5]
 
-``GET /v1/mutable/:storage_index?share=:s0&share=:sN&offset=:o1&size=:z0&offset=:oN&size=:zN``
+``GET /v1/mutable/:storage_index/:share_number``
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-Read data from the indicated mutable shares.
-Just like ``GET /v1/mutable/:storage_index``.
+Read data from the indicated mutable shares, just like ``GET /v1/immutable/:storage_index``
+
+The ``Range`` header may be used to request exactly one ``bytes`` range, in which case the response code will be 206 (partial content).
+Interpretation and response behavior is as specified in RFC 7233 § 4.1.
+Multiple ranges in a single request are *not* supported; open-ended ranges are also not supported.
+
 
 ``POST /v1/mutable/:storage_index/:share_number/corrupt``
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -5,7 +5,6 @@ HTTP client that talks to the HTTP storage server.
 from __future__ import annotations
 
 from typing import Union, Set, Optional
-from enum import Enum
 from base64 import b64encode
 
 from attrs import define, field, asdict

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -4,10 +4,10 @@ HTTP client that talks to the HTTP storage server.
 
 from __future__ import annotations
 
-from typing import Union, Set, Optional
+from typing import Union, Optional, Sequence, Mapping
 from base64 import b64encode
 
-from attrs import define, field, asdict
+from attrs import define, asdict, frozen
 
 # TODO Make sure to import Python version?
 from cbor2 import loads, dumps
@@ -134,8 +134,8 @@ def _decode_cbor(response, schema: Schema):
 class ImmutableCreateResult(object):
     """Result of creating a storage index for an immutable."""
 
-    already_have: Set[int]
-    allocated: Set[int]
+    already_have: set[int]
+    allocated: set[int]
 
 
 class _TLSContextFactory(CertificateOptions):
@@ -420,7 +420,7 @@ class StorageClientImmutables(object):
         upload_secret,
         lease_renew_secret,
         lease_cancel_secret,
-    ):  # type: (bytes, Set[int], int, bytes, bytes, bytes) -> Deferred[ImmutableCreateResult]
+    ):  # type: (bytes, set[int], int, bytes, bytes, bytes) -> Deferred[ImmutableCreateResult]
         """
         Create a new storage index for an immutable.
 
@@ -534,7 +534,7 @@ class StorageClientImmutables(object):
         )
 
     @inlineCallbacks
-    def list_shares(self, storage_index):  # type: (bytes,) -> Deferred[Set[int]]
+    def list_shares(self, storage_index):  # type: (bytes,) -> Deferred[set[int]]
         """
         Return the set of shares for a given storage index.
         """
@@ -600,7 +600,7 @@ class StorageClientImmutables(object):
             )
 
 
-@define
+@frozen
 class WriteVector:
     """Data to write to a chunk."""
 
@@ -608,7 +608,7 @@ class WriteVector:
     data: bytes
 
 
-@define
+@frozen
 class TestVector:
     """Checks to make on a chunk before writing to it."""
 
@@ -617,7 +617,7 @@ class TestVector:
     specimen: bytes
 
 
-@define
+@frozen
 class ReadVector:
     """
     Reads to do on chunks, as part of a read/test/write operation.
@@ -627,13 +627,13 @@ class ReadVector:
     size: int
 
 
-@define
+@frozen
 class TestWriteVectors:
     """Test and write vectors for a specific share."""
 
-    test_vectors: list[TestVector]
-    write_vectors: list[WriteVector]
-    new_length: Optional[int] = field(default=None)
+    test_vectors: Sequence[TestVector]
+    write_vectors: Sequence[WriteVector]
+    new_length: Optional[int] = None
 
     def asdict(self) -> dict:
         """Return dictionary suitable for sending over CBOR."""
@@ -644,17 +644,17 @@ class TestWriteVectors:
         return d
 
 
-@define
+@frozen
 class ReadTestWriteResult:
     """Result of sending read-test-write vectors."""
 
     success: bool
     # Map share numbers to reads corresponding to the request's list of
     # ReadVectors:
-    reads: dict[int, list[bytes]]
+    reads: Mapping[int, Sequence[bytes]]
 
 
-@define
+@frozen
 class StorageClientMutables:
     """
     APIs for interacting with mutables.

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -8,7 +8,7 @@ from typing import Union, Set, Optional
 
 from base64 import b64encode
 
-import attr
+from attrs import define
 
 # TODO Make sure to import Python version?
 from cbor2 import loads, dumps
@@ -121,12 +121,12 @@ def _decode_cbor(response, schema: Schema):
         )
 
 
-@attr.s
+@define
 class ImmutableCreateResult(object):
     """Result of creating a storage index for an immutable."""
 
-    already_have = attr.ib(type=Set[int])
-    allocated = attr.ib(type=Set[int])
+    already_have: Set[int]
+    allocated: Set[int]
 
 
 class _TLSContextFactory(CertificateOptions):
@@ -200,14 +200,14 @@ class _TLSContextFactory(CertificateOptions):
 
 @implementer(IPolicyForHTTPS)
 @implementer(IOpenSSLClientConnectionCreator)
-@attr.s
+@define
 class _StorageClientHTTPSPolicy:
     """
     A HTTPS policy that ensures the SPKI hash of the public key matches a known
     hash, i.e. pinning-based validation.
     """
 
-    expected_spki_hash = attr.ib(type=bytes)
+    expected_spki_hash: bytes
 
     # IPolicyForHTTPS
     def creatorForNetloc(self, hostname, port):
@@ -220,24 +220,22 @@ class _StorageClientHTTPSPolicy:
         )
 
 
+@define
 class StorageClient(object):
     """
     Low-level HTTP client that talks to the HTTP storage server.
     """
 
-    def __init__(
-        self, url, swissnum, treq=treq
-    ):  # type: (DecodedURL, bytes, Union[treq,StubTreq,HTTPClient]) -> None
-        """
-        The URL is a HTTPS URL ("https://...").  To construct from a NURL, use
-        ``StorageClient.from_nurl()``.
-        """
-        self._base_url = url
-        self._swissnum = swissnum
-        self._treq = treq
+    # The URL is a HTTPS URL ("https://...").  To construct from a NURL, use
+    # ``StorageClient.from_nurl()``.
+    _base_url: DecodedURL
+    _swissnum: bytes
+    _treq: Union[treq, StubTreq, HTTPClient]
 
     @classmethod
-    def from_nurl(cls, nurl: DecodedURL, reactor, persistent: bool = True) -> StorageClient:
+    def from_nurl(
+        cls, nurl: DecodedURL, reactor, persistent: bool = True
+    ) -> StorageClient:
         """
         Create a ``StorageClient`` for the given NURL.
 
@@ -342,25 +340,25 @@ class StorageClientGeneral(object):
         returnValue(decoded_response)
 
 
-@attr.s
+@define
 class UploadProgress(object):
     """
     Progress of immutable upload, per the server.
     """
 
     # True when upload has finished.
-    finished = attr.ib(type=bool)
+    finished: bool
     # Remaining ranges to upload.
-    required = attr.ib(type=RangeMap)
+    required: RangeMap
 
 
+@define
 class StorageClientImmutables(object):
     """
     APIs for interacting with immutables.
     """
 
-    def __init__(self, client: StorageClient):
-        self._client = client
+    _client: StorageClient
 
     @inlineCallbacks
     def create(

--- a/src/allmydata/storage/http_common.py
+++ b/src/allmydata/storage/http_common.py
@@ -38,6 +38,7 @@ class Secrets(Enum):
     LEASE_RENEW = "lease-renew-secret"
     LEASE_CANCEL = "lease-cancel-secret"
     UPLOAD = "upload-secret"
+    WRITE_ENABLER = "write-enabler"
 
 
 def get_spki_hash(certificate: Certificate) -> bytes:

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -589,8 +589,15 @@ class HTTPServer(object):
         success, read_data = self._storage_server.slot_testv_and_readv_and_writev(
             storage_index,
             secrets,
-            rtw_request["test-write-vectors"],
-            rtw_request["read-vector"],
+            {
+                k: (
+                    [(d["offset"], d["size"], b"eq", d["specimen"]) for d in v["test"]],
+                    [(d["offset"], d["data"]) for d in v["write"]],
+                    v["new-length"],
+                )
+                for (k, v) in rtw_request["test-write-vectors"].items()
+            },
+            [(d["offset"], d["size"]) for d in rtw_request["read-vector"]],
         )
         return self._send_encoded(request, {"success": success, "data": read_data})
 

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -261,7 +261,7 @@ _SCHEMAS = {
                 * share_number: {
                     "test": [* {"offset": uint, "size": uint, "specimen": bstr}]
                     "write": [* {"offset": uint, "data": bstr}]
-                    "new-length": (uint // null)
+                    "new-length": uint // null
                 }
             }
             "read-vector": [* {"offset": uint, "size": uint}]
@@ -590,7 +590,7 @@ class HTTPServer(object):
             storage_index,
             secrets,
             rtw_request["test-write-vectors"],
-            rtw_request["read-vectors"],
+            rtw_request["read-vector"],
         )
         return self._send_encoded(request, {"success": success, "data": read_data})
 

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -261,7 +261,7 @@ _SCHEMAS = {
                 * share_number: {
                     "test": [* {"offset": uint, "size": uint, "specimen": bstr}]
                     "write": [* {"offset": uint, "data": bstr}]
-                    "new-length": uint
+                    "new-length": (uint // null)
                 }
             }
             "read-vector": [* {"offset": uint, "size": uint}]

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -570,7 +570,7 @@ class HTTPServer(object):
         bucket.advise_corrupt_share(info["reason"].encode("utf-8"))
         return b""
 
-    ##### Immutable APIs #####
+    ##### Mutable APIs #####
 
     @_authorized_route(
         _app,

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -580,6 +580,7 @@ class HTTPServer(object):
     )
     def mutable_read_test_write(self, request, authorization, storage_index):
         """Read/test/write combined operation for mutables."""
+        # TODO unit tests
         rtw_request = self._read_encoded(request, _SCHEMAS["mutable_read_test_write"])
         secrets = (
             authorization[Secrets.WRITE_ENABLER],

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1195,18 +1195,17 @@ class _HTTPStorageServer(object):
     def slot_readv(self, storage_index, shares, readv):
         mutable_client = StorageClientMutables(self._http_client)
         reads = {}
+        # TODO if shares list is empty, that means list all shares, so we need
+        # to do a query to get that.
+        assert shares  # TODO replace with call to list shares
         for share_number in shares:
             share_reads = reads[share_number] = []
             for (offset, length) in readv:
-                d = mutable_client.read_share_chunk(
+                r = yield mutable_client.read_share_chunk(
                     storage_index, share_number, offset, length
                 )
-                share_reads.append(d)
-        result = {
-            share_number: [(yield d) for d in share_reads]
-            for (share_number, reads) in reads.items()
-        }
-        defer.returnValue(result)
+                share_reads.append(r)
+        defer.returnValue(reads)
 
     @defer.inlineCallbacks
     def slot_testv_and_readv_and_writev(

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -1197,7 +1197,7 @@ class _HTTPStorageServer(object):
         reads = {}
         # TODO if shares list is empty, that means list all shares, so we need
         # to do a query to get that.
-        assert shares  # TODO replace with call to list shares
+        assert shares  # TODO replace with call to list shares if and only if it's empty
         for share_number in shares:
             share_reads = reads[share_number] = []
             for (offset, length) in readv:

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -78,7 +78,7 @@ from allmydata.util.dictutil import BytesKeyDict, UnicodeKeyDict
 from allmydata.storage.http_client import (
     StorageClient, StorageClientImmutables, StorageClientGeneral,
     ClientException as HTTPClientException, StorageClientMutables,
-    ReadVector, TestWriteVectors, WriteVector, TestVector, TestVectorOperator
+    ReadVector, TestWriteVectors, WriteVector, TestVector
 )
 
 
@@ -1221,8 +1221,8 @@ class _HTTPStorageServer(object):
         client_tw_vectors = {}
         for share_num, (test_vector, data_vector, new_length) in tw_vectors.items():
             client_test_vectors = [
-                TestVector(offset=offset, size=size, operator=TestVectorOperator[op], specimen=specimen)
-                for (offset, size, op, specimen) in test_vector
+                TestVector(offset=offset, size=size, specimen=specimen)
+                for (offset, size, specimen) in test_vector
             ]
             client_write_vectors = [
                 WriteVector(offset=offset, data=data) for (offset, data) in data_vector

--- a/src/allmydata/test/test_deferredutil.py
+++ b/src/allmydata/test/test_deferredutil.py
@@ -129,3 +129,31 @@ class UntilTests(unittest.TestCase):
         self.assertEqual([1], counter)
         r1.callback(None)
         self.assertEqual([2], counter)
+
+
+class AsyncToDeferred(unittest.TestCase):
+    """Tests for ``deferredutil.async_to_deferred.``"""
+
+    def test_async_to_deferred_success(self):
+        """
+        Normal results from a ``@async_to_deferred``-wrapped function get
+        turned into a ``Deferred`` with that value.
+        """
+        @deferredutil.async_to_deferred
+        async def f(x, y):
+            return x + y
+
+        result = f(1, y=2)
+        self.assertEqual(self.successResultOf(result), 3)
+
+    def test_async_to_deferred_exception(self):
+        """
+        Exceptions from a ``@async_to_deferred``-wrapped function get
+        turned into a ``Deferred`` with that value.
+        """
+        @deferredutil.async_to_deferred
+        async def f(x, y):
+            return x/y
+
+        result = f(1, 0)
+        self.assertIsInstance(self.failureResultOf(result).value, ZeroDivisionError)

--- a/src/allmydata/test/test_istorageserver.py
+++ b/src/allmydata/test/test_istorageserver.py
@@ -1140,4 +1140,10 @@ class HTTPImmutableAPIsTests(
 class FoolscapMutableAPIsTests(
     _FoolscapMixin, IStorageServerMutableAPIsTestsMixin, AsyncTestCase
 ):
-    """Foolscap-specific tests for immutable ``IStorageServer`` APIs."""
+    """Foolscap-specific tests for mutable ``IStorageServer`` APIs."""
+
+
+class HTTPMutableAPIsTests(
+    _HTTPMixin, IStorageServerMutableAPIsTestsMixin, AsyncTestCase
+):
+    """HTTP-specific tests for mutable ``IStorageServer`` APIs."""

--- a/src/allmydata/test/test_istorageserver.py
+++ b/src/allmydata/test/test_istorageserver.py
@@ -1147,3 +1147,12 @@ class HTTPMutableAPIsTests(
     _HTTPMixin, IStorageServerMutableAPIsTestsMixin, AsyncTestCase
 ):
     """HTTP-specific tests for mutable ``IStorageServer`` APIs."""
+
+    # TODO will be implemented in later tickets
+    SKIP_TESTS = {
+        "test_STARAW_write_enabler_must_match",
+        "test_add_lease_renewal",
+        "test_add_new_lease",
+        "test_advise_corrupt_share",
+        "test_slot_readv_no_shares",
+    }

--- a/src/allmydata/test/test_storage_https.py
+++ b/src/allmydata/test/test_storage_https.py
@@ -6,14 +6,12 @@ server authentication logic, which may one day apply outside of HTTP Storage
 Protocol.
 """
 
-from functools import wraps
 from contextlib import asynccontextmanager
 
 from cryptography import x509
 
 from twisted.internet.endpoints import serverFromString
 from twisted.internet import reactor
-from twisted.internet.defer import Deferred
 from twisted.internet.task import deferLater
 from twisted.web.server import Site
 from twisted.web.static import Data
@@ -31,6 +29,7 @@ from .certs import (
 from ..storage.http_common import get_spki_hash
 from ..storage.http_client import _StorageClientHTTPSPolicy
 from ..storage.http_server import _TLSEndpointWrapper
+from ..util.deferredutil import async_to_deferred
 
 
 class HTTPSNurlTests(SyncTestCase):
@@ -71,20 +70,6 @@ ox5zO3LrQmQw11OaIAs2/kviKAoKTFFxeyYcpS5RuKNDZfHQCXlLwt9bySxG
 """
         certificate = x509.load_pem_x509_certificate(certificate_text)
         self.assertEqual(get_spki_hash(certificate), expected_hash)
-
-
-def async_to_deferred(f):
-    """
-    Wrap an async function to return a Deferred instead.
-
-    Maybe solution to https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3886
-    """
-
-    @wraps(f)
-    def not_async(*args, **kwargs):
-        return Deferred.fromCoroutine(f(*args, **kwargs))
-
-    return not_async
 
 
 class PinningHTTPSValidation(AsyncTestCase):

--- a/src/allmydata/util/deferredutil.py
+++ b/src/allmydata/util/deferredutil.py
@@ -4,24 +4,13 @@ Utilities for working with Twisted Deferreds.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from future.utils import PY2
-if PY2:
-    from builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
-
 import time
+from functools import wraps
 
-try:
-    from typing import (
-        Callable,
-        Any,
-    )
-except ImportError:
-    pass
+from typing import (
+    Callable,
+    Any,
+)
 
 from foolscap.api import eventually
 from eliot.twisted import (
@@ -231,3 +220,17 @@ def until(
         yield action()
         if condition():
             break
+
+
+def async_to_deferred(f):
+    """
+    Wrap an async function to return a Deferred instead.
+
+    Maybe solution to https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3886
+    """
+
+    @wraps(f)
+    def not_async(*args, **kwargs):
+        return defer.Deferred.fromCoroutine(f(*args, **kwargs))
+
+    return not_async


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3890

This makes some of the end-to-end tests pass, implements writes, and implements some of the for read logic for mutable shares.

Follow-up PRs/tickets will finish up the read logic, add missing endpoints (listing shares, leases, corruption notification), and unit test coverage.