### PR TITLE
Refactor FakeWebTest & MemoryConsumerTest classes

### DIFF
--- a/src/allmydata/test/test_consumer.py
+++ b/src/allmydata/test/test_consumer.py
@@ -14,10 +14,16 @@ if PY2:
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 
 from zope.interface import implementer
-from twisted.trial.unittest import TestCase
 from twisted.internet.interfaces import IPushProducer, IPullProducer
 
 from allmydata.util.consumer import MemoryConsumer
+
+from .common import (
+    SyncTestCase,
+)
+from testtools.matchers import (
+    Equals,
+)
 
 
 @implementer(IPushProducer)
@@ -50,7 +56,7 @@ class Producer(object):
             self.consumer.unregisterProducer()
 
 
-class MemoryConsumerTests(TestCase):
+class MemoryConsumerTests(SyncTestCase):
     """Tests for MemoryConsumer."""
 
     def test_push_producer(self):
@@ -60,14 +66,14 @@ class MemoryConsumerTests(TestCase):
         consumer = MemoryConsumer()
         producer = Producer(consumer, [b"abc", b"def", b"ghi"])
         consumer.registerProducer(producer, True)
-        self.assertEqual(consumer.chunks, [b"abc"])
+        self.assertThat(consumer.chunks, Equals([b"abc"]))
         producer.iterate()
         producer.iterate()
-        self.assertEqual(consumer.chunks, [b"abc", b"def", b"ghi"])
-        self.assertEqual(consumer.done, False)
+        self.assertThat(consumer.chunks, Equals([b"abc", b"def", b"ghi"]))
+        self.assertFalse(consumer.done)
         producer.iterate()
-        self.assertEqual(consumer.chunks, [b"abc", b"def", b"ghi"])
-        self.assertEqual(consumer.done, True)
+        self.assertThat(consumer.chunks, Equals([b"abc", b"def", b"ghi"]))
+        self.assertTrue(consumer.done)
 
     def test_pull_producer(self):
         """
@@ -76,8 +82,8 @@ class MemoryConsumerTests(TestCase):
         consumer = MemoryConsumer()
         producer = Producer(consumer, [b"abc", b"def", b"ghi"])
         consumer.registerProducer(producer, False)
-        self.assertEqual(consumer.chunks, [b"abc", b"def", b"ghi"])
-        self.assertEqual(consumer.done, True)
+        self.assertThat(consumer.chunks, Equals([b"abc", b"def", b"ghi"]))
+        self.assertTrue(consumer.done)
 
 
 # download_to_data() is effectively tested by some of the filenode tests, e.g.

--- a/src/allmydata/test/test_testing.py
+++ b/src/allmydata/test/test_testing.py
@@ -46,9 +46,10 @@ from hypothesis.strategies import (
     binary,
 )
 
-from testtools import (
-    TestCase,
+from .common import (
+    SyncTestCase,
 )
+
 from testtools.matchers import (
     Always,
     Equals,
@@ -61,7 +62,7 @@ from testtools.twistedsupport import (
 )
 
 
-class FakeWebTest(TestCase):
+class FakeWebTest(SyncTestCase):
     """
     Test the WebUI verified-fakes infrastucture
     """


### PR DESCRIPTION
There are base test classes namely `SyncTestCase` and `AsyncTestCase` which we would like all test classes inthis code base to extend.

This commit refactors two test classes to use the `SyncTestCase` with the newer assert methods.

Resolves : [#3916](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3916)