### PR TITLE
Unpin charset-normalizer / (re-)fix PyInstaller builds

### DIFF
--- a/newsfragments/3966.bugfix
+++ b/newsfragments/3966.bugfix
@@ -1,1 +1,1 @@
-Fix incompatibility with newer versions of the transitive charset_normalizer dependency when using PyInstaller.
+Fix incompatibility with transitive dependency charset_normalizer >= 3  when using PyInstaller.

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -36,6 +36,7 @@ hidden_imports = [
     'allmydata.stats',
     'base64',
     'cffi',
+    'charset_normalizer.md__mypyc',
     'collections',
     'commands',
     'Crypto',

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -36,7 +36,6 @@ hidden_imports = [
     'allmydata.stats',
     'base64',
     'cffi',
-    'charset_normalizer.md__mypyc',
     'collections',
     'commands',
     'Crypto',

--- a/setup.py
+++ b/setup.py
@@ -147,13 +147,6 @@ install_requires = [
     # for pid-file support
     "psutil",
     "filelock",
-
-    # treq needs requests, requests needs charset_normalizer,
-    # charset_normalizer breaks PyInstaller
-    # (https://github.com/Ousret/charset_normalizer/issues/253). So work around
-    # this by using a lower version number. Once upstream issue is fixed, or
-    # requests drops charset_normalizer, this can go away.
-    "charset_normalizer < 3",
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,13 @@ install_requires = [
     # for pid-file support
     "psutil",
     "filelock",
+
+    # treq needs requests, requests needs charset_normalizer,
+    # charset_normalizer breaks PyInstaller
+    # (https://github.com/Ousret/charset_normalizer/issues/253). So work around
+    # this by using a lower version number. Once upstream issue is fixed, or
+    # requests drops charset_normalizer, this can go away.
+    "charset_normalizer < 3",
 ]
 
 setup_requires = [


### PR DESCRIPTION
PR https://github.com/tahoe-lafs/tahoe-lafs/pull/1248 resolved [ticket 3966](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3966) by introducing a "charset_normalizer < 3" constraint in order to unbreak PyInstaller builds. This constraint is unnecessary, however (and can introduce conflicts in shared environments where another adjacent package might require charset_normalizer >= 3); the original issue can instead be resolved more parsimoniously either by a) adding `charset_normalizer.md__mypyc` to PyInstaller's ["hidden imports" list](https://pyinstaller.org/en/v5.7.0/when-things-go-wrong.html#listing-hidden-imports) (in order to make the seemingly-missing package visible to PyInstaller) or b) requiring `pyinstaller-hooks-contrib>=2022.15` (as per https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/534). This PR takes the former approach.