### PR TITLE
Remove support for Python 3.7, Ubuntu 18.04, Debian 10 (oldstable)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,12 +167,7 @@ jobs:
           command: |
             dist/Tahoe-LAFS/tahoe --version
 
-  debian-10: &DEBIAN
-    docker:
-      - <<: *DOCKERHUB_AUTH
-        image: "tahoelafsci/debian:10-py3.7"
-        user: "nobody"
-
+  debian-11: &DEBIAN
     environment: &UTF_8_ENVIRONMENT
       # In general, the test suite is not allowed to fail while the job
       # succeeds.  But you can set this to "yes" if you want it to be
@@ -184,7 +179,7 @@ jobs:
       # filenames and argv).
       LANG: "en_US.UTF-8"
       # Select a tox environment to run for this job.
-      TAHOE_LAFS_TOX_ENVIRONMENT: "py37"
+      TAHOE_LAFS_TOX_ENVIRONMENT: "py39"
       # Additional arguments to pass to tox.
       TAHOE_LAFS_TOX_ARGS: ""
       # The path in which test artifacts will be placed.
@@ -252,15 +247,11 @@ jobs:
               /tmp/venv/bin/codecov
             fi
 
-  debian-11:
-    <<: *DEBIAN
     docker:
       - <<: *DOCKERHUB_AUTH
         image: "tahoelafsci/debian:11-py3.9"
         user: "nobody"
-    environment:
-      <<: *UTF_8_ENVIRONMENT
-      TAHOE_LAFS_TOX_ENVIRONMENT: "py39"
+
 
   # Restore later using PyPy3.8
   # pypy27-buster:
@@ -311,22 +302,6 @@ jobs:
       # DRY, YAML-style.  See the debian-9 steps.
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
-
-  ubuntu-18-04: &UBUNTU_18_04
-    <<: *DEBIAN
-    docker:
-      - <<: *DOCKERHUB_AUTH
-        image: "tahoelafsci/ubuntu:18.04-py3.7"
-        user: "nobody"
-
-    environment:
-      <<: *UTF_8_ENVIRONMENT
-      # The default trial args include --rterrors which is incompatible with
-      # this reporter on Python 3.  So drop that and just specify the
-      # reporter.
-      TAHOE_LAFS_TRIAL_ARGS: "--reporter=subunitv2-file"
-      TAHOE_LAFS_TOX_ENVIRONMENT: "py37"
-
 
   ubuntu-20-04:
     <<: *DEBIAN
@@ -445,7 +420,7 @@ jobs:
   typechecks:
     docker:
       - <<: *DOCKERHUB_AUTH
-        image: "tahoelafsci/ubuntu:18.04-py3.7"
+        image: "tahoelafsci/ubuntu:20.04-py3.9"
 
     steps:
       - "checkout"
@@ -457,7 +432,7 @@ jobs:
   docs:
     docker:
       - <<: *DOCKERHUB_AUTH
-        image: "tahoelafsci/ubuntu:18.04-py3.7"
+        image: "tahoelafsci/ubuntu:20.04-py3.9"
 
     steps:
       - "checkout"
@@ -508,15 +483,6 @@ jobs:
             docker push tahoelafsci/${DISTRO}:${TAG}-py${PYTHON_VERSION}
 
 
-  build-image-debian-10:
-    <<: *BUILD_IMAGE
-
-    environment:
-      DISTRO: "debian"
-      TAG: "10"
-      PYTHON_VERSION: "3.7"
-
-
   build-image-debian-11:
     <<: *BUILD_IMAGE
 
@@ -524,14 +490,6 @@ jobs:
       DISTRO: "debian"
       TAG: "11"
       PYTHON_VERSION: "3.9"
-
-  build-image-ubuntu-18-04:
-    <<: *BUILD_IMAGE
-
-    environment:
-      DISTRO: "ubuntu"
-      TAG: "18.04"
-      PYTHON_VERSION: "3.7"
 
 
   build-image-ubuntu-20-04:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,21 +48,20 @@ jobs:
           - windows-latest
           - ubuntu-latest
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
         include:
-          # On macOS don't bother with 3.7-3.8, just to get faster builds.
+          # On macOS don't bother with 3.8, just to get faster builds.
           - os: macos-latest
             python-version: "3.9"
           - os: macos-latest
             python-version: "3.10"
           # We only support PyPy on Linux at the moment.
           - os: ubuntu-latest
-            python-version: "pypy-3.7"
-          - os: ubuntu-latest
             python-version: "pypy-3.8"
+          - os: ubuntu-latest
+            python-version: "pypy-3.9"
 
     steps:
       # See https://github.com/actions/checkout. A fetch-depth of 0
@@ -162,9 +161,6 @@ jobs:
             force-foolscap: false
           # 22.04 has some issue with Tor at the moment:
           # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943
-          - os: ubuntu-20.04
-            python-version: "3.7"
-            force-foolscap: true
           - os: ubuntu-20.04
             python-version: "3.9"
             force-foolscap: false

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Once ``tahoe --version`` works, see `How to Run Tahoe-LAFS <docs/running.rst>`__
 🐍 Python 2
 -----------
 
-Python 3.7 or later is now required.
+Python 3.8 or later is required.
 If you are still using Python 2.7, use Tahoe-LAFS version 1.17.1.
 
 

--- a/newsfragments/3964.removed
+++ b/newsfragments/3964.removed
@@ -1,0 +1,1 @@
+Python 3.7 is no longer supported.

--- a/newsfragments/3964.removed
+++ b/newsfragments/3964.removed
@@ -1,1 +1,1 @@
-Python 3.7 is no longer supported.
+Python 3.7 is no longer supported, and Debian 10 and Ubuntu 18.04 are no longer tested.

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ def run_command(args, cwd=None):
     use_shell = sys.platform == "win32"
     try:
         p = subprocess.Popen(args, stdout=subprocess.PIPE, cwd=cwd, shell=use_shell)
-    except EnvironmentError as e:  # if this gives a SyntaxError, note that Tahoe-LAFS requires Python 3.7+
+    except EnvironmentError as e:  # if this gives a SyntaxError, note that Tahoe-LAFS requires Python 3.8+
         print("Warning: unable to run %r." % (" ".join(args),))
         print(e)
         return None
@@ -374,8 +374,8 @@ setup(name="tahoe-lafs", # also set in __init__.py
       package_dir = {'':'src'},
       packages=find_packages('src') + ['allmydata.test.plugins'],
       classifiers=trove_classifiers,
-      # We support Python 3.7 or later. 3.11 is not supported yet.
-      python_requires=">=3.7, <3.11",
+      # We support Python 3.8 or later. 3.11 is not supported yet.
+      python_requires=">=3.8, <3.11",
       install_requires=install_requires,
       extras_require={
           # Duplicate the Twisted pywin32 dependency here.  See
@@ -388,9 +388,6 @@ setup(name="tahoe-lafs", # also set in __init__.py
           ],
           "test": [
               "flake8",
-              # On Python 3.7, importlib_metadata v5 breaks flake8.
-              # https://github.com/python/importlib_metadata/issues/407
-              "importlib_metadata<5; python_version < '3.8'",
               # Pin a specific pyflakes so we don't have different folks
               # disagreeing on what is or is not a lint issue.  We can bump
               # this version from time to time, but we will do it

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,9 @@
 # the tox-gh-actions package.
 [gh-actions]
 python =
-    3.7: py37-coverage
     3.8: py38-coverage
     3.9: py39-coverage
     3.10: py310-coverage
-    pypy-3.7: pypy37
     pypy-3.8: pypy38
     pypy-3.9: pypy39
 
@@ -19,7 +17,7 @@ python =
 twisted = 1
 
 [tox]
-envlist = typechecks,codechecks,py{37,38,39,310}-{coverage},pypy27,pypy37,pypy38,pypy39,integration
+envlist = typechecks,codechecks,py{38,39,310}-{coverage},pypy27,pypy38,pypy39,integration
 minversion = 2.4
 
 [testenv]
@@ -49,8 +47,6 @@ deps =
      # regressions in new releases of this package that cause us the kind of
      # suffering we're trying to avoid with the above pins.
      certifi
-     # VCS hooks support
-     py37,!coverage: pre-commit
 
 # We add usedevelop=False because testing against a true installation gives
 # more useful results.


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3964

Motivation:

* 3.7 is end of life in June.
* Ubuntu 18.04 is end of life in April.
* Debian 10 is supported for longer, but is only packaged with 3.7, and in any case won't be shipping new versions of Tahoe because it's in security-fix-only mode. They'd be doing backports anyway in the highly unlikely event they backported a security fix, and dropping 3.7 support won't make that particularly any more difficult.