### PR TITLE
Add http storage timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,8 @@ jobs:
       matrix:
         os:
           - windows-latest
+          # 22.04 has some issue with Tor at the moment:
+          # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943
           - ubuntu-20.04
         python-version:
           - 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     steps:
 
       - name: Install Tor [Ubuntu]
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ contains(matrix.os, 'ubuntu') }}
         run: sudo apt install tor
 
       # TODO: See https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3744.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - ubuntu-latest
+          - ubuntu-20.04
         python-version:
           - 3.7
           - 3.9

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -164,6 +164,7 @@ def limited_content(
     d.addCallback(lambda _: treq.collect(response, collector))
 
     def done(_):
+        timeout.cancel()
         collector.f.seek(0)
         return collector.f
 
@@ -539,7 +540,7 @@ def read_share_chunk(
             raise ValueError("Server sent more than we asked for?!")
         # It might also send less than we asked for. That's (probably) OK, e.g.
         # if we went past the end of the file.
-        body = yield limited_content(response, supposed_length)
+        body = yield limited_content(response, supposed_length, client._clock)
         body.seek(0, SEEK_END)
         actual_length = body.tell()
         if actual_length != supposed_length:

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -169,7 +169,12 @@ def limited_content(
         collector.f.seek(0)
         return collector.f
 
-    return d.addCallback(done)
+    def failed(f):
+        if timeout.active():
+            timeout.cancel()
+        return f
+
+    return d.addCallbacks(done, failed)
 
 
 def _decode_cbor(response, schema: Schema, clock: IReactorTime):

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -382,7 +382,7 @@ class StorageClient(object):
         write_enabler_secret=None,
         headers=None,
         message_to_serialize=None,
-        timeout: Union[int, float] = 60,
+        timeout: float = 60,
         **kwargs,
     ):
         """

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -343,8 +343,6 @@ class StorageClient(object):
             Agent(
                 reactor,
                 _StorageClientHTTPSPolicy(expected_spki_hash=certificate_hash),
-                # TCP-level connection timeout
-                connectTimeout=5,
                 pool=pool,
             )
         )
@@ -385,6 +383,8 @@ class StorageClient(object):
 
         If ``message_to_serialize`` is set, it will be serialized (by default
         with CBOR) and set as the request body.
+
+        Default timeout is 60 seconds.
         """
         headers = self._get_headers(headers)
 
@@ -506,9 +506,9 @@ def read_share_chunk(
             share_type, _encode_si(storage_index), share_number
         )
     )
-    # The default timeout is for getting the response, so it doesn't include
-    # the time it takes to download the body... so we will will deal with that
-    # later.
+    # The default 60 second timeout is for getting the response, so it doesn't
+    # include the time it takes to download the body... so we will will deal
+    # with that later, via limited_content().
     response = yield client.request(
         "GET",
         url,

--- a/src/allmydata/test/common_system.py
+++ b/src/allmydata/test/common_system.py
@@ -643,10 +643,16 @@ def _render_section_values(values):
 @async_to_deferred
 async def spin_until_cleanup_done(value=None, timeout=10):
     """
-    At the end of the test, spin until either a timeout is hit, or the reactor
-    has no more DelayedCalls.
+    At the end of the test, spin until the reactor has no more DelayedCalls
+    and file descriptors (or equivalents) registered. This prevents dirty
+    reactor errors, while also not hard-coding a fixed amount of time, so it
+    can finish faster on faster computers.
 
-    Make sure to register during setUp.
+    There is also a timeout: if it takes more than 10 seconds (by default) for
+    the remaining reactor state to clean itself up, the presumption is that it
+    will never get cleaned up and the spinning stops.
+
+    Make sure to run as last thing in tearDown.
     """
     def num_fds():
         if hasattr(reactor, "handles"):

--- a/src/allmydata/test/common_system.py
+++ b/src/allmydata/test/common_system.py
@@ -659,10 +659,11 @@ async def spin_until_cleanup_done(value=None, timeout=10):
             # IOCP!
             return len(reactor.handles)
         else:
-            # Normal reactor
-            return len([r for r in reactor.getReaders()
-                        if r.__class__.__name__ not in ("_UnixWaker", "_SIGCHLDWaker", "_SocketWaker")]
-                       ) + len(reactor.getWriters())
+            # Normal reactor; having internal readers still registered is fine,
+            # that's not our code.
+            return len(
+                set(reactor.getReaders()) - set(reactor._internalReaders)
+            ) + len(reactor.getWriters())
 
     for i in range(timeout * 1000):
         # There's a single DelayedCall for AsynchronousDeferredRunTest's

--- a/src/allmydata/test/common_system.py
+++ b/src/allmydata/test/common_system.py
@@ -655,7 +655,7 @@ async def spin_until_cleanup_done(value=None, timeout=10):
         else:
             # Normal reactor
             return len([r for r in reactor.getReaders()
-                        if r.__class__.__name__ not in ("_UnixWaker", "_SIGCHLDWaker")]
+                        if r.__class__.__name__ not in ("_UnixWaker", "_SIGCHLDWaker", "_SocketWaker")]
                        ) + len(reactor.getWriters())
 
     for i in range(timeout * 1000):

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -371,7 +371,9 @@ class CustomHTTPServerTests(SyncTestCase):
             )
 
             self.assertEqual(
-                result_of(limited_content(response, at_least_length)).read(),
+                result_of(
+                    limited_content(response, self._http_server.clock, at_least_length)
+                ).read(),
                 gen_bytes(length),
             )
 
@@ -390,7 +392,7 @@ class CustomHTTPServerTests(SyncTestCase):
             )
 
             with self.assertRaises(ValueError):
-                result_of(limited_content(response, too_short))
+                result_of(limited_content(response, self._http_server.clock, too_short))
 
     def test_limited_content_silence_causes_timeout(self):
         """
@@ -404,7 +406,7 @@ class CustomHTTPServerTests(SyncTestCase):
             )
         )
 
-        body_deferred = limited_content(response, 4, self._http_server.clock)
+        body_deferred = limited_content(response, self._http_server.clock, 4)
         result = []
         error = []
         body_deferred.addCallbacks(result.append, error.append)

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -311,16 +311,18 @@ class CustomHTTPServerTests(SyncTestCase):
         # Could be a fixture, but will only be used in this test class so not
         # going to bother:
         self._http_server = TestApp()
+        treq = StubTreq(self._http_server._app.resource())
         self.client = StorageClient(
             DecodedURL.from_text("http://127.0.0.1"),
             SWISSNUM_FOR_TEST,
-            treq=StubTreq(self._http_server._app.resource()),
-            clock=Clock(),
+            treq=treq,
+            # We're using a Treq private API to get the reactor, alas, but only
+            # in a test, so not going to worry about it too much. This would be
+            # fixed if https://github.com/twisted/treq/issues/226 were ever
+            # fixed.
+            clock=treq._agent._memoryReactor,
         )
-        # We're using a Treq private API to get the reactor, alas, but only in
-        # a test, so not going to worry about it too much. This would be fixed
-        # if https://github.com/twisted/treq/issues/226 were ever fixed.
-        self._http_server.clock = self.client._treq._agent._memoryReactor
+        self._http_server.clock = self.client._clock
 
     def test_authorization_enforcement(self):
         """

--- a/src/allmydata/test/test_storage_https.py
+++ b/src/allmydata/test/test_storage_https.py
@@ -183,6 +183,10 @@ class PinningHTTPSValidation(AsyncTestCase):
             response = await self.request(url, certificate)
             self.assertEqual(await response.content(), b"YOYODYNE")
 
+        # We keep getting TLSMemoryBIOProtocol being left around, so try harder
+        # to wait for it to finish.
+        await deferLater(reactor, 0.01)
+
     @async_to_deferred
     async def test_server_certificate_not_valid_yet(self):
         """

--- a/src/allmydata/test/test_storage_https.py
+++ b/src/allmydata/test/test_storage_https.py
@@ -12,6 +12,7 @@ from cryptography import x509
 
 from twisted.internet.endpoints import serverFromString
 from twisted.internet import reactor
+from twisted.internet.defer import maybeDeferred
 from twisted.web.server import Site
 from twisted.web.static import Data
 from twisted.web.client import Agent, HTTPConnectionPool, ResponseNeverReceived
@@ -88,8 +89,8 @@ class PinningHTTPSValidation(AsyncTestCase):
         return AsyncTestCase.setUp(self)
 
     def tearDown(self):
-        AsyncTestCase.tearDown(self)
-        return spin_until_cleanup_done()
+        d = maybeDeferred(AsyncTestCase.tearDown, self)
+        return d.addCallback(lambda _: spin_until_cleanup_done())
 
     @asynccontextmanager
     async def listen(self, private_key_path: FilePath, cert_path: FilePath):

--- a/src/allmydata/test/test_storage_https.py
+++ b/src/allmydata/test/test_storage_https.py
@@ -12,7 +12,6 @@ from cryptography import x509
 
 from twisted.internet.endpoints import serverFromString
 from twisted.internet import reactor
-from twisted.internet.task import deferLater
 from twisted.web.server import Site
 from twisted.web.static import Data
 from twisted.web.client import Agent, HTTPConnectionPool, ResponseNeverReceived
@@ -30,6 +29,7 @@ from ..storage.http_common import get_spki_hash
 from ..storage.http_client import _StorageClientHTTPSPolicy
 from ..storage.http_server import _TLSEndpointWrapper
 from ..util.deferredutil import async_to_deferred
+from .common_system import spin_until_cleanup_done
 
 
 class HTTPSNurlTests(SyncTestCase):
@@ -87,6 +87,10 @@ class PinningHTTPSValidation(AsyncTestCase):
         self.addCleanup(self._port_assigner.tearDown)
         return AsyncTestCase.setUp(self)
 
+    def tearDown(self):
+        AsyncTestCase.tearDown(self)
+        return spin_until_cleanup_done()
+
     @asynccontextmanager
     async def listen(self, private_key_path: FilePath, cert_path: FilePath):
         """
@@ -107,9 +111,6 @@ class PinningHTTPSValidation(AsyncTestCase):
             yield f"https://127.0.0.1:{listening_port.getHost().port}/"
         finally:
             await listening_port.stopListening()
-            # Make sure all server connections are closed :( No idea why this
-            # is necessary when it's not for IStorageServer HTTPS tests.
-            await deferLater(reactor, 0.01)
 
     def request(self, url: str, expected_certificate: x509.Certificate):
         """
@@ -143,10 +144,6 @@ class PinningHTTPSValidation(AsyncTestCase):
         ) as url:
             response = await self.request(url, certificate)
             self.assertEqual(await response.content(), b"YOYODYNE")
-
-        # We keep getting TLSMemoryBIOProtocol being left around, so try harder
-        # to wait for it to finish.
-        await deferLater(reactor, 0.01)
 
     @async_to_deferred
     async def test_server_certificate_has_wrong_hash(self):
@@ -183,10 +180,6 @@ class PinningHTTPSValidation(AsyncTestCase):
             response = await self.request(url, certificate)
             self.assertEqual(await response.content(), b"YOYODYNE")
 
-        # We keep getting TLSMemoryBIOProtocol being left around, so try harder
-        # to wait for it to finish.
-        await deferLater(reactor, 0.01)
-
     @async_to_deferred
     async def test_server_certificate_not_valid_yet(self):
         """
@@ -205,10 +198,6 @@ class PinningHTTPSValidation(AsyncTestCase):
         ) as url:
             response = await self.request(url, certificate)
             self.assertEqual(await response.content(), b"YOYODYNE")
-
-        # We keep getting TLSMemoryBIOProtocol being left around, so try harder
-        # to wait for it to finish.
-        await deferLater(reactor, 0.001)
 
     # A potential attack to test is a private key that doesn't match the
     # certificate... but OpenSSL (quite rightly) won't let you listen with that


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3940

Also this has some fixes for the intermittent dirty reactor timeouts, and workaround for Tor integration test issues that started failing when GitHub Actions switched `ubuntu-latest` to 22.04 (I have filed an issue: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943)