### PR TITLE
Require latest pycddl, and work around a regression

### DIFF
--- a/newsfragments/3938.bugfix
+++ b/newsfragments/3938.bugfix
@@ -1,0 +1,1 @@
+Work with (and require) newer versions of pycddl.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "76b8f1e44a8ec051b853494bcf3cc8453a294a6a",
-        "sha256": "18fgqyh4z578jjhk26n1xi2cw2l98vrqp962rgz9a6wa5yh1nm4x",
+        "rev": "5fe7d2d1c85cd86d64f4f079eef3f1ff5653bcd6",
+        "sha256": "0pc6mj7rzvmhh303rvj5wf4hrksm4h2rf4fsvqs0ljjdmgxrqm3f",
         "type": "tarball",
-        "url": "https://github.com/DavHau/pypi-deps-db/archive/76b8f1e44a8ec051b853494bcf3cc8453a294a6a.tar.gz",
+        "url": "https://github.com/DavHau/pypi-deps-db/archive/5fe7d2d1c85cd86d64f4f079eef3f1ff5653bcd6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ install_requires = [
     "werkzeug != 2.2.0",
     "treq",
     "cbor2",
-    "pycddl",
+    "pycddl >= 0.2",
 
     # for pid-file support
     "psutil",

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -83,35 +83,35 @@ _SCHEMAS = {
     "allocate_buckets": Schema(
         """
     response = {
-      already-have: #6.258([* uint])
-      allocated: #6.258([* uint])
+      already-have: #6.258([0*256 uint])
+      allocated: #6.258([0*256 uint])
     }
     """
     ),
     "immutable_write_share_chunk": Schema(
         """
     response = {
-      required: [* {begin: uint, end: uint}]
+      required: [0* {begin: uint, end: uint}]
     }
     """
     ),
     "list_shares": Schema(
         """
-    response = #6.258([* uint])
+    response = #6.258([0*256 uint])
     """
     ),
     "mutable_read_test_write": Schema(
         """
         response = {
           "success": bool,
-          "data": {* share_number: [* bstr]}
+          "data": {0*256 share_number: [0* bstr]}
         }
         share_number = uint
         """
     ),
     "mutable_list_shares": Schema(
         """
-        response = #6.258([* uint])
+        response = #6.258([0*256 uint])
         """
     ),
 }

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -260,7 +260,7 @@ _SCHEMAS = {
     "allocate_buckets": Schema(
         """
     request = {
-      share-numbers: #6.258([*256 uint])
+      share-numbers: #6.258([0*256 uint])
       allocated-size: uint
     }
     """
@@ -276,15 +276,13 @@ _SCHEMAS = {
         """
         request = {
             "test-write-vectors": {
-                ; TODO Add length limit here, after
-                ; https://github.com/anweiss/cddl/issues/128 is fixed
-                * share_number => {
-                    "test": [*30 {"offset": uint, "size": uint, "specimen": bstr}]
-                    "write": [*30 {"offset": uint, "data": bstr}]
+                0*256 share_number : {
+                    "test": [0*30 {"offset": uint, "size": uint, "specimen": bstr}]
+                    "write": [0*30 {"offset": uint, "data": bstr}]
                     "new-length": uint / null
                 }
             }
-            "read-vector": [*30 {"offset": uint, "size": uint}]
+            "read-vector": [0*30 {"offset": uint, "size": uint}]
         }
         share_number = uint
         """


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3938

Uses a new feature in pycddl 0.2, and works around a regression (caused by https://github.com/anweiss/cddl/issues/148).