### PR TITLE
Improved HTTP response length handling

### DIFF
--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -654,6 +654,8 @@ The ``Range`` header may be used to request exactly one ``bytes`` range, in whic
 Interpretation and response behavior is as specified in RFC 7233 § 4.1.
 Multiple ranges in a single request are *not* supported; open-ended ranges are also not supported.
 
+If the response to a query is an empty range, the ``NO CONTENT`` (204) response code will be used.
+
 Discussion
 ``````````
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -654,7 +654,7 @@ The ``Range`` header may be used to request exactly one ``bytes`` range, in whic
 Interpretation and response behavior is as specified in RFC 7233 § 4.1.
 Multiple ranges in a single request are *not* supported; open-ended ranges are also not supported.
 
-If the response reads beyond the end fo the data, the response may be shorter than then requested range.
+If the response reads beyond the end of the data, the response may be shorter than the requested range.
 The resulting ``Content-Range`` header will be consistent with the returned data.
 
 If the response to a query is an empty range, the ``NO CONTENT`` (204) response code will be used.
@@ -759,7 +759,7 @@ The ``Range`` header may be used to request exactly one ``bytes`` range, in whic
 Interpretation and response behavior is as specified in RFC 7233 § 4.1.
 Multiple ranges in a single request are *not* supported; open-ended ranges are also not supported.
 
-If the response reads beyond the end fo the data, the response may be shorter than then requested range.
+If the response reads beyond the end of the data, the response may be shorter than the requested range.
 The resulting ``Content-Range`` header will be consistent with the returned data.
 
 If the response to a query is an empty range, the ``NO CONTENT`` (204) response code will be used.

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -654,6 +654,9 @@ The ``Range`` header may be used to request exactly one ``bytes`` range, in whic
 Interpretation and response behavior is as specified in RFC 7233 § 4.1.
 Multiple ranges in a single request are *not* supported; open-ended ranges are also not supported.
 
+If the response reads beyond the end fo the data, the response may be shorter than then requested range.
+The resulting ``Content-Range`` header will be consistent with the returned data.
+
 If the response to a query is an empty range, the ``NO CONTENT`` (204) response code will be used.
 
 Discussion
@@ -755,6 +758,11 @@ Read data from the indicated mutable shares, just like ``GET /v1/immutable/:stor
 The ``Range`` header may be used to request exactly one ``bytes`` range, in which case the response code will be 206 (partial content).
 Interpretation and response behavior is as specified in RFC 7233 § 4.1.
 Multiple ranges in a single request are *not* supported; open-ended ranges are also not supported.
+
+If the response reads beyond the end fo the data, the response may be shorter than then requested range.
+The resulting ``Content-Range`` header will be consistent with the returned data.
+
+If the response to a query is an empty range, the ``NO CONTENT`` (204) response code will be used.
 
 
 ``POST /v1/mutable/:storage_index/:share_number/corrupt``

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -494,7 +494,7 @@ def read_share_chunk(
         actual_length = body.tell()
         if actual_length != supposed_length:
             # Most likely a mutable that got changed out from under us, but
-            # concievably could be a bug...
+            # conceivably could be a bug...
             raise ValueError(
                 f"Length of response sent from server ({actual_length}) "
                 + f"didn't match Content-Range header ({supposed_length})"

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -474,8 +474,16 @@ def read_share_chunk(
 
     if response.code == http.PARTIAL_CONTENT:
         content_range = parse_content_range_header(
-            response.headers.getRawHeaders("content-range")[0]
+            response.headers.getRawHeaders("content-range")[0] or ""
         )
+        if (
+            content_range is None
+            or content_range.stop is None
+            or content_range.start is None
+        ):
+            raise ValueError(
+                "Content-Range was missing, invalid, or in format we don't support"
+            )
         supposed_length = content_range.stop - content_range.start
         if supposed_length > length:
             raise ValueError("Server sent more than we asked for?!")

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Union, Optional, Sequence, Mapping, BinaryIO
 from base64 import b64encode
 from io import BytesIO
+from os import SEEK_END
 
 from attrs import define, asdict, frozen, field
 
@@ -29,6 +30,7 @@ from treq.client import HTTPClient
 from treq.testing import StubTreq
 from OpenSSL import SSL
 from cryptography.hazmat.bindings.openssl.binding import Binding
+from werkzeug.http import parse_content_range_header
 
 from .http_common import (
     swissnum_auth_header,
@@ -461,13 +463,36 @@ def read_share_chunk(
         "GET",
         url,
         headers=Headers(
+            # Ranges in HTTP are _inclusive_, Python's convention is exclusive,
+            # but Range constructor does that the conversion for us.
             {"range": [Range("bytes", [(offset, offset + length)]).to_header()]}
         ),
     )
     if response.code == http.PARTIAL_CONTENT:
-        body = yield response.content()
-        returnValue(body)
+        content_range = parse_content_range_header(
+            response.headers.getRawHeaders("content-range")[0]
+        )
+        supposed_length = content_range.stop - content_range.start
+        if supposed_length > length:
+            raise ValueError("Server sent more than we asked for?!")
+        # It might also send less than we asked for. That's (probably) OK, e.g.
+        # if we went past the end of the file.
+        body = yield limited_content(response, supposed_length)
+        body.seek(0, SEEK_END)
+        actual_length = body.tell()
+        if actual_length != supposed_length:
+            # Most likely a mutable that got changed out from under us, but
+            # concievably could be a bug...
+            raise ValueError(
+                f"Length of response sent from server ({actual_length}) "
+                + f"didn't match Content-Range header ({supposed_length})"
+            )
+        body.seek(0)
+        returnValue(body.read())
     else:
+        # Technically HTTP allows sending an OK with full body under these
+        # circumstances, but the server is not designed to do that so we ignore
+        # than possibility for now...
         raise ClientException(response.code)
 
 

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -504,7 +504,7 @@ def read_share_chunk(
     else:
         # Technically HTTP allows sending an OK with full body under these
         # circumstances, but the server is not designed to do that so we ignore
-        # than possibility for now...
+        # that possibility for now...
         raise ClientException(response.code)
 
 

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -468,6 +468,10 @@ def read_share_chunk(
             {"range": [Range("bytes", [(offset, offset + length)]).to_header()]}
         ),
     )
+
+    if response.code == http.NO_CONTENT:
+        return b""
+
     if response.code == http.PARTIAL_CONTENT:
         content_range = parse_content_range_header(
             response.headers.getRawHeaders("content-range")[0]
@@ -488,7 +492,7 @@ def read_share_chunk(
                 + f"didn't match Content-Range header ({supposed_length})"
             )
         body.seek(0)
-        returnValue(body.read())
+        return body.read()
     else:
         # Technically HTTP allows sending an OK with full body under these
         # circumstances, but the server is not designed to do that so we ignore

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -353,7 +353,7 @@ class _ReadRangeProducer:
             d, self.result = self.result, None
             d.errback(
                 ValueError(
-                    f"Should be {remaining} bytes left, but we got an empty read"
+                    f"Should be {self.remaining} bytes left, but we got an empty read"
                 )
             )
             self.stopProducing()
@@ -363,7 +363,7 @@ class _ReadRangeProducer:
             d, self.result = self.result, None
             d.errback(
                 ValueError(
-                    f"Should be {remaining} bytes left, but we got more than that ({len(data)})!"
+                    f"Should be {self.remaining} bytes left, but we got more than that ({len(data)})!"
                 )
             )
             self.stopProducing()

--- a/src/allmydata/storage/immutable.py
+++ b/src/allmydata/storage/immutable.py
@@ -199,7 +199,12 @@ class ShareFile(object):
                 raise UnknownImmutableContainerVersionError(filename, version)
             self._num_leases = num_leases
             self._lease_offset = filesize - (num_leases * self.LEASE_SIZE)
+            self._length = filesize - 0xc - (num_leases * self.LEASE_SIZE)
+
         self._data_offset = 0xc
+
+    def get_length(self):
+        return self._length
 
     def unlink(self):
         os.unlink(self.home)
@@ -543,6 +548,9 @@ class BucketReader(object):
                                             self.storage_index,
                                             self.shnum,
                                             reason)
+
+    def get_length(self):
+        return self._share_file.get_length()
 
 
 @implementer(RIBucketReader)

--- a/src/allmydata/storage/immutable.py
+++ b/src/allmydata/storage/immutable.py
@@ -552,6 +552,12 @@ class BucketReader(object):
                                             self.shnum,
                                             reason)
 
+    def get_length(self):
+        """
+        Return the length of the data in the share.
+        """
+        return self._share_file.get_length()
+
 
 @implementer(RIBucketReader)
 class FoolscapBucketReader(Referenceable):  # type: ignore # warner/foolscap#78

--- a/src/allmydata/storage/immutable.py
+++ b/src/allmydata/storage/immutable.py
@@ -204,6 +204,9 @@ class ShareFile(object):
         self._data_offset = 0xc
 
     def get_length(self):
+        """
+        Return the length of the data in the share, if we're reading.
+        """
         return self._length
 
     def unlink(self):
@@ -548,9 +551,6 @@ class BucketReader(object):
                                             self.storage_index,
                                             self.shnum,
                                             reason)
-
-    def get_length(self):
-        return self._share_file.get_length()
 
 
 @implementer(RIBucketReader)

--- a/src/allmydata/storage/mutable.py
+++ b/src/allmydata/storage/mutable.py
@@ -412,11 +412,11 @@ class MutableShareFile(object):
                 datav.append(self._read_share_data(f, offset, length))
         return datav
 
-#    def remote_get_length(self):
-#        f = open(self.home, 'rb')
-#        data_length = self._read_data_length(f)
-#        f.close()
-#        return data_length
+    def get_length(self):
+        f = open(self.home, 'rb')
+        data_length = self._read_data_length(f)
+        f.close()
+        return data_length
 
     def check_write_enabler(self, write_enabler, si_s):
         with open(self.home, 'rb+') as f:

--- a/src/allmydata/storage/mutable.py
+++ b/src/allmydata/storage/mutable.py
@@ -413,6 +413,9 @@ class MutableShareFile(object):
         return datav
 
     def get_length(self):
+        """
+        Return the length of the data in the share.
+        """
         f = open(self.home, 'rb')
         data_length = self._read_data_length(f)
         f.close()

--- a/src/allmydata/storage/server.py
+++ b/src/allmydata/storage/server.py
@@ -805,6 +805,8 @@ class StorageServer(service.MultiService):
         """Returns the length (in bytes) of a mutable."""
         si_dir = storage_index_to_dir(storage_index)
         path = os.path.join(self.sharedir, si_dir, str(share_number))
+        if not os.path.exists(path):
+            raise KeyError("No such storage index or share number")
         return MutableShareFile(path).get_length()
 
 

--- a/src/allmydata/storage/server.py
+++ b/src/allmydata/storage/server.py
@@ -796,13 +796,16 @@ class StorageServer(service.MultiService):
 
     def get_immutable_share_length(self, storage_index: bytes, share_number: int) -> int:
         """Returns the length (in bytes) of an immutable."""
-        return self.get_buckets(storage_index)[share_number].get_length()
+        si_dir = storage_index_to_dir(storage_index)
+        path = os.path.join(self.sharedir, si_dir, str(share_number))
+        bucket = BucketReader(self, path, storage_index, share_number)
+        return bucket.get_length()
 
     def get_mutable_share_length(self, storage_index: bytes, share_number: int) -> int:
         """Returns the length (in bytes) of a mutable."""
-        return MutableShareFile(
-            dict(self.get_shares(storage_index))[share_number]
-        ).get_length()
+        si_dir = storage_index_to_dir(storage_index)
+        path = os.path.join(self.sharedir, si_dir, str(share_number))
+        return MutableShareFile(path).get_length()
 
 
 @implementer(RIStorageServer)

--- a/src/allmydata/storage/server.py
+++ b/src/allmydata/storage/server.py
@@ -798,8 +798,7 @@ class StorageServer(service.MultiService):
         """Returns the length (in bytes) of an immutable."""
         si_dir = storage_index_to_dir(storage_index)
         path = os.path.join(self.sharedir, si_dir, str(share_number))
-        bucket = BucketReader(self, path, storage_index, share_number)
-        return bucket.get_length()
+        return ShareFile(path).get_length()
 
     def get_mutable_share_length(self, storage_index: bytes, share_number: int) -> int:
         """Returns the length (in bytes) of a mutable."""

--- a/src/allmydata/storage/server.py
+++ b/src/allmydata/storage/server.py
@@ -794,6 +794,16 @@ class StorageServer(service.MultiService):
 
         return None
 
+    def get_immutable_share_length(self, storage_index: bytes, share_number: int) -> int:
+        """Returns the length (in bytes) of an immutable."""
+        return self.get_buckets(storage_index)[share_number].get_length()
+
+    def get_mutable_share_length(self, storage_index: bytes, share_number: int) -> int:
+        """Returns the length (in bytes) of a mutable."""
+        return MutableShareFile(
+            dict(self.get_shares(storage_index))[share_number]
+        ).get_length()
+
 
 @implementer(RIStorageServer)
 class FoolscapStorageServer(Referenceable):  # type: ignore # warner/foolscap#78

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -688,6 +688,15 @@ class Server(unittest.TestCase):
             writer.abort()
         self.failUnlessEqual(ss.allocated_size(), 0)
 
+    def test_immutable_length(self):
+        """``get_immutable_share_length()`` returns the length of an immutable share."""
+        ss = self.create("test_immutable_length")
+        _, writers = self.allocate(ss, b"allocate", [22], 75)
+        bucket = writers[22]
+        bucket.write(0, b"X" * 75)
+        bucket.close()
+        self.assertEqual(ss.get_immutable_share_length(b"allocate", 22), 75)
+
     def test_allocate(self):
         ss = self.create("test_allocate")
 
@@ -1339,6 +1348,19 @@ class MutableServer(unittest.TestCase):
             (empty, shares0_1_2_4, shares0_1_4),
             (set(), {0, 1, 2, 4}, {0, 1, 4})
         )
+
+    def test_mutable_share_length(self):
+        """``get_mutable_share_length()`` returns the length of the share."""
+        ss = self.create("test_mutable_share_length")
+        self.allocate(ss, b"si1", b"we1", b"le1", [16], 23)
+        ss.slot_testv_and_readv_and_writev(
+            b"si1", (self.write_enabler(b"we1"),
+                     self.renew_secret(b"le1"),
+                     self.cancel_secret(b"le1")),
+            {16: ([], [(0, b"x" * 23)], None)},
+            []
+        )
+        self.assertEqual(ss.get_mutable_share_length(b"si1", 16), 23)
 
     def test_bad_magic(self):
         ss = self.create("test_bad_magic")


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3907

There's a few error handling codepaths that aren't handled, like "mutable changed out from under you" or "there's a bug!". Can try to figure something out if reviewer feels it's useful.