### PR TITLE
3926.pid time reactor

### DIFF
--- a/docs/check_running.py
+++ b/docs/check_running.py
@@ -21,22 +21,22 @@ def can_spawn_tahoe(pidfile):
         except FileNotFoundError:
             return True
 
-    # somewhat interesting: we have a pidfile
-    pid = int(pid)
-    create_time = float(create_time)
+        # somewhat interesting: we have a pidfile
+        pid = int(pid)
+        create_time = float(create_time)
 
-    try:
-        proc = psutil.Process(pid)
-        # most interesting case: there _is_ a process running at the
-        # recorded PID -- but did it just happen to get that PID, or
-        # is it the very same one that wrote the file?
-        if create_time == proc.create_time():
-            # _not_ stale! another intance is still running against
-            # this configuration
-            return False
+        try:
+            proc = psutil.Process(pid)
+            # most interesting case: there _is_ a process running at the
+            # recorded PID -- but did it just happen to get that PID, or
+            # is it the very same one that wrote the file?
+            if create_time == proc.create_time():
+                # _not_ stale! another intance is still running against
+                # this configuration
+                return False
 
-    except psutil.NoSuchProcess:
-        pass
+        except psutil.NoSuchProcess:
+            pass
 
     # the file is stale
     pidfile.unlink()

--- a/docs/check_running.py
+++ b/docs/check_running.py
@@ -1,0 +1,47 @@
+
+import psutil
+import filelock
+
+
+def can_spawn_tahoe(pidfile):
+    """
+    Determine if we can spawn a Tahoe-LAFS for the given pidfile. That
+    pidfile may be deleted if it is stale.
+
+    :param pathlib.Path pidfile: the file to check, that is the Path
+        to "running.process" in a Tahoe-LAFS configuration directory
+
+    :returns bool: True if we can spawn `tahoe run` here
+    """
+    lockpath = pidfile.parent / (pidfile.name + ".lock")
+    with filelock.FileLock(lockpath):
+        try:
+            with pidfile.open("r") as f:
+                pid, create_time = f.read().strip().split(" ", 1)
+        except FileNotFoundError:
+            return True
+
+    # somewhat interesting: we have a pidfile
+    pid = int(pid)
+    create_time = float(create_time)
+
+    try:
+        proc = psutil.Process(pid)
+        # most interesting case: there _is_ a process running at the
+        # recorded PID -- but did it just happen to get that PID, or
+        # is it the very same one that wrote the file?
+        if create_time == proc.create_time():
+            # _not_ stale! another intance is still running against
+            # this configuration
+            return False
+
+    except psutil.NoSuchProcess:
+        pass
+
+    # the file is stale
+    pidfile.unlink()
+    return True
+
+
+from pathlib import Path
+print("can spawn?", can_spawn_tahoe(Path("running.process")))

--- a/docs/check_running.py
+++ b/docs/check_running.py
@@ -38,9 +38,9 @@ def can_spawn_tahoe(pidfile):
         except psutil.NoSuchProcess:
             pass
 
-    # the file is stale
-    pidfile.unlink()
-    return True
+        # the file is stale
+        pidfile.unlink()
+        return True
 
 
 from pathlib import Path

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -142,7 +142,7 @@ When no such file exists, there is no other process running on this configuratio
 If there is a ``running.process`` file, it may be a leftover file or it may indicate that another process is running against this config.
 To tell the difference, determine if the PID in the file exists currently.
 If it does, check the creation-time of the process versus the one in the file.
-If these match, there is another process currently running.
+If these match, there is another process currently running and using this config.
 Otherwise, the file is stale -- it should be removed before starting Tahoe-LAFS.
 
 Some example Python code to check the above situations:

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -124,6 +124,35 @@ Tahoe-LAFS.
 .. _magic wormhole: https://magic-wormhole.io/
 
 
+Multiple Instances
+------------------
+
+Running multiple instances against the same configuration directory isn't supported.
+This will lead to undefined behavior and could corrupt the configuration state.
+
+We attempt to avoid this situation with a "pidfile"-style file in the config directory called ``running.process``.
+There may be a parallel file called ``running.process.lock`` in existence.
+
+The ``.lock`` file exists to make sure only one process modifies ``running.process`` at once.
+The lock file is managed by the `lockfile <https://pypi.org/project/lockfile/>`_ library.
+If you wish to make use of ``running.process`` for any reason you should also lock it and follow the semantics of lockfile.
+
+If ``running.process` exists it file contains the PID and the creation-time of the process.
+When no such file exists, there is no other process running on this configuration.
+If there is a ``running.process`` file, it may be a leftover file or it may indicate that another process is running against this config.
+To tell the difference, determine if the PID in the file exists currently.
+If it does, check the creation-time of the process versus the one in the file.
+If these match, there is another process currently running.
+Otherwise, the file is stale -- it should be removed before starting Tahoe-LAFS.
+
+Some example Python code to check the above situations:
+
+.. literalinclude:: check_running.py
+
+
+
+
+
 A note about small grids
 ------------------------
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -128,7 +128,7 @@ Multiple Instances
 ------------------
 
 Running multiple instances against the same configuration directory isn't supported.
-This will lead to undefined behavior and could corrupt the configuration state.
+This will lead to undefined behavior and could corrupt the configuration or state.
 
 We attempt to avoid this situation with a "pidfile"-style file in the config directory called ``running.process``.
 There may be a parallel file called ``running.process.lock`` in existence.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -137,7 +137,7 @@ The ``.lock`` file exists to make sure only one process modifies ``running.proce
 The lock file is managed by the `lockfile <https://pypi.org/project/lockfile/>`_ library.
 If you wish to make use of ``running.process`` for any reason you should also lock it and follow the semantics of lockfile.
 
-If ``running.process` exists it file contains the PID and the creation-time of the process.
+If ``running.process`` exists then it contains the PID and the creation-time of the process.
 When no such file exists, there is no other process running on this configuration.
 If there is a ``running.process`` file, it may be a leftover file or it may indicate that another process is running against this config.
 To tell the difference, determine if the PID in the file exists currently.

--- a/newsfragments/3926.incompat
+++ b/newsfragments/3926.incompat
@@ -1,0 +1,10 @@
+Record both the PID and the process creation-time
+
+A new kind of pidfile in `running.process` records both
+the PID and the creation-time of the process. This facilitates
+automatic discovery of a "stale" pidfile that points to a
+currently-running process. If the recorded creation-time matches
+the creation-time of the running process, then it is a still-running
+`tahoe run` proecss. Otherwise, the file is stale.
+
+The `twistd.pid` file is no longer present.

--- a/newsfragments/3926.incompat
+++ b/newsfragments/3926.incompat
@@ -1,10 +1,10 @@
-Record both the PID and the process creation-time
+Record both the PID and the process creation-time:
 
-A new kind of pidfile in `running.process` records both
+a new kind of pidfile in `running.process` records both
 the PID and the creation-time of the process. This facilitates
 automatic discovery of a "stale" pidfile that points to a
 currently-running process. If the recorded creation-time matches
 the creation-time of the running process, then it is a still-running
-`tahoe run` proecss. Otherwise, the file is stale.
+`tahoe run` process. Otherwise, the file is stale.
 
 The `twistd.pid` file is no longer present.

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,9 @@ install_requires = [
     "treq",
     "cbor2",
     "pycddl",
+
+    # for pid-file support
+    "psutil",
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ install_requires = [
 
     # for pid-file support
     "psutil",
+    "filelock",
 ]
 
 setup_requires = [

--- a/src/allmydata/scripts/runner.py
+++ b/src/allmydata/scripts/runner.py
@@ -47,11 +47,6 @@ if _default_nodedir:
     NODEDIR_HELP += " [default for most commands: " + quote_local_unicode_path(_default_nodedir) + "]"
 
 
-# XXX all this 'dispatch' stuff needs to be unified + fixed up
-_control_node_dispatch = {
-    "run": tahoe_run.run,
-}
-
 process_control_commands = [
     ("run", None, tahoe_run.RunOptions, "run a node without daemonizing"),
 ]  # type: SubCommands
@@ -195,6 +190,7 @@ def parse_or_exit(config, argv, stdout, stderr):
     return config
 
 def dispatch(config,
+             reactor,
              stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr):
     command = config.subCommand
     so = config.subOptions
@@ -206,8 +202,8 @@ def dispatch(config,
 
     if command in create_dispatch:
         f = create_dispatch[command]
-    elif command in _control_node_dispatch:
-        f = _control_node_dispatch[command]
+    elif command == "run":
+        f = lambda config: tahoe_run.run(reactor, config)
     elif command in debug.dispatch:
         f = debug.dispatch[command]
     elif command in admin.dispatch:
@@ -361,7 +357,7 @@ def _run_with_reactor(reactor, config, argv, stdout, stderr):
         stderr,
     )
     d.addCallback(_maybe_enable_eliot_logging, reactor)
-    d.addCallback(dispatch, stdout=stdout, stderr=stderr)
+    d.addCallback(dispatch, reactor, stdout=stdout, stderr=stderr)
     def _show_exception(f):
         # when task.react() notices a non-SystemExit exception, it does
         # log.err() with the failure and then exits with rc=1. We want this

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -266,7 +266,7 @@ def run(reactor, config, runApp=twistd.runApp):
     pidfile = FilePath(get_pidfile(config['basedir']))
     try:
         check_pid_process(pidfile)
-    except ProcessInTheWay as e:
+    except (ProcessInTheWay, InvalidPidFile) as e:
         print("ERROR: {}".format(e))
         return 1
     else:

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -244,7 +244,7 @@ def run(reactor, config, runApp=twistd.runApp):
         "--rundir", basedir,
     ]
     if sys.platform != "win32":
-        # turn off Twisted's pid-file to use our own -- but only on
+        # turn off Twisted's pid-file to use our own -- but not on
         # windows, because twistd doesn't know about pidfiles there
         twistd_args.extend(["--pidfile", None])
     twistd_args.extend(config.twistd_args)

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -30,6 +30,7 @@ from allmydata.util.configutil import UnknownConfigError
 from allmydata.util.deferredutil import HookMixin
 from allmydata.util.pid import (
     check_pid_process,
+    cleanup_pidfile,
     ProcessInTheWay,
     InvalidPidFile,
 )

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -239,12 +239,14 @@ def run(config, runApp=twistd.runApp):
         return 1
 
     twistd_args = [
-        # turn off Twisted's pid-file to use our own
-        "--pidfile", None,
         # ensure twistd machinery does not daemonize.
         "--nodaemon",
         "--rundir", basedir,
     ]
+    if sys.platform != "win32":
+        # turn off Twisted's pid-file to use our own -- but only on
+        # windows, because twistd doesn't know about pidfiles there
+        twistd_args.extend(["--pidfile", None])
     twistd_args.extend(config.twistd_args)
     twistd_args.append("DaemonizeTahoeNode") # point at our DaemonizeTahoeNodePlugin
 

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -217,7 +217,7 @@ class DaemonizeTahoeNodePlugin(object):
         return DaemonizeTheRealService(self.nodetype, self.basedir, so)
 
 
-def run(config, runApp=twistd.runApp):
+def run(reactor, config, runApp=twistd.runApp):
     """
     Runs a Tahoe-LAFS node in the foreground.
 

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -62,13 +62,9 @@ def get_pid_from_pidfile(pidfile):
               inaccessible, ``-1`` if PID file invalid.
     """
     try:
-        with open(pidfile, "r") as f:
-            data = f.read().strip()
+        pid, _ = parse_pidfile(pidfile)
     except EnvironmentError:
         return None
-
-    try:
-        pid, _ = parse_pidfile(pidfile)
     except InvalidPidFile:
         return -1
 

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -269,6 +269,11 @@ def run(reactor, config, runApp=twistd.runApp):
     except ProcessInTheWay as e:
         print("ERROR: {}".format(e))
         return 1
+    else:
+        reactor.addSystemEventTrigger(
+            "during", "shutdown",
+            lambda: cleanup_pidfile(pidfile)
+        )
 
     # We always pass --nodaemon so twistd.runApp does not daemonize.
     runApp(twistd_config)

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -29,6 +29,7 @@ from allmydata.util.encodingutil import listdir_unicode, quote_local_unicode_pat
 from allmydata.util.configutil import UnknownConfigError
 from allmydata.util.deferredutil import HookMixin
 from allmydata.util.pid import (
+    parse_pidfile,
     check_pid_process,
     cleanup_pidfile,
     ProcessInTheWay,
@@ -66,10 +67,9 @@ def get_pid_from_pidfile(pidfile):
     except EnvironmentError:
         return None
 
-    pid, _ = data.split()
     try:
-        pid = int(pid)
-    except ValueError:
+        pid, _ = parse_pidfile(pidfile)
+    except InvalidPidFile:
         return -1
 
     return pid

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -267,7 +267,7 @@ def run(reactor, config, runApp=twistd.runApp):
     try:
         check_pid_process(pidfile)
     except (ProcessInTheWay, InvalidPidFile) as e:
-        print("ERROR: {}".format(e))
+        print("ERROR: {}".format(e), file=err)
         return 1
     else:
         reactor.addSystemEventTrigger(

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -276,5 +276,6 @@ def run(reactor, config, runApp=twistd.runApp):
         )
 
     # We always pass --nodaemon so twistd.runApp does not daemonize.
+    print("running node in %s" % (quoted_basedir,), file=out)
     runApp(twistd_config)
     return 0

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -271,7 +271,7 @@ def run(reactor, config, runApp=twistd.runApp):
         return 1
     else:
         reactor.addSystemEventTrigger(
-            "during", "shutdown",
+            "after", "shutdown",
             lambda: cleanup_pidfile(pidfile)
         )
 

--- a/src/allmydata/test/cli/test_run.py
+++ b/src/allmydata/test/cli/test_run.py
@@ -151,7 +151,7 @@ class RunTests(SyncTestCase):
     """
     Tests for ``run``.
     """
-    @skipIf(platform.isWindows(), "There are no PID files on Windows.")
+
     def test_non_numeric_pid(self):
         """
         If the pidfile exists but does not contain a numeric value, a complaint to

--- a/src/allmydata/test/cli/test_run.py
+++ b/src/allmydata/test/cli/test_run.py
@@ -17,22 +17,14 @@ from six.moves import (
     StringIO,
 )
 
-from testtools import (
-    skipIf,
-)
-
 from hypothesis.strategies import text
 from hypothesis import given, assume
 
 from testtools.matchers import (
     Contains,
     Equals,
-    HasLength,
 )
 
-from twisted.python.runtime import (
-    platform,
-)
 from twisted.python.filepath import (
     FilePath,
 )
@@ -184,10 +176,8 @@ class RunTests(SyncTestCase):
         )
         # because the pidfile is invalid we shouldn't get to the
         # .run() call itself.
-        self.assertThat(
-            runs,
-            Equals([])
-        )
+        self.assertThat(runs, Equals([]))
+        self.assertThat(result_code, Equals(1))
 
     good_file_content_re = re.compile(r"\w[0-9]*\w[0-9]*\w")
 

--- a/src/allmydata/test/cli/test_run.py
+++ b/src/allmydata/test/cli/test_run.py
@@ -185,6 +185,9 @@ class RunTests(SyncTestCase):
 
     @given(text())
     def test_pidfile_contents(self, content):
+        """
+        invalid contents for a pidfile raise errors
+        """
         assume(not self.good_file_content_re.match(content))
         pidfile = FilePath("pidfile")
         pidfile.setContent(content.encode("utf8"))

--- a/src/allmydata/test/cli/test_run.py
+++ b/src/allmydata/test/cli/test_run.py
@@ -12,6 +12,7 @@ from future.utils import PY2
 if PY2:
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 
+import re
 from six.moves import (
     StringIO,
 )
@@ -21,7 +22,7 @@ from testtools import (
 )
 
 from hypothesis.strategies import text
-from hypothesis import given
+from hypothesis import given, assume
 
 from testtools.matchers import (
     Contains,
@@ -194,8 +195,11 @@ class RunTests(SyncTestCase):
             Equals([])
         )
 
+    good_file_content_re = re.compile(r"\w[0-9]*\w[0-9]*\w")
+
     @given(text())
     def test_pidfile_contents(self, content):
+        assume(not self.good_file_content_re.match(content))
         pidfile = FilePath("pidfile")
         pidfile.setContent(content.encode("utf8"))
 

--- a/src/allmydata/test/cli/test_run.py
+++ b/src/allmydata/test/cli/test_run.py
@@ -176,14 +176,8 @@ class RunTests(SyncTestCase):
         config['basedir'] = basedir.path
         config.twistd_args = []
 
-        class DummyRunner:
-            runs = []
-            _exitSignal = None
-
-            def run(self):
-                self.runs.append(True)
-
-        result_code = run(config, runner=DummyRunner())
+        runs = []
+        result_code = run(config, runApp=runs.append)
         self.assertThat(
             config.stderr.getvalue(),
             Contains("found invalid PID file in"),
@@ -191,7 +185,7 @@ class RunTests(SyncTestCase):
         # because the pidfile is invalid we shouldn't get to the
         # .run() call itself.
         self.assertThat(
-            DummyRunner.runs,
+            runs,
             Equals([])
         )
 

--- a/src/allmydata/test/cli/test_run.py
+++ b/src/allmydata/test/cli/test_run.py
@@ -168,7 +168,7 @@ class RunTests(SyncTestCase):
         config['basedir'] = basedir.path
         config.twistd_args = []
 
-        from twisted.internet import reactor
+        reactor = MemoryReactor()
 
         runs = []
         result_code = run(reactor, config, runApp=runs.append)

--- a/src/allmydata/test/cli/test_run.py
+++ b/src/allmydata/test/cli/test_run.py
@@ -168,8 +168,10 @@ class RunTests(SyncTestCase):
         config['basedir'] = basedir.path
         config.twistd_args = []
 
+        from twisted.internet import reactor
+
         runs = []
-        result_code = run(config, runApp=runs.append)
+        result_code = run(reactor, config, runApp=runs.append)
         self.assertThat(
             config.stderr.getvalue(),
             Contains("found invalid PID file in"),

--- a/src/allmydata/test/cli_node_api.py
+++ b/src/allmydata/test/cli_node_api.py
@@ -134,7 +134,7 @@ class CLINodeAPI(object):
 
     @property
     def twistd_pid_file(self):
-        return self.basedir.child(u"twistd.pid")
+        return self.basedir.child(u"running.process")
 
     @property
     def node_url_file(self):

--- a/src/allmydata/test/common_util.py
+++ b/src/allmydata/test/common_util.py
@@ -145,6 +145,7 @@ def run_cli_native(verb, *args, **kwargs):
     )
     d.addCallback(
         runner.dispatch,
+        reactor,
         stdin=stdin,
         stdout=stdout,
         stderr=stderr,

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -652,7 +652,6 @@ class PidFileLocking(SyncTestCase):
             [sys.executable, "other_lock.py", lockfile.path],
             stdout=PIPE,
             stderr=PIPE,
-            start_new_session=True,
         )
         # make sure our subprocess has had time to acquire the lock
         # for sure (from the "." it prints)

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -642,14 +642,14 @@ class PidFileLocking(SyncTestCase):
             f.write(
                 "\n".join([
                     "import filelock, time, sys",
-                    "with filelock.FileLock(r'{}', timeout=1):".format(lockfile.path),
+                    "with filelock.FileLock(sys.argv[1], timeout=1):",
                     "    sys.stdout.write('.\\n')",
                     "    sys.stdout.flush()",
                     "    time.sleep(10)",
                 ])
             )
         proc = Popen(
-            [sys.executable, "other_lock.py"],
+            [sys.executable, "other_lock.py", lockfile.path],
             stdout=PIPE,
             stderr=PIPE,
             start_new_session=True,

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -47,9 +47,6 @@ from twisted.internet.defer import (
     DeferredList,
 )
 from twisted.python.filepath import FilePath
-from twisted.python.runtime import (
-    platform,
-)
 from allmydata.util import fileutil, pollmixin
 from allmydata.util.encodingutil import unicode_to_argv
 from allmydata.test import common_util

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -605,8 +605,10 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin):
             ),
         )
 
-        # It should not be running.
-        self.assertFalse(tahoe.twistd_pid_file.exists())
+        # It should not be running (but windows shutdown can't run
+        # code so the PID file still exists there).
+        if not platform.isWindows():
+            self.assertFalse(tahoe.twistd_pid_file.exists())
 
         # Wait for the operation to *complete*.  If we got this far it's
         # because we got the expected message so we can expect the "tahoe ..."

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -645,7 +645,7 @@ class PidFileLocking(SyncTestCase):
                     "with filelock.FileLock('{}', timeout=1):".format(lockfile.path),
                     "    sys.stdout.write('.\\n')",
                     "    sys.stdout.flush()",
-                    "    time.sleep(5)",
+                    "    time.sleep(10)",
                 ])
             )
         proc = Popen(
@@ -656,7 +656,7 @@ class PidFileLocking(SyncTestCase):
         )
         # make sure our subprocess has had time to acquire the lock
         # for sure (from the "." it prints)
-        proc.stdout.read(2),
+        proc.stdout.read(2)
 
         # acquiring the same lock should fail; it is locked by the subprocess
         with self.assertRaises(ProcessInTheWay):

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -642,7 +642,7 @@ class PidFileLocking(SyncTestCase):
             f.write(
                 "\n".join([
                     "import filelock, time, sys",
-                    "with filelock.FileLock('{}', timeout=1):".format(lockfile.path),
+                    "with filelock.FileLock(r'{}', timeout=1):".format(lockfile.path),
                     "    sys.stdout.write('.\\n')",
                     "    sys.stdout.flush()",
                     "    time.sleep(10)",

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -643,7 +643,7 @@ class PidFileLocking(SyncTestCase):
                 "\n".join([
                     "import filelock, time",
                     "with filelock.FileLock('{}', timeout=1):".format(lockfile.path),
-                    "    print('.', flush=True)",
+                    "    print('.\n', flush=True)",
                     "    time.sleep(5)",
                 ])
             )
@@ -657,7 +657,7 @@ class PidFileLocking(SyncTestCase):
         # for sure (from the "." it prints)
         self.assertThat(
             proc.stdout.read(1),
-            Equals(b".")
+            Equals(b".\n")
         )
 
         # we should not be able to acuire this corresponding lock as well

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -635,7 +635,7 @@ class PidFileLocking(SyncTestCase):
         """
         # this can't just be "our" process because the locking library
         # allows the same process to acquire a lock multiple times.
-        pidfile = FilePath("foo")
+        pidfile = FilePath(self.mktemp())
         lockfile = _pidfile_to_lockpath(pidfile)
 
         with open("other_lock.py", "w") as f:

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -638,7 +638,7 @@ class PidFileLocking(SyncTestCase):
         pidfile = FilePath("foo")
         lockfile = _pidfile_to_lockpath(pidfile)
 
-        with open("code.py", "w") as f:
+        with open("other_lock.py", "w") as f:
             f.write(
                 "\n".join([
                     "import filelock, time",
@@ -648,7 +648,7 @@ class PidFileLocking(SyncTestCase):
                 ])
             )
         proc = Popen(
-            [sys.executable, "code.py"],
+            [sys.executable, "other_lock.py"],
             stdout=PIPE,
             stderr=PIPE,
             start_new_session=True,

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -656,12 +656,9 @@ class PidFileLocking(SyncTestCase):
         )
         # make sure our subprocess has had time to acquire the lock
         # for sure (from the "." it prints)
-        self.assertThat(
-            proc.stdout.read(2),
-            Equals(b".\n")
-        )
+        proc.stdout.read(2),
 
-        # we should not be able to acuire this corresponding lock as well
+        # acquiring the same lock should fail; it is locked by the subprocess
         with self.assertRaises(ProcessInTheWay):
             check_pid_process(pidfile)
         proc.terminate()

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -418,9 +418,7 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin):
 
         tahoe.active()
 
-        # We don't keep track of PIDs in files on Windows.
-        if not platform.isWindows():
-            self.assertTrue(tahoe.twistd_pid_file.exists())
+        self.assertTrue(tahoe.twistd_pid_file.exists())
         self.assertTrue(tahoe.node_url_file.exists())
 
         # rm this so we can detect when the second incarnation is ready
@@ -493,9 +491,7 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin):
         # change on restart
         storage_furl = fileutil.read(tahoe.storage_furl_file.path)
 
-        # We don't keep track of PIDs in files on Windows.
-        if not platform.isWindows():
-            self.assertTrue(tahoe.twistd_pid_file.exists())
+        self.assertTrue(tahoe.twistd_pid_file.exists())
 
         # rm this so we can detect when the second incarnation is ready
         tahoe.node_url_file.remove()
@@ -513,21 +509,18 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin):
             fileutil.read(tahoe.storage_furl_file.path),
         )
 
-        if not platform.isWindows():
-            self.assertTrue(
-                tahoe.twistd_pid_file.exists(),
-                "PID file ({}) didn't exist when we expected it to.  "
-                "These exist: {}".format(
-                    tahoe.twistd_pid_file,
-                    tahoe.twistd_pid_file.parent().listdir(),
-                ),
-            )
+        self.assertTrue(
+            tahoe.twistd_pid_file.exists(),
+            "PID file ({}) didn't exist when we expected it to.  "
+            "These exist: {}".format(
+                tahoe.twistd_pid_file,
+                tahoe.twistd_pid_file.parent().listdir(),
+            ),
+        )
         yield tahoe.stop_and_wait()
 
-        if not platform.isWindows():
-            # twistd.pid should be gone by now.
-            self.assertFalse(tahoe.twistd_pid_file.exists())
-
+        # twistd.pid should be gone by now.
+        self.assertFalse(tahoe.twistd_pid_file.exists())
 
     def _remove(self, res, file):
         fileutil.remove(file)
@@ -610,9 +603,8 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin):
             ),
         )
 
-        if not platform.isWindows():
-            # It should not be running.
-            self.assertFalse(tahoe.twistd_pid_file.exists())
+        # It should not be running.
+        self.assertFalse(tahoe.twistd_pid_file.exists())
 
         # Wait for the operation to *complete*.  If we got this far it's
         # because we got the expected message so we can expect the "tahoe ..."

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -641,9 +641,10 @@ class PidFileLocking(SyncTestCase):
         with open("other_lock.py", "w") as f:
             f.write(
                 "\n".join([
-                    "import filelock, time",
+                    "import filelock, time, sys",
                     "with filelock.FileLock('{}', timeout=1):".format(lockfile.path),
-                    "    print('.\n', flush=True)",
+                    "    sys.stdout.write('.\\n')",
+                    "    sys.stdout.flush()",
                     "    time.sleep(5)",
                 ])
             )
@@ -656,7 +657,7 @@ class PidFileLocking(SyncTestCase):
         # make sure our subprocess has had time to acquire the lock
         # for sure (from the "." it prints)
         self.assertThat(
-            proc.stdout.read(1),
+            proc.stdout.read(2),
             Equals(b".\n")
         )
 

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -42,6 +42,7 @@ from twisted.trial import unittest
 
 from twisted.internet import reactor
 from twisted.python import usage
+from twisted.python.runtime import platform
 from twisted.internet.defer import (
     inlineCallbacks,
     DeferredList,
@@ -516,8 +517,12 @@ class RunNode(common_util.SignalMixin, unittest.TestCase, pollmixin.PollMixin):
         )
         yield tahoe.stop_and_wait()
 
-        # twistd.pid should be gone by now.
-        self.assertFalse(tahoe.twistd_pid_file.exists())
+        # twistd.pid should be gone by now -- except on Windows, where
+        # killing a subprocess immediately exits with no chance for
+        # any shutdown code (that is, no Twisted shutdown hooks can
+        # run).
+        if not platform.isWindows():
+            self.assertFalse(tahoe.twistd_pid_file.exists())
 
     def _remove(self, res, file):
         fileutil.remove(file)

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -1,0 +1,72 @@
+import os
+import psutil
+
+
+class ProcessInTheWay(Exception):
+    """
+    our pidfile points at a running process
+    """
+
+
+def check_pid_process(pidfile, find_process=None):
+    """
+    If another instance appears to be running already, raise an
+    exception.  Otherwise, write our PID + start time to the pidfile
+    and arrange to delete it upon exit.
+
+    :param FilePath pidfile: the file to read/write our PID from.
+
+    :param Callable find_process: None, or a custom way to get a
+        Process objet (usually for tests)
+
+    :raises ProcessInTheWay: if a running process exists at our PID
+    """
+    find_process = psutil.Process if find_process is None else find_process
+    # check if we have another instance running already
+    if pidfile.exists():
+        with pidfile.open("r") as f:
+            content = f.read().decode("utf8").strip()
+        pid, starttime = content.split()
+        pid = int(pid)
+        starttime = float(starttime)
+        try:
+            # if any other process is running at that PID, let the
+            # user decide if this is another magic-older
+            # instance. Automated programs may use the start-time to
+            # help decide this (if the PID is merely recycled, the
+            # start-time won't match).
+            proc = find_process(pid)
+            raise ProcessInTheWay(
+                "A process is already running as PID {}".format(pid)
+            )
+        except psutil.NoSuchProcess:
+            print(
+                "'{pidpath}' refers to {pid} that isn't running".format(
+                    pidpath=pidfile.path,
+                    pid=pid,
+                )
+            )
+            # nothing is running at that PID so it must be a stale file
+            pidfile.remove()
+
+    # write our PID + start-time to the pid-file
+    pid = os.getpid()
+    starttime = find_process(pid).create_time()
+    with pidfile.open("w") as f:
+        f.write("{} {}\n".format(pid, starttime).encode("utf8"))
+
+
+def cleanup_pidfile(pidfile):
+    """
+    Safely remove the given pidfile
+    """
+
+    try:
+        pidfile.remove()
+    except Exception as e:
+        print(
+            "Couldn't remove '{pidfile}': {err}.".format(
+                pidfile=pidfile.path,
+                err=e,
+            )
+        )

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -53,7 +53,7 @@ def parse_pidfile(pidfile):
     return pid, startime
 
 
-def check_pid_process(pidfile, find_process=None):
+def check_pid_process(pidfile):
     """
     If another instance appears to be running already, raise an
     exception.  Otherwise, write our PID + start time to the pidfile
@@ -61,12 +61,8 @@ def check_pid_process(pidfile, find_process=None):
 
     :param FilePath pidfile: the file to read/write our PID from.
 
-    :param Callable find_process: None, or a custom way to get a
-        Process objet (usually for tests)
-
     :raises ProcessInTheWay: if a running process exists at our PID
     """
-    find_process = psutil.Process if find_process is None else find_process
     lock_path = _pidfile_to_lockpath(pidfile)
 
     try:
@@ -83,7 +79,7 @@ def check_pid_process(pidfile, find_process=None):
                     # instance. Automated programs may use the start-time to
                     # help decide this (if the PID is merely recycled, the
                     # start-time won't match).
-                    find_process(pid)
+                    psutil.Process(pid)
                     raise ProcessInTheWay(
                         "A process is already running as PID {}".format(pid)
                     )
@@ -98,8 +94,7 @@ def check_pid_process(pidfile, find_process=None):
                     pidfile.remove()
 
             # write our PID + start-time to the pid-file
-            pid = os.getpid()
-            starttime = find_process(pid).create_time()
+            starttime = psutil.Process().create_time()
             with pidfile.open("w") as f:
                 f.write("{} {}\n".format(pid, starttime).encode("utf8"))
     except Timeout:

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -94,9 +94,9 @@ def check_pid_process(pidfile):
                     pidfile.remove()
 
             # write our PID + start-time to the pid-file
-            starttime = psutil.Process().create_time()
+            proc = psutil.Process()
             with pidfile.open("w") as f:
-                f.write("{} {}\n".format(pid, starttime).encode("utf8"))
+                f.write("{} {}\n".format(proc.pid, proc.create_time()).encode("utf8"))
     except Timeout:
         raise ProcessInTheWay(
             "Another process is still locking {}".format(pidfile.path)

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -50,7 +50,7 @@ def parse_pidfile(pidfile):
                 pidfile
             )
         )
-    return pid, startime
+    return pid, starttime
 
 
 def check_pid_process(pidfile):

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -1,8 +1,5 @@
 import os
 import psutil
-from contextlib import (
-    contextmanager,
-)
 
 
 class ProcessInTheWay(Exception):
@@ -17,7 +14,12 @@ class InvalidPidFile(Exception):
     """
 
 
-@contextmanager
+class CannotRemovePidFile(Exception):
+    """
+    something went wrong removing the pidfile
+    """
+
+
 def check_pid_process(pidfile, find_process=None):
     """
     If another instance appears to be running already, raise an
@@ -72,12 +74,15 @@ def check_pid_process(pidfile, find_process=None):
     with pidfile.open("w") as f:
         f.write("{} {}\n".format(pid, starttime).encode("utf8"))
 
-    yield  # setup completed, await cleanup
 
+def cleanup_pidfile(pidfile):
+    """
+    Safely clean up a PID-file
+    """
     try:
         pidfile.remove()
     except Exception as e:
-        print(
+        raise CannotRemovePidFile(
             "Couldn't remove '{pidfile}': {err}.".format(
                 pidfile=pidfile.path,
                 err=e,

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -1,6 +1,10 @@
 import os
 import psutil
 
+# the docs are a little misleading, but this is either WindowsFileLock
+# or UnixFileLock depending upon the platform we're currently on
+from filelock import FileLock, Timeout
+
 
 class ProcessInTheWay(Exception):
     """
@@ -20,6 +24,14 @@ class CannotRemovePidFile(Exception):
     """
 
 
+def _pidfile_to_lockpath(pidfile):
+    """
+    internal helper.
+    :returns FilePath: a path to use for file-locking the given pidfile
+    """
+    return pidfile.sibling("{}.lock".format(pidfile.basename()))
+
+
 def check_pid_process(pidfile, find_process=None):
     """
     If another instance appears to be running already, raise an
@@ -34,57 +46,70 @@ def check_pid_process(pidfile, find_process=None):
     :raises ProcessInTheWay: if a running process exists at our PID
     """
     find_process = psutil.Process if find_process is None else find_process
-    # check if we have another instance running already
-    if pidfile.exists():
-        with pidfile.open("r") as f:
-            content = f.read().decode("utf8").strip()
-        try:
-            pid, starttime = content.split()
-            pid = int(pid)
-            starttime = float(starttime)
-        except ValueError:
-            raise InvalidPidFile(
-                "found invalid PID file in {}".format(
-                    pidfile
-                )
-            )
-        try:
-            # if any other process is running at that PID, let the
-            # user decide if this is another legitimate
-            # instance. Automated programs may use the start-time to
-            # help decide this (if the PID is merely recycled, the
-            # start-time won't match).
-            find_process(pid)
-            raise ProcessInTheWay(
-                "A process is already running as PID {}".format(pid)
-            )
-        except psutil.NoSuchProcess:
-            print(
-                "'{pidpath}' refers to {pid} that isn't running".format(
-                    pidpath=pidfile.path,
-                    pid=pid,
-                )
-            )
-            # nothing is running at that PID so it must be a stale file
-            pidfile.remove()
+    lock_path = _pidfile_to_lockpath(pidfile)
 
-    # write our PID + start-time to the pid-file
-    pid = os.getpid()
-    starttime = find_process(pid).create_time()
-    with pidfile.open("w") as f:
-        f.write("{} {}\n".format(pid, starttime).encode("utf8"))
+    try:
+        # a short timeout is fine, this lock should only be active
+        # while someone is reading or deleting the pidfile .. and
+        # facilitates testing the locking itself.
+        with FileLock(lock_path.path, timeout=2):
+            # check if we have another instance running already
+            if pidfile.exists():
+                with pidfile.open("r") as f:
+                    content = f.read().decode("utf8").strip()
+                try:
+                    pid, starttime = content.split()
+                    pid = int(pid)
+                    starttime = float(starttime)
+                except ValueError:
+                    raise InvalidPidFile(
+                        "found invalid PID file in {}".format(
+                            pidfile
+                        )
+                    )
+                try:
+                    # if any other process is running at that PID, let the
+                    # user decide if this is another legitimate
+                    # instance. Automated programs may use the start-time to
+                    # help decide this (if the PID is merely recycled, the
+                    # start-time won't match).
+                    find_process(pid)
+                    raise ProcessInTheWay(
+                        "A process is already running as PID {}".format(pid)
+                    )
+                except psutil.NoSuchProcess:
+                    print(
+                        "'{pidpath}' refers to {pid} that isn't running".format(
+                            pidpath=pidfile.path,
+                            pid=pid,
+                        )
+                    )
+                    # nothing is running at that PID so it must be a stale file
+                    pidfile.remove()
+
+            # write our PID + start-time to the pid-file
+            pid = os.getpid()
+            starttime = find_process(pid).create_time()
+            with pidfile.open("w") as f:
+                f.write("{} {}\n".format(pid, starttime).encode("utf8"))
+    except Timeout:
+        raise ProcessInTheWay(
+            "Another process is still locking {}".format(pidfile.path)
+        )
 
 
 def cleanup_pidfile(pidfile):
     """
     Safely clean up a PID-file
     """
-    try:
-        pidfile.remove()
-    except Exception as e:
-        raise CannotRemovePidFile(
-            "Couldn't remove '{pidfile}': {err}.".format(
-                pidfile=pidfile.path,
-                err=e,
+    lock_path = _pidfile_to_lockpath(pidfile)
+    with FileLock(lock_path.path):
+        try:
+            pidfile.remove()
+        except Exception as e:
+            raise CannotRemovePidFile(
+                "Couldn't remove '{pidfile}': {err}.".format(
+                    pidfile=pidfile.path,
+                    err=e,
+                )
             )
-        )

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -1,4 +1,3 @@
-import os
 import psutil
 
 # the docs are a little misleading, but this is either WindowsFileLock

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -105,7 +105,8 @@ def check_pid_process(pidfile):
 
 def cleanup_pidfile(pidfile):
     """
-    Safely clean up a PID-file
+    Remove the pidfile specified (respecting locks). If anything at
+    all goes wrong, `CannotRemovePidFile` is raised.
     """
     lock_path = _pidfile_to_lockpath(pidfile)
     with FileLock(lock_path.path):

--- a/src/allmydata/util/pid.py
+++ b/src/allmydata/util/pid.py
@@ -50,11 +50,11 @@ def check_pid_process(pidfile, find_process=None):
             )
         try:
             # if any other process is running at that PID, let the
-            # user decide if this is another magic-older
+            # user decide if this is another legitimate
             # instance. Automated programs may use the start-time to
             # help decide this (if the PID is merely recycled, the
             # start-time won't match).
-            proc = find_process(pid)
+            find_process(pid)
             raise ProcessInTheWay(
                 "A process is already running as PID {}".format(pid)
             )


### PR DESCRIPTION
fixes:ticket:3926

since we already import the reactor "too early" for `--reactor` to work, we can just use the reactor-events to enable pid-file cleanup.

note that on windows there will "always" be a pid-file because getting killed on windows means no chance to run any code no matter what the signal (thus, no Twisted reactor shutdown events).