### PR TITLE
suppress the new click mypy errors

### DIFF
--- a/src/allmydata/cli/grid_manager.py
+++ b/src/allmydata/cli/grid_manager.py
@@ -28,7 +28,7 @@ from allmydata.grid_manager import (
 from allmydata.util import jsonbytes as json
 
 
-@click.group()
+@click.group() # type: ignore[arg-type]
 @click.option(
     '--config', '-c',
     type=click.Path(),
@@ -71,7 +71,7 @@ def grid_manager(ctx, config):
     ctx.obj = Config()
 
 
-@grid_manager.command()
+@grid_manager.command() # type: ignore[attr-defined]
 @click.pass_context
 def create(ctx):
     """
@@ -91,7 +91,7 @@ def create(ctx):
         )
 
 
-@grid_manager.command()
+@grid_manager.command() # type: ignore[attr-defined]
 @click.pass_obj
 def public_identity(config):
     """
@@ -103,7 +103,7 @@ def public_identity(config):
     click.echo(config.grid_manager.public_identity())
 
 
-@grid_manager.command()
+@grid_manager.command() # type: ignore[arg-type, attr-defined]
 @click.argument("name")
 @click.argument("public_key", type=click.STRING)
 @click.pass_context
@@ -132,7 +132,7 @@ def add(ctx, name, public_key):
     return 0
 
 
-@grid_manager.command()
+@grid_manager.command() # type: ignore[arg-type, attr-defined]
 @click.argument("name")
 @click.pass_context
 def remove(ctx, name):
@@ -155,7 +155,8 @@ def remove(ctx, name):
     save_grid_manager(fp, ctx.obj.grid_manager, create=False)
 
 
-@grid_manager.command()  # noqa: F811
+@grid_manager.command() # type: ignore[attr-defined]
+                        # noqa: F811
 @click.pass_context
 def list(ctx):
     """
@@ -175,7 +176,7 @@ def list(ctx):
                 click.echo("expired {} ({})".format(cert.expires, abbreviate_time(delta)))
 
 
-@grid_manager.command()
+@grid_manager.command() # type: ignore[arg-type, attr-defined]
 @click.argument("name")
 @click.argument(
     "expiry_days",

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,9 @@ deps =
      # Pin a specific version so we get consistent outcomes; update this
      # occasionally:
      ruff == 0.0.263
+     # towncrier doesn't work with importlib_resources 6.0.0
+     # https://github.com/twisted/towncrier/issues/528
+     importlib_resources < 6.0.0
      towncrier
 # On macOS, git inside of towncrier needs $HOME.
 passenv = HOME


### PR DESCRIPTION
See https://github.com/pallets/click/issues/2558

Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4045

Also, as a freebie, this has a fix for https://github.com/twisted/towncrier/issues/528
