### PR TITLE
Add timeout to the blocking http client

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -4,6 +4,7 @@ Ported to Python 3.
 
 from __future__ import annotations
 
+import os
 import sys
 import shutil
 from time import sleep
@@ -47,6 +48,11 @@ from .util import (
     generate_ssh_key,
     block_with_timeout,
 )
+
+
+# No reason for HTTP requests to take longer than two minutes in the
+# integration tests. See allmydata/scripts/common_http.py for usage.
+os.environ["__TAHOE_CLI_HTTP_TIMEOUT"] = "120"
 
 
 # pytest customization hooks

--- a/newsfragments/4012.bugfix
+++ b/newsfragments/4012.bugfix
@@ -1,0 +1,1 @@
+The command-line tools now have a 60-second timeout on individual network reads/writes/connects; previously they could block forever in some situations.

--- a/newsfragments/4012.bugfix
+++ b/newsfragments/4012.bugfix
@@ -1,1 +1,0 @@
-The command-line tools now have a 300-second timeout on individual network reads/writes/connects; previously they could block forever in some situations.

--- a/newsfragments/4012.bugfix
+++ b/newsfragments/4012.bugfix
@@ -1,1 +1,1 @@
-The command-line tools now have a 60-second timeout on individual network reads/writes/connects; previously they could block forever in some situations.
+The command-line tools now have a 300-second timeout on individual network reads/writes/connects; previously they could block forever in some situations.

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -1,18 +1,11 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-from future.utils import PY2
-if PY2:
-    from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401
 
 import os
 from io import BytesIO
-from six.moves import urllib, http_client
+from http import client as http_client
+import urllib
 import six
 import allmydata # for __full_version__
 

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -62,9 +62,9 @@ def do_http(method, url, body=b""):
         assert body.read
     scheme, host, port, path = parse_url(url)
     if scheme == "http":
-        c = http_client.HTTPConnection(host, port)
+        c = http_client.HTTPConnection(host, port, timeout=60)
     elif scheme == "https":
-        c = http_client.HTTPSConnection(host, port)
+        c = http_client.HTTPSConnection(host, port, timeout=60)
     else:
         raise ValueError("unknown scheme '%s', need http or https" % scheme)
     c.putrequest(method, path)

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -53,10 +53,17 @@ def do_http(method, url, body=b""):
         assert body.seek
         assert body.read
     scheme, host, port, path = parse_url(url)
+
+    # For testing purposes, allow setting a timeout on HTTP requests. If this
+    # ever become a user-facing feature, this should probably be a CLI option?
+    timeout = os.environ.get("__TAHOE_CLI_HTTP_TIMEOUT", None)
+    if timeout is not None:
+        timeout = float(timeout)
+
     if scheme == "http":
-        c = http_client.HTTPConnection(host, port, timeout=300, blocksize=65536)
+        c = http_client.HTTPConnection(host, port, timeout=timeout, blocksize=65536)
     elif scheme == "https":
-        c = http_client.HTTPSConnection(host, port, timeout=300, blocksize=65536)
+        c = http_client.HTTPSConnection(host, port, timeout=timeout, blocksize=65536)
     else:
         raise ValueError("unknown scheme '%s', need http or https" % scheme)
     c.putrequest(method, path)

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -55,9 +55,9 @@ def do_http(method, url, body=b""):
         assert body.read
     scheme, host, port, path = parse_url(url)
     if scheme == "http":
-        c = http_client.HTTPConnection(host, port, timeout=60)
+        c = http_client.HTTPConnection(host, port, timeout=60, blocksize=65536)
     elif scheme == "https":
-        c = http_client.HTTPSConnection(host, port, timeout=60)
+        c = http_client.HTTPSConnection(host, port, timeout=60, blocksize=65536)
     else:
         raise ValueError("unknown scheme '%s', need http or https" % scheme)
     c.putrequest(method, path)
@@ -78,7 +78,7 @@ def do_http(method, url, body=b""):
         return BadResponse(url, err)
 
     while True:
-        data = body.read(8192)
+        data = body.read(65536)
         if not data:
             break
         c.send(data)

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -54,9 +54,9 @@ def do_http(method, url, body=b""):
         assert body.read
     scheme, host, port, path = parse_url(url)
     if scheme == "http":
-        c = http_client.HTTPConnection(host, port, timeout=60, blocksize=65536)
+        c = http_client.HTTPConnection(host, port, timeout=300, blocksize=65536)
     elif scheme == "https":
-        c = http_client.HTTPSConnection(host, port, timeout=60, blocksize=65536)
+        c = http_client.HTTPSConnection(host, port, timeout=300, blocksize=65536)
     else:
         raise ValueError("unknown scheme '%s', need http or https" % scheme)
     c.putrequest(method, path)

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -92,7 +92,7 @@ def format_http_success(resp):
 
 def format_http_error(msg, resp):
     return quote_output(
-        "%s: %s %s\n%s" % (msg, resp.status, resp.reason,
+        "%s: %s %s\n%r" % (msg, resp.status, resp.reason,
                            resp.read()),
         quotemarks=False)
 

--- a/src/allmydata/scripts/common_http.py
+++ b/src/allmydata/scripts/common_http.py
@@ -1,12 +1,11 @@
 """
-Ported to Python 3.
+Blocking HTTP client APIs.
 """
 
 import os
 from io import BytesIO
 from http import client as http_client
 import urllib
-import six
 import allmydata # for __full_version__
 
 from allmydata.util.encodingutil import quote_output
@@ -44,7 +43,7 @@ class BadResponse(object):
 def do_http(method, url, body=b""):
     if isinstance(body, bytes):
         body = BytesIO(body)
-    elif isinstance(body, six.text_type):
+    elif isinstance(body, str):
         raise TypeError("do_http body must be a bytestring, not unicode")
     else:
         # We must give a Content-Length header to twisted.web, otherwise it
@@ -87,16 +86,14 @@ def do_http(method, url, body=b""):
 
 
 def format_http_success(resp):
-    # ensure_text() shouldn't be necessary when Python 2 is dropped.
     return quote_output(
-        "%s %s" % (resp.status, six.ensure_text(resp.reason)),
+        "%s %s" % (resp.status, resp.reason),
         quotemarks=False)
 
 def format_http_error(msg, resp):
-    # ensure_text() shouldn't be necessary when Python 2 is dropped.
     return quote_output(
-        "%s: %s %s\n%s" % (msg, resp.status, six.ensure_text(resp.reason),
-                           six.ensure_text(resp.read())),
+        "%s: %s %s\n%s" % (msg, resp.status, resp.reason,
+                           resp.read()),
         quotemarks=False)
 
 def check_http_error(resp, stderr):


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4012

* Add a timeout!!!
* Increase block size to be less teensy; might give a speed boost.
* Modernizations while I'm at it.

My hope this will make the macOS CI failures result in a failure, rather than freezing and running until they get killed by the overall CI timeout.