### PR TITLE
Faster HTTP for immutable downloads

### DIFF
--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -323,6 +323,7 @@ class StorageClient(object):
         swissnum = nurl.path[0].encode("ascii")
         certificate_hash = nurl.user.encode("ascii")
         pool = HTTPConnectionPool(reactor)
+        pool.maxPersistentPerHost = 20
 
         if cls.TEST_MODE_REGISTER_HTTP_POOL is not None:
             cls.TEST_MODE_REGISTER_HTTP_POOL(pool)


### PR DESCRIPTION
This takes CPU (and clock time) from 1.2 seconds to 0.6 seconds for downloading 20MB file with no latency over loopback. Probably just fewer TLS handshakes, basically.

This likely speeds up anything using HTTP.

Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3954