### PR TITLE
"make release" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,4 +270,6 @@ release-test:
 	rm -rf testmf_venv
 
 release-upload:
+	scp dist/*`git describe | cut -b 12-`* meejah@tahoe-lafs.org:/home/source/downloads
+	git push origin_push tahoe-lafs-`git describe | cut -b 12-`
 	twine upload dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl.asc dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz.asc

--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,9 @@ release:
 	@echo "Test README"
 	python3 setup.py check -r -s
 
+# XXX make branch, based on a ticket (provided how?)
+# XXX or, specify that "make release" must run on such a branch "XXXX.tahoe-release"
+
 	@echo "Update NEWS"
 	python3 -m towncrier build --yes --version `python3 misc/build_helpers/update-version.py --no-tag`
 	git add -u
@@ -249,22 +252,22 @@ release:
 
 	@echo "Build and sign wheel"
 	python3 setup.py bdist_wheel
-	gpg --pinentry=loopback -u meejah@meejah.ca --armor --detach-sign dist/tahoe_lafs-`git describe --abbrev=0`-py3-none-any.whl
-	ls dist/*`git describe --abbrev=0`*
+	gpg --pinentry=loopback -u meejah@meejah.ca --armor --detach-sign dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl
+	ls dist/*`git describe | cut -b 12-`*
 
 	@echo "Build and sign source-dist"
 	python3 setup.py sdist
-	gpg --pinentry=loopback -u meejah@meejah.ca --armor --detach-sign dist/tahoe-lafs-`git describe --abbrev=0`.tar.gz
-	ls dist/*`git describe --abbrev=0`*
+	gpg --pinentry=loopback -u meejah@meejah.ca --armor --detach-sign dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz
+	ls dist/*`git describe | cut -b 12-`*
 
 release-test:
-	gpg --verify dist/tahoe-lafs-`git describe --abbrev=0`.tar.gz.asc
-	gpg --verify dist/tahoe_lafs-`git describe --abbrev=0`-py3-none-any.whl.asc
+	gpg --verify dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz.asc
+	gpg --verify dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl.asc
 	virtualenv testmf_venv
-	testmf_venv/bin/pip install dist/tahoe_lafs-`git describe --abbrev=0`-py3-none-any.whl
+	testmf_venv/bin/pip install dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl
 	testmf_venv/bin/tahoe-lafs --version
 # ... 
 	rm -rf testmf_venv
 
 release-upload:
-	twine upload dist/tahoe_lafs-`git describe --abbrev=0`-py3-none-any.whl dist/tahoe_lafs-`git describe --abbrev=0`-py3-none-any.whl.asc dist/tahoe-lafs-`git describe --abbrev=0`.tar.gz dist/tahoe-lafs-`git describe --abbrev=0`.tar.gz.asc
+	twine upload dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl.asc dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz.asc

--- a/Makefile
+++ b/Makefile
@@ -250,14 +250,13 @@ release:
 	@echo "Test README"
 	python3 setup.py check -r -s
 
-# XXX make branch, based on a ticket (provided how?)
-# XXX or, specify that "make release" must run on such a branch "XXXX.tahoe-release"
-
 	@echo "Update NEWS"
 	python3 -m towncrier build --yes --version `python3 misc/build_helpers/update-version.py --no-tag`
 	git add -u
 	git commit -m "update NEWS for release"
 
+# note that this always bumps the "middle" number, e.g. from 1.17.1 -> 1.18.0
+# and produces a tag into the Git repository
 	@echo "Bump version and create tag"
 	python3 misc/build_helpers/update-version.py
 

--- a/Makefile
+++ b/Makefile
@@ -260,13 +260,13 @@ release:
 	gpg --pinentry=loopback -u meejah@meejah.ca --armor --detach-sign dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz
 	ls dist/*`git describe | cut -b 12-`*
 
+# basically just a bare-minimum smoke-test that it installs and runs
 release-test:
 	gpg --verify dist/tahoe-lafs-`git describe | cut -b 12-`.tar.gz.asc
 	gpg --verify dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl.asc
 	virtualenv testmf_venv
 	testmf_venv/bin/pip install dist/tahoe_lafs-`git describe | cut -b 12-`-py3-none-any.whl
-	testmf_venv/bin/tahoe-lafs --version
-# ... 
+	testmf_venv/bin/tahoe --version
 	rm -rf testmf_venv
 
 release-upload:

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,9 @@ release:
 	git diff-files --quiet
 	git diff-index --quiet --cached HEAD --
 
+	@echo "Clean docs build area"
+	rm -rf docs/_build/
+
 	@echo "Install required build software"
 	python3 -m pip install --editable .[build]
 

--- a/Makefile
+++ b/Makefile
@@ -226,8 +226,16 @@ src/allmydata/_version.py:
 	tox --notest -p all | tee -a "$(@)"
 
 
-# Make a new release. TODO:
-# - clean checkout necessary? garbage in tarball?
+# to make a new release:
+# - create a ticket for the release in Trac
+# - ensure local copy is up-to-date
+# - create a branch like "XXXX.release" from up-to-date master
+# - in the branch, run "make release"
+# - run "make release-test"
+# - perform any other sanity-checks on the release
+# - run "make release-upload"
+# Note that several commands below hard-code "meejah"; if you are
+# someone else please adjust them.
 release:
 	@echo "Is checkout clean?"
 	git diff-files --quiet

--- a/misc/build_helpers/update-version.py
+++ b/misc/build_helpers/update-version.py
@@ -1,0 +1,96 @@
+#
+# this updates the (tagged) version of the software
+#
+# Any "options" are hard-coded in here (e.g. the GnuPG key to use)
+#
+
+author = "meejah <meejah@meejah.ca>"
+
+
+import sys
+import time
+import itertools
+from datetime import datetime
+from packaging.version import Version
+
+from dulwich.repo import Repo
+from dulwich.porcelain import (
+    tag_list,
+    tag_create,
+    status,
+)
+
+from twisted.internet.task import (
+    react,
+)
+from twisted.internet.defer import (
+    ensureDeferred,
+)
+
+
+def existing_tags(git):
+    versions = sorted(
+        Version(v.decode("utf8").lstrip("tahoe-lafs-"))
+        for v in tag_list(git)
+        if v.startswith(b"tahoe-lafs-")
+    )
+    return versions
+
+
+def create_new_version(git):
+    versions = existing_tags(git)
+    biggest = versions[-1]
+
+    return Version(
+        "{}.{}.{}".format(
+            biggest.major,
+            biggest.minor + 1,
+            0,
+        )
+    )
+
+
+async def main(reactor):
+    git = Repo(".")
+
+    st = status(git)
+    if any(st.staged.values()) or st.unstaged:
+        print("unclean checkout; aborting")
+        raise SystemExit(1)
+
+    v = create_new_version(git)
+    if "--no-tag" in sys.argv:
+        print(v)
+        return
+
+    print("Existing tags: {}".format("\n".join(str(x) for x in existing_tags(git))))
+    print("New tag will be {}".format(v))
+
+    # the "tag time" is seconds from the epoch .. we quantize these to
+    # the start of the day in question, in UTC.
+    now = datetime.now()
+    s = now.utctimetuple()
+    ts = int(
+        time.mktime(
+            time.struct_time((s.tm_year, s.tm_mon, s.tm_mday, 0, 0, 0, 0, s.tm_yday, 0))
+        )
+    )
+    tag_create(
+        repo=git,
+        tag="tahoe-lafs-{}".format(str(v)).encode("utf8"),
+        author=author.encode("utf8"),
+        message="Release {}".format(v).encode("utf8"),
+        annotated=True,
+        objectish=b"HEAD",
+        sign=author.encode("utf8"),
+        tag_time=ts,
+        tag_timezone=0,
+    )
+
+    print("Tag created locally, it is not pushed")
+    print("To push it run something like:")
+    print("   git push origin {}".format(v))
+
+
+if __name__ == "__main__":
+    react(lambda r: ensureDeferred(main(r)))

--- a/misc/build_helpers/update-version.py
+++ b/misc/build_helpers/update-version.py
@@ -9,7 +9,6 @@ author = "meejah <meejah@meejah.ca>"
 
 import sys
 import time
-import itertools
 from datetime import datetime
 from packaging.version import Version
 

--- a/newsfragments/3846.feature
+++ b/newsfragments/3846.feature
@@ -1,0 +1,1 @@
+"make" based release automation

--- a/setup.py
+++ b/setup.py
@@ -380,6 +380,10 @@ setup(name="tahoe-lafs", # also set in __init__.py
           # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2392 for some
           # discussion.
           ':sys_platform=="win32"': ["pywin32 != 226"],
+          "build": [
+              "dulwich",
+              "gpg",
+          ],
           "test": [
               "flake8",
               # Pin a specific pyflakes so we don't have different folks


### PR DESCRIPTION
While preparing 1.18.0 I tried to use the `release.py` script from  #1181 but it's not quite ready for use yet.

So, I copied most of the magic-folder release process as encoded in this "make" target -- at least for 1.18.0. The 1.18.0 release branch is based on top of this but figured it's easier to see by itself.

I left in hard-coded "meejah" usernames etc since I'm the only one who has done a release recently.