### PR TITLE
Fixes to truthy conditional and variable names same as built-in

### DIFF
--- a/newsfragments/3975.minor
+++ b/newsfragments/3975.minor
@@ -1,0 +1,1 @@
+Fixes truthy conditional in status.py

--- a/newsfragments/3976.minor
+++ b/newsfragments/3976.minor
@@ -1,0 +1,1 @@
+Fixes variable name same as built-in type.

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1616,30 +1616,30 @@ class StatisticsElement(Element):
     @renderer
     def uploads(self, req, tag):
         files = self._stats["counters"].get("uploader.files_uploaded", 0)
-        bytes = self._stats["counters"].get("uploader.bytes_uploaded", 0)
+        bytes_uploaded = self._stats["counters"].get("uploader.bytes_uploaded", 0)
         return tag(("%s files / %s bytes (%s)" %
-                    (files, bytes, abbreviate_size(bytes))))
+                    (files, bytes_uploaded, abbreviate_size(bytes_uploaded))))
 
     @renderer
     def downloads(self, req, tag):
         files = self._stats["counters"].get("downloader.files_downloaded", 0)
-        bytes = self._stats["counters"].get("downloader.bytes_downloaded", 0)
+        bytes_uploaded = self._stats["counters"].get("downloader.bytes_downloaded", 0)
         return tag("%s files / %s bytes (%s)" %
-                   (files, bytes, abbreviate_size(bytes)))
+                   (files, bytes_uploaded, abbreviate_size(bytes_uploaded)))
 
     @renderer
     def publishes(self, req, tag):
         files = self._stats["counters"].get("mutable.files_published", 0)
-        bytes = self._stats["counters"].get("mutable.bytes_published", 0)
-        return tag("%s files / %s bytes (%s)" % (files, bytes,
-                                                 abbreviate_size(bytes)))
+        bytes_uploaded = self._stats["counters"].get("mutable.bytes_published", 0)
+        return tag("%s files / %s bytes (%s)" % (files, bytes_uploaded,
+                                                 abbreviate_size(bytes_uploaded)))
 
     @renderer
     def retrieves(self, req, tag):
         files = self._stats["counters"].get("mutable.files_retrieved", 0)
-        bytes = self._stats["counters"].get("mutable.bytes_retrieved", 0)
-        return tag("%s files / %s bytes (%s)" % (files, bytes,
-                                                 abbreviate_size(bytes)))
+        bytes_uploaded = self._stats["counters"].get("mutable.bytes_retrieved", 0)
+        return tag("%s files / %s bytes (%s)" % (files, bytes_uploaded,
+                                                 abbreviate_size(bytes_uploaded)))
 
     @renderer
     def raw(self, req, tag):

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -550,7 +550,7 @@ class DownloadStatusElement(Element):
             length = r_ev["length"]
             bytes_returned = r_ev["bytes_returned"]
             decrypt_time = ""
-            if bytes_returned is not None:
+            if bytes_returned:
                 decrypt_time = self._rate_and_time(bytes_returned, r_ev["decrypt_time"])
             speed, rtt = "",""
             if r_ev["finish_time"] is not None:

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -550,7 +550,7 @@ class DownloadStatusElement(Element):
             length = r_ev["length"]
             bytes_returned = r_ev["bytes_returned"]
             decrypt_time = ""
-            if bytes:
+            if bytes_returned is not None:
                 decrypt_time = self._rate_and_time(bytes_returned, r_ev["decrypt_time"])
             speed, rtt = "",""
             if r_ev["finish_time"] is not None:


### PR DESCRIPTION
These 2 tickets cannot be solved without each other, if one is pushed without the other tests will fail. So the PR for that solves these 2 tickets have to be made together.

Ticket are:
https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3975
https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3976

1. Currently our there is a conditional that checks a built-in type I think this might be a typo.
2. There are a few functions which use variables with the same name as built-in type. 

Changes:
Fix to truthy conditional check.
Renamed variables to different name from built-in type.