### PR TITLE
Make the client respect the force_foolscap flag

### DIFF
--- a/integration/util.py
+++ b/integration/util.py
@@ -367,6 +367,12 @@ def _create_node(reactor, request, temp_dir, introducer_furl, flog_gatherer, nam
                 'force_foolscap',
                 str(force_foolscap),
             )
+            set_config(
+                config,
+                'client',
+                'force_foolscap',
+                str(force_foolscap),
+            )
             write_config(FilePath(config_path), config)
         created_d.addCallback(created)
 

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -60,7 +60,7 @@ from allmydata.interfaces import (
 )
 from allmydata.nodemaker import NodeMaker
 from allmydata.blacklist import Blacklist
-
+from allmydata.node import _Config
 
 KiB=1024
 MiB=1024*KiB

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -94,6 +94,7 @@ _client_config = configutil.ValidConfiguration(
             "shares.total",
             "shares._max_immutable_segment_size_for_testing",
             "storage.plugins",
+            "force_foolscap",
         ),
         "storage": (
             "debug_discard",

--- a/src/allmydata/client.py
+++ b/src/allmydata/client.py
@@ -466,7 +466,7 @@ def create_introducer_clients(config, main_tub, _introducer_factory=None):
     return introducer_clients
 
 
-def create_storage_farm_broker(config, default_connection_handlers, foolscap_connection_handlers, tub_options, introducer_clients):
+def create_storage_farm_broker(config: _Config, default_connection_handlers, foolscap_connection_handlers, tub_options, introducer_clients):
     """
     Create a StorageFarmBroker object, for use by Uploader/Downloader
     (and everybody else who wants to use storage servers)

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from six import ensure_text
 
-from typing import Union
+from typing import Union, Any
 from os import urandom
 import re
 import time
@@ -219,9 +219,9 @@ class StorageFarmBroker(service.MultiService):
         # own Reconnector, and will give us a RemoteReference when we ask
         # them for it.
         self.servers = BytesKeyDict()
-        self._static_server_ids = set() # ignore announcements for these
+        self._static_server_ids : set[bytes] = set() # ignore announcements for these
         self.introducer_client = None
-        self._threshold_listeners = [] # tuples of (threshold, Deferred)
+        self._threshold_listeners : list[tuple[float,defer.Deferred[Any]]]= [] # tuples of (threshold, Deferred)
         self._connected_high_water_mark = 0
 
     @log_call(action_type=u"storage-client:broker:set-static-servers")

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -299,7 +299,9 @@ class StorageFarmBroker(service.MultiService):
             "pub-{}".format(str(server_id, "ascii")),  # server_id is v0-<key> not pub-v0-key .. for reasons?
         )
 
-        if len(server["ann"].get(ANONYMOUS_STORAGE_NURLS, [])) > 0:
+        if not self.node_config.get_config(
+                "storage", "force_foolscap", default=True, boolean=True,
+        ) and len(server["ann"].get(ANONYMOUS_STORAGE_NURLS, [])) > 0:
             s = HTTPNativeStorageServer(
                 server_id,
                 server["ann"],

--- a/src/allmydata/storage_client.py
+++ b/src/allmydata/storage_client.py
@@ -300,7 +300,7 @@ class StorageFarmBroker(service.MultiService):
         )
 
         if not self.node_config.get_config(
-                "storage", "force_foolscap", default=True, boolean=True,
+                "client", "force_foolscap", default=True, boolean=True,
         ) and len(server["ann"].get(ANONYMOUS_STORAGE_NURLS, [])) > 0:
             s = HTTPNativeStorageServer(
                 server_id,

--- a/src/allmydata/test/common_system.py
+++ b/src/allmydata/test/common_system.py
@@ -871,6 +871,7 @@ class SystemTestMixin(pollmixin.PollMixin, testutil.StallMixin):
 
         setnode("nickname", u"client %d \N{BLACK SMILING FACE}" % (which,))
         setconf(config, which, "storage", "force_foolscap", str(force_foolscap))
+        setconf(config, which, "client", "force_foolscap", str(force_foolscap))
 
         tub_location_hint, tub_port_endpoint = self.port_assigner.assign(reactor)
         setnode("tub.port", tub_port_endpoint)


### PR DESCRIPTION
For now HTTP is disabled by default client-side.

Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3936