### PR TITLE
missing release-announcement for 1.18.0

### DIFF
--- a/relnotes.txt
+++ b/relnotes.txt
@@ -1,6 +1,6 @@
-﻿ANNOUNCING Tahoe, the Least-Authority File Store, v1.17.1
+﻿ANNOUNCING Tahoe, the Least-Authority File Store, v1.18.0
 
-The Tahoe-LAFS team is pleased to announce version 1.17.1 of
+The Tahoe-LAFS team is pleased to announce version 1.18.0 of
 Tahoe-LAFS, an extremely reliable decentralized storage
 system. Get it with "pip install tahoe-lafs", or download a
 tarball here:
@@ -15,10 +15,12 @@ unique security and fault-tolerance properties:
 
   https://tahoe-lafs.readthedocs.org/en/latest/about.html
 
-The previous stable release of Tahoe-LAFS was v1.17.0, released on
-December 6, 2021.
+The previous stable release of Tahoe-LAFS was v1.17.1, released on
+January 7, 2022.
 
-This release fixes two Python3-releated regressions and 4 minor bugs.
+This release drops support for Python 2 and for Python 3.6 and earlier.
+twistd.pid is no longer used (in favour of one with pid + process creation time).
+A collection of minor bugs and issues were also fixed.
 
 Please see ``NEWS.rst`` [1] for a complete list of changes.
 
@@ -132,24 +134,23 @@ Of Fame" [13].
 
 ACKNOWLEDGEMENTS
 
-This is the nineteenth release of Tahoe-LAFS to be created
-solely as a labor of love by volunteers. Thank you very much
-to the team of "hackers in the public interest" who make
-Tahoe-LAFS possible.
+This is the twentieth release of Tahoe-LAFS to be created solely as a
+labor of love by volunteers. Thank you very much to the team of
+"hackers in the public interest" who make Tahoe-LAFS possible.
 
 meejah
 on behalf of the Tahoe-LAFS team
 
-January 7, 2022
+October 1, 2022
 Planet Earth
 
 
-[1] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.17.1/NEWS.rst
+[1] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.18.0/NEWS.rst
 [2] https://github.com/tahoe-lafs/tahoe-lafs/blob/master/docs/known_issues.rst
 [3] https://tahoe-lafs.org/trac/tahoe-lafs/wiki/RelatedProjects
-[4] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.17.1/COPYING.GPL
-[5] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.17.1/COPYING.TGPPL.rst
-[6] https://tahoe-lafs.readthedocs.org/en/tahoe-lafs-1.17.1/INSTALL.html
+[4] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.18.0/COPYING.GPL
+[5] https://github.com/tahoe-lafs/tahoe-lafs/blob/tahoe-lafs-1.18.0/COPYING.TGPPL.rst
+[6] https://tahoe-lafs.readthedocs.org/en/tahoe-lafs-1.18.0/INSTALL.html
 [7] https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev
 [8] https://tahoe-lafs.org/trac/tahoe-lafs/roadmap
 [9] https://github.com/tahoe-lafs/tahoe-lafs/blob/master/CREDITS


### PR DESCRIPTION
Missed `relnotes.txt` for 1.18.0 release