### PR TITLE
Great black swamp spec tweaks

### DIFF
--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -864,7 +864,7 @@ For example::
   [1, 5]
 
 ``GET /storage/v1/mutable/:storage_index/:share_number``
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Read data from the indicated mutable shares, just like ``GET /storage/v1/immutable/:storage_index``.
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -347,6 +347,8 @@ A request MAY be submitted using an alternate encoding by declaring this in the 
 A request MAY indicate its preference for an alternate encoding in the response using the ``Accept`` header field.
 A request which includes no ``Accept`` header field MUST be interpreted in the same way as a request including a ``Accept: application/cbor`` header field.
 
+Clients and servers MAY support additional request and response message body encodings.
+
 Clients and servers SHOULD support ``application/json`` request and response message body encoding.
 For HTTP messages carrying binary share data,
 this is expected to be a particularly poor encoding.
@@ -360,7 +362,11 @@ Because of the simple types used throughout
 and the equivalence described in `RFC 7049`_
 these examples should be representative regardless of which of these two encodings is chosen.
 
-One exception to this rule is for sets.
+There are two exceptions to this rule.
+
+1. Sets
+!!!!!!!
+
 For CBOR messages,
 any sequence that is semantically a set (i.e. no repeated values allowed, order doesn't matter, and elements are hashable in Python) should be sent as a set.
 Tag 6.258 is used to indicate sets in CBOR;
@@ -368,11 +374,11 @@ see `the CBOR registry <https://www.iana.org/assignments/cbor-tags/cbor-tags.xht
 The JSON encoding does not support sets.
 Sets MUST be represented as arrays in JSON-encoded messages.
 
-Another exception to this rule is for bytes.
+2. Bytes
+!!!!!!!!
+
 The CBOR encoding natively supports a bytes type while the JSON encoding does not.
 Bytes MUST be represented as strings giving the `Base64`_ representation of the original bytes value.
-
-Clients and servers MAY support additional request and response message body encodings.
 
 HTTP Design
 ~~~~~~~~~~~

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -244,9 +244,9 @@ When Bob's client issues HTTP requests to Alice's storage node it includes the *
 .. note::
 
    Foolscap TubIDs are 20 bytes (SHA1 digest of the certificate).
-   They are encoded with Base32 for a length of 32 bytes.
+   They are encoded with `Base32_` for a length of 32 bytes.
    SPKI information discussed here is 32 bytes (SHA256 digest).
-   They would be encoded in Base32 for a length of 52 bytes.
+   They would be encoded in `Base32`_ for a length of 52 bytes.
    `unpadded base64url`_ provides a more compact encoding of the information while remaining URL-compatible.
    This would encode the SPKI information for a length of merely 43 bytes.
    SHA1,
@@ -335,6 +335,100 @@ storage indexes
 and shares.
 A particular resource is addressed by the HTTP request path.
 Details about the interface are encoded in the HTTP message body.
+
+String Encoding
+~~~~~~~~~~~~~~~
+
+.. _Base32:
+
+Where the specification refers to Base32 the meaning is *unpadded* Base32 encoding as specified by `RFC 4648`_ using a *lowercase variation* of the alphabet from Section 6.
+
+That is, the alphabet is:
+
+.. list-table:: Base32 Alphabet
+		:header-rows: 1
+
+   * - Value
+     - Encoding
+     - Value
+     - Encoding
+     - Value
+     - Encoding
+     - Value
+     - Encoding
+
+   * - 0
+     - a
+     - 9
+     - j
+     - 18
+     - s
+     - 27
+     - 3
+   * - 1
+     - b
+     - 10
+     - k
+     - 19
+     - t
+     - 28
+     - 4
+   * - 2
+     - c
+     - 11
+     - l
+     - 20
+     - u
+     - 29
+     - 5
+   * - 3
+     - d
+     - 12
+     - m
+     - 21
+     - v
+     - 30
+     - 6
+   * - 4
+     - e
+     - 13
+     - n
+     - 22
+     - w
+     - 31
+     - 7
+   * - 5
+     - f
+     - 14
+     - o
+     - 23
+     - x
+     -
+     -
+   * - 6
+     - g
+     - 15
+     - p
+     - 24
+     - y
+     -
+     -
+   * - 7
+     - h
+     - 16
+     - q
+     - 25
+     - z
+     -
+     -
+   * - 8
+     - i
+     - 17
+     - r
+     - 26
+     - 2
+     -
+     -
 
 Message Encoding
 ~~~~~~~~~~~~~~~~
@@ -1057,8 +1151,6 @@ otherwise it will read a byte which won't match `b""`::
      204 NO CONTENT
 
 .. _Base64: https://www.rfc-editor.org/rfc/rfc4648#section-4
-
-.. _Base32: https://www.rfc-editor.org/rfc/rfc4648#section-6
 
 .. _RFC 4648: https://tools.ietf.org/html/rfc4648
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -244,7 +244,7 @@ When Bob's client issues HTTP requests to Alice's storage node it includes the *
 .. note::
 
    Foolscap TubIDs are 20 bytes (SHA1 digest of the certificate).
-   They are encoded with `Base32_` for a length of 32 bytes.
+   They are encoded with `Base32`_ for a length of 32 bytes.
    SPKI information discussed here is 32 bytes (SHA256 digest).
    They would be encoded in `Base32`_ for a length of 52 bytes.
    `unpadded base64url`_ provides a more compact encoding of the information while remaining URL-compatible.

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -341,6 +341,9 @@ String Encoding
 
 .. _Base32:
 
+Base32
+!!!!!!
+
 Where the specification refers to Base32 the meaning is *unpadded* Base32 encoding as specified by `RFC 4648`_ using a *lowercase variation* of the alphabet from Section 6.
 
 That is, the alphabet is:

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -560,6 +560,7 @@ For fields that are more general than a single API the semantics are as follows:
 
 * available-space:
   The server SHOULD use this field to advertise the amount of space that it currently considers unused and is willing to allocate for client requests.
+  The value is a number of bytes.
 
 
 ``PUT /storage/v1/lease/:storage_index``

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -950,8 +950,17 @@ For example::
       }
   }
 
-A server MUST return nothing for any bytes beyond the end of existing data for a test vector or read vector that reads tries to read such data.
-As a result, if there is no data at all, an empty bytestring is returned no matter what the offset or length.
+A client MAY send a test vector or read vector to bytes beyond the end of existing data.
+In this case a server MUST behave as if the test or read vector referred to exactly as much data exists.
+
+For example,
+consider the case where the server has 5 bytes of data for a particular share.
+If a client sends a read vector with an ``offset`` of 1 and a ``size`` of 4 then the server MUST respond with all of the data except the first byte.
+If a client sends a read vector with the same ``offset`` and a ``size`` of 5 (or any larger value) then the server MUST respond in the same way.
+
+Similarly,
+if there is no data at all,
+an empty byte string is returned no matter what the offset or length.
 
 Reading
 ~~~~~~~

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -346,7 +346,7 @@ Where the specification refers to Base32 the meaning is *unpadded* Base32 encodi
 That is, the alphabet is:
 
 .. list-table:: Base32 Alphabet
-		:header-rows: 1
+   :header-rows: 1
 
    * - Value
      - Encoding

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -436,6 +436,7 @@ Encoding
 ~~~~~~~~
 
 * ``storage_index`` MUST be `Base32`_ encoded in URLs.
+* ``share_number`` MUST be a decimal representation
 
 General
 ~~~~~~~

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -391,7 +391,7 @@ Clients and servers MUST use the ``Authorization`` header field,
 as specified in `RFC 9110`_,
 for authorization of all requests to all endpoints specified here.
 The authentication *type* MUST be ``Tahoe-LAFS``.
-Clients MUST present the swissnum from the NURL used to locate the storage service as the *credentials*.
+Clients MUST present the `Base64`_-encoded representation of the swissnum from the NURL used to locate the storage service as the *credentials*.
 
 If credentials are not presented or the swissnum is not associated with a storage service then the server MUST issue a ``401 UNAUTHORIZED`` response and perform no other processing of the message.
 

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -194,7 +194,7 @@ An HTTP-based protocol, dubbed "Great Black Swamp" (or "GBS"), is described belo
 This protocol aims to satisfy the above requirements at a lower level of complexity than the current Foolscap-based protocol.
 
 Summary (Non-normative)
-!!!!!!!!!!!!!!!!!!!!!!!
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Communication with the storage node will take place using TLS.
 The TLS version and configuration will be dictated by an ongoing understanding of best practices.

--- a/docs/proposed/http-storage-node-protocol.rst
+++ b/docs/proposed/http-storage-node-protocol.rst
@@ -692,7 +692,7 @@ It also includes potentially important details about the share.
 The request body MUST validate against this CDDL schema::
 
   {
-    reason: tstr
+    reason: tstr .size (1..32765)
   }
 
 For example::
@@ -703,6 +703,11 @@ The report pertains to the immutable share with a **storage index** and **share 
 If the identified **storage index** and **share number** are known to the server then the response SHOULD be accepted and made available to server administrators.
 In this case the response SHOULD be ``OK``.
 If the response is not accepted then the response SHOULD be ``Not Found`` (404).
+
+Discussion
+``````````
+
+The seemingly odd length limit on ``reason`` is chosen so that the *encoded* representation of the message is limited to 32768.
 
 Reading
 ~~~~~~~

--- a/src/allmydata/storage/http_common.py
+++ b/src/allmydata/storage/http_common.py
@@ -28,7 +28,7 @@ def get_content_type(headers: Headers) -> Optional[str]:
 
 
 def swissnum_auth_header(swissnum: bytes) -> bytes:
-    """Return value for ``Authentication`` header."""
+    """Return value for ``Authorization`` header."""
     return b"Tahoe-LAFS " + b64encode(swissnum).strip()
 
 

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -592,7 +592,26 @@ class HTTPServer(object):
     @_authorized_route(_app, set(), "/storage/v1/version", methods=["GET"])
     def version(self, request, authorization):
         """Return version information."""
-        return self._send_encoded(request, self._storage_server.get_version())
+        return self._send_encoded(request, self._get_version())
+
+    def _get_version(self) -> dict[str, Any]:
+        """
+        Get the HTTP version of the storage server's version response.
+
+        This differs from the Foolscap version by omitting certain obsolete
+        fields.
+        """
+        v = self._storage_server.get_version()
+        v1_identifier = b"http://allmydata.org/tahoe/protocols/storage/v1"
+        v1 = v[v1_identifier]
+        return {
+            v1_identifier: {
+                b"maximum-immutable-share-size": v1[b"maximum-immutable-share-size"],
+                b"maximum-mutable-share-size": v1[b"maximum-mutable-share-size"],
+                b"available-space": v1[b"available-space"],
+            },
+            b"application-version": v[b"application-version"],
+        }
 
     ##### Immutable APIs #####
 

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -594,7 +594,7 @@ class HTTPServer(object):
         """Return version information."""
         return self._send_encoded(request, self._get_version())
 
-    def _get_version(self) -> dict[str, Any]:
+    def _get_version(self) -> dict[bytes, Any]:
         """
         Get the HTTP version of the storage server's version response.
 

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -273,7 +273,7 @@ _SCHEMAS = {
     "advise_corrupt_share": Schema(
         """
     request = {
-      reason: tstr
+      reason: tstr .size (1..32765)
     }
     """
     ),


### PR DESCRIPTION
https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3986

I went a little beyond the scope of the ticket.

* Adopt RFC 2119 terms (MUST, MAY, etc)
* Formalize some language
* Clarify that we use the unpadded variation of the URL-safe variation of Base64 in some places.
* Add the definition of our Base32 alphabet since it *is not* the alphabet from the RFC
* Clarify which secrets are required by which endpoints
* Clarify encoding of some parameters placed in endpoints
* Add inline CDDL for endpoint inputs/outputs
* *Remove* some fields from the GBS server's version response (all GBS servers ever will behave in just one way with respect to these)
