### PR TITLE
Update the Nix package build to pycddl 0.4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "mach-nix": {
-        "branch": "master",
+        "branch": "switch-to-nix-pypi-fetcher-2",
         "description": "Create highly reproducible python environments",
         "homepage": "",
-        "owner": "davhau",
+        "owner": "PrivateStorageio",
         "repo": "mach-nix",
-        "rev": "bdc97ba6b2ecd045a467b008cff4ae337b6a7a6b",
-        "sha256": "12b3jc0g0ak6s93g3ifvdpwxbyqx276k1kl66bpwz8a67qjbcbwf",
+        "rev": "f6d1a1841d8778c199326f95d0703c16bee2f8c4",
+        "sha256": "0krc4yhnpbzc4yhja9frnmym2vqm5zyacjnqb3fq9z9gav8vs9ls",
         "type": "tarball",
-        "url": "https://github.com/davhau/mach-nix/archive/bdc97ba6b2ecd045a467b008cff4ae337b6a7a6b.tar.gz",
+        "url": "https://github.com/PrivateStorageio/mach-nix/archive/f6d1a1841d8778c199326f95d0703c16bee2f8c4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "5fe7d2d1c85cd86d64f4f079eef3f1ff5653bcd6",
-        "sha256": "0pc6mj7rzvmhh303rvj5wf4hrksm4h2rf4fsvqs0ljjdmgxrqm3f",
+        "rev": "5440c9c76f6431f300fb6a1ecae762a5444de5f6",
+        "sha256": "08r3iiaxzw9v2gq15y1m9bwajshyyz9280g6aia7mkgnjs9hnd1n",
         "type": "tarball",
-        "url": "https://github.com/DavHau/pypi-deps-db/archive/5fe7d2d1c85cd86d64f4f079eef3f1ff5653bcd6.tar.gz",
+        "url": "https://github.com/DavHau/pypi-deps-db/archive/5440c9c76f6431f300fb6a1ecae762a5444de5f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -139,11 +139,10 @@ install_requires = [
     "werkzeug != 2.2.0",
     "treq",
     "cbor2",
-    # Ideally we want 0.4+ to be able to pass in mmap(), but it's not strictly
-    # necessary yet until we fix the workaround to
-    # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3963 in
-    # allmydata.storage.http_server.
-    "pycddl",
+
+    # 0.4 adds the ability to pass in mmap() values which greatly reduces the
+    # amount of copying involved.
+    "pycddl >= 0.4",
 
     # for pid-file support
     "psutil",

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -11,7 +11,6 @@ import binascii
 from tempfile import TemporaryFile
 from os import SEEK_END, SEEK_SET
 import mmap
-from importlib.metadata import version as get_package_version, PackageNotFoundError
 
 from cryptography.x509 import Certificate as CryptoCertificate
 from zope.interface import implementer
@@ -58,20 +57,6 @@ from .immutable import BucketWriter, ConflictingWriteError
 from ..util.hashutil import timing_safe_compare
 from ..util.base32 import rfc3548_alphabet
 from allmydata.interfaces import BadWriteEnablerError
-
-
-# Until we figure out Nix (https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3963),
-# need to support old pycddl which can only take bytes:
-from distutils.version import LooseVersion
-
-try:
-    PYCDDL_BYTES_ONLY = LooseVersion(get_package_version("pycddl")) < LooseVersion(
-        "0.4"
-    )
-except PackageNotFoundError:
-    # This can happen when building PyInstaller distribution. We'll just assume
-    # you installed a modern pycddl, cause why wouldn't you?
-    PYCDDL_BYTES_ONLY = False
 
 
 class ClientSecretsException(Exception):
@@ -572,7 +557,7 @@ class HTTPServer(object):
             fd = request.content.fileno()
         except (ValueError, OSError):
             fd = -1
-        if fd >= 0 and not PYCDDL_BYTES_ONLY:
+        if fd >= 0:
             # It's a file, so we can use mmap() to save memory.
             message = mmap.mmap(fd, 0, access=mmap.ACCESS_READ)
         else:


### PR DESCRIPTION
This updates two packaging dependencies managed by niv:

* pypi-deps-db - bump to a version that includes pycddl 0.4
* mach-nix - bump to a version that works with the new version of pypi-deps-db (necessary due to the more-complex-than-average pypi-deps-db changes being pulled in).  The version used is a *branch* waiting to be merged upstream - https://github.com/DavHau/mach-nix/pull/536

It also changes the Python packaging metadata to have a hard requirement on pycddl >= 0.4 so that we can also drop the version check in http_server.py and just assume mmap() is allowed.

https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3967