### PR TITLE
Fix integration test for Tor

### DIFF
--- a/integration/test_tor.py
+++ b/integration/test_tor.py
@@ -21,7 +21,8 @@ from . import util
 from twisted.python.filepath import (
     FilePath,
 )
-
+from twisted.internet.task import deferLater
+from twisted.internet import reactor
 from allmydata.test.common import (
     write_introducer,
 )
@@ -68,6 +69,9 @@ def test_onion_service_storage(reactor, request, temp_dir, flog_gatherer, tor_ne
     cap = proto.output.getvalue().strip().split()[-1]
     print("TEH CAP!", cap)
 
+    # For some reason a wait is needed, or sometimes the get fails...
+    yield deferLater(reactor, 2, lambda: None)
+    
     proto = util._CollectOutputProtocol(capture_stderr=False)
     reactor.spawnProcess(
         proto,

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ setenv =
          COVERAGE_PROCESS_START=.coveragerc
 commands =
          # NOTE: 'run with "py.test --keep-tempdir -s -v integration/" to debug failures'
-         py.test --timeout=1800 --coverage -v {posargs:integration}
+         py.test --timeout=1800 --coverage -s -v {posargs:integration}
          coverage combine
          coverage report
 


### PR DESCRIPTION
Or maybe "fix"

https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3895

My feeling is that insofar as the test's goal is to test _Tor_, this "fix" doesn't detract from the test's validity. I admit to not being happy about, nor understanding quite where the lag comes from.