### PR TITLE
Disable C version of cbor2 loading

### DIFF
--- a/newsfragments/4088.bugfix
+++ b/newsfragments/4088.bugfix
@@ -1,0 +1,1 @@
+Stop using the C version of the cbor2 decoder.

--- a/nix/pycddl.nix
+++ b/nix/pycddl.nix
@@ -30,12 +30,12 @@
 { lib, fetchPypi, python, buildPythonPackage, rustPlatform }:
 buildPythonPackage rec {
   pname = "pycddl";
-  version = "0.4.0";
+  version = "0.6.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-w0CGbPeiXyS74HqZXyiXhvaAMUaIj5onwjl9gWKAjqY=";
+    sha256 = "sha256-kmXXJAHkP4Wltp01Os5DPlygEI7nxd0FdaFqdD43X3g=";
   };
 
   # Without this, when building for PyPy, `maturin build` seems to fail to
@@ -52,6 +52,6 @@ buildPythonPackage rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-g96eeaqN9taPED4u+UKUcoitf5aTGFrW2/TOHoHEVHs=";
+    hash = "sha256-PjAcAf7T03hKmBhDlXJdkwCkiGNfzc1ajukhf+tFpMo=";
   };
 }

--- a/nix/pycddl.nix
+++ b/nix/pycddl.nix
@@ -30,12 +30,12 @@
 { lib, fetchPypi, python, buildPythonPackage, rustPlatform }:
 buildPythonPackage rec {
   pname = "pycddl";
-  version = "0.6.0";
+  version = "0.6.1";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-kmXXJAHkP4Wltp01Os5DPlygEI7nxd0FdaFqdD43X3g=";
+    sha256 = "sha256-63fe8UJXEH6t4l7ujV8JDvlGb7q3kL6fHHATFdklzFc=";
   };
 
   # Without this, when building for PyPy, `maturin build` seems to fail to
@@ -52,6 +52,6 @@ buildPythonPackage rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-PjAcAf7T03hKmBhDlXJdkwCkiGNfzc1ajukhf+tFpMo=";
+    hash = "sha256-ssDEKRd3Y9/10oXBZHCxvlRkl9KMh3pGYbCkM4rXThQ=";
   };
 }

--- a/setup.py
+++ b/setup.py
@@ -146,9 +146,8 @@ install_requires = [
     # 5.6.0 excluded because https://github.com/agronholm/cbor2/issues/208
     "cbor2 != 5.6.0",
 
-    # 0.4 adds the ability to pass in mmap() values which greatly reduces the
-    # amount of copying involved.
-    "pycddl >= 0.4",
+    # 0.6 adds the ability to decode CBOR.
+    "pycddl >= 0.6",
 
     # Command-line parsing
     "click >= 8.1.1",

--- a/setup.py
+++ b/setup.py
@@ -146,8 +146,8 @@ install_requires = [
     # 5.6.0 excluded because https://github.com/agronholm/cbor2/issues/208
     "cbor2 != 5.6.0",
 
-    # 0.6 adds the ability to decode CBOR.
-    "pycddl >= 0.6",
+    # 0.6 adds the ability to decode CBOR. 0.6.1 fixes PyPy.
+    "pycddl >= 0.6.1",
 
     # Command-line parsing
     "click >= 8.1.1",

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -63,7 +63,7 @@ from ..util.hashutil import timing_safe_compare
 from ..util.deferredutil import async_to_deferred
 from ..util.tor_provider import _Provider as TorProvider
 from ..util.cputhreadpool import defer_to_thread
-from ..util.cbor import dumps, loads
+from ..util.cbor import dumps
 
 try:
     from txtorcon import Tor  # type: ignore
@@ -560,8 +560,7 @@ class StorageClient(object):
                     data = f.read()
 
                     def validate_and_decode():
-                        schema.validate_cbor(data)
-                        return loads(data)
+                        return schema.validate_cbor(data, True)
 
                     return await defer_to_thread(validate_and_decode)
                 else:

--- a/src/allmydata/storage/http_client.py
+++ b/src/allmydata/storage/http_client.py
@@ -26,8 +26,6 @@ from attrs import define, asdict, frozen, field
 from eliot import start_action, register_exception_extractor
 from eliot.twisted import DeferredContext
 
-# TODO Make sure to import Python version?
-from cbor2 import loads, dumps
 from pycddl import Schema
 from collections_extended import RangeMap
 from werkzeug.datastructures import Range, ContentRange
@@ -65,6 +63,7 @@ from ..util.hashutil import timing_safe_compare
 from ..util.deferredutil import async_to_deferred
 from ..util.tor_provider import _Provider as TorProvider
 from ..util.cputhreadpool import defer_to_thread
+from ..util.cbor import dumps, loads
 
 try:
     from txtorcon import Tor  # type: ignore

--- a/src/allmydata/storage/http_server.py
+++ b/src/allmydata/storage/http_server.py
@@ -57,8 +57,6 @@ from hyperlink import DecodedURL
 from cryptography.x509 import load_pem_x509_certificate
 
 
-# TODO Make sure to use pure Python versions?
-import cbor2
 from pycddl import Schema, ValidationError as CDDLValidationError
 from .server import StorageServer
 from .http_common import (
@@ -75,7 +73,8 @@ from ..util.hashutil import timing_safe_compare
 from ..util.base32 import rfc3548_alphabet
 from ..util.deferredutil import async_to_deferred
 from ..util.cputhreadpool import defer_to_thread
-from allmydata.interfaces import BadWriteEnablerError
+from ..util import cbor
+from ..interfaces import BadWriteEnablerError
 
 
 class ClientSecretsException(Exception):
@@ -647,7 +646,7 @@ async def read_encoded(
     # Typically deserialization to Python will not release the GIL, and
     # indeed as of Jan 2023 cbor2 didn't have any code to release the GIL
     # in the decode path. As such, running it in a different thread has no benefit.
-    return cbor2.load(request.content)
+    return cbor.load(request.content)
 
 
 class HTTPServer(BaseApp):
@@ -695,7 +694,7 @@ class HTTPServer(BaseApp):
         if accept.best == CBOR_MIME_TYPE:
             request.setHeader("Content-Type", CBOR_MIME_TYPE)
             f = TemporaryFile()
-            cbor2.dump(data, f)  # type: ignore
+            cbor.dump(data, f)  # type: ignore
 
             def read_data(offset: int, length: int) -> bytes:
                 f.seek(offset)

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -24,7 +24,6 @@ from contextlib import contextmanager
 from os import urandom
 from typing import Union, Callable, Tuple, Iterable
 from queue import Queue
-from cbor2 import dumps
 from pycddl import ValidationError as CDDLValidationError
 from hypothesis import assume, given, strategies as st, settings as hypothesis_settings
 from fixtures import Fixture, TempDir, MonkeyPatch
@@ -41,8 +40,8 @@ from werkzeug import routing
 from werkzeug.exceptions import NotFound as WNotFound
 from testtools.matchers import Equals
 from zope.interface import implementer
-import cbor2
 
+from ..util.cbor import dumps, loads
 from ..util.deferredutil import async_to_deferred
 from ..util.cputhreadpool import disable_thread_pool_for_test
 from .common import SyncTestCase
@@ -1845,5 +1844,5 @@ class MutableSharedTests(SharedImmutableMutableTestsMixin, SyncTestCase):
         for size in range(0, 65535*2, 17):
             self.assertEqual(
                 size,
-                len(cbor2.loads(cbor2.dumps(b"\12" * size)))
+                len(loads(dumps(b"\12" * size)))
             )

--- a/src/allmydata/test/test_storage_http.py
+++ b/src/allmydata/test/test_storage_http.py
@@ -41,7 +41,7 @@ from werkzeug.exceptions import NotFound as WNotFound
 from testtools.matchers import Equals
 from zope.interface import implementer
 
-from ..util.cbor import dumps, loads
+from ..util.cbor import dumps
 from ..util.deferredutil import async_to_deferred
 from ..util.cputhreadpool import disable_thread_pool_for_test
 from .common import SyncTestCase
@@ -1835,14 +1835,3 @@ class MutableSharedTests(SharedImmutableMutableTestsMixin, SyncTestCase):
         A read with no range returns the whole mutable.
         """
         return self._read_with_no_range_test(data_length)
-
-    def test_roundtrip_cbor2_encoding_issue(self):
-        """
-        Some versions of cbor2 (5.6.0) don't correctly encode bytestrings
-        bigger than 65535
-        """
-        for size in range(0, 65535*2, 17):
-            self.assertEqual(
-                size,
-                len(loads(dumps(b"\12" * size)))
-            )

--- a/src/allmydata/util/cbor.py
+++ b/src/allmydata/util/cbor.py
@@ -1,21 +1,19 @@
 """
 Unified entry point for CBOR encoding and decoding.
-"""
 
-import sys
+Makes it less likely to use ``cbor2.loads()`` by mistake, which we want to avoid.
+"""
 
 # We don't want to use the C extension for loading, at least for now, but using
 # it for dumping should be fine.
 from cbor2 import dumps, dump
 
-# Now, override the C extension so we can import the Python versions of loading
-# functions.
-del sys.modules["cbor2"]
-sys.modules["_cbor2"] = None  # type: ignore[assignment]
-from cbor2 import load, loads
+def load(*args, **kwargs):
+    """
+    Don't use this!  Here just in case someone uses it by mistake.
+    """
+    raise RuntimeError("Use pycddl for decoding CBOR")
 
-# Quick validation that we got the Python version, not the C version.
-assert type(load) == type(lambda: None), repr(load)   # type: ignore[comparison-overlap]
-assert type(loads) == type(lambda: None), repr(loads)   # type: ignore[comparison-overlap]
+loads = load
 
 __all__ = ["dumps", "loads", "dump", "load"]

--- a/src/allmydata/util/cbor.py
+++ b/src/allmydata/util/cbor.py
@@ -1,0 +1,7 @@
+"""
+Unified entry point for CBOR encoding and decoding.
+"""
+
+from cbor2 import dumps, loads, dump, load
+
+__all__ = ["dumps", "loads", "dump", "load"]

--- a/src/allmydata/util/cbor.py
+++ b/src/allmydata/util/cbor.py
@@ -11,11 +11,11 @@ from cbor2 import dumps, dump
 # Now, override the C extension so we can import the Python versions of loading
 # functions.
 del sys.modules["cbor2"]
-sys.modules["_cbor2"] = None
+sys.modules["_cbor2"] = None  # type: ignore[assignment]
 from cbor2 import load, loads
 
 # Quick validation that we got the Python version, not the C version.
-assert type(load) == type(lambda: None), repr(load)
-assert type(loads) == type(lambda: None), repr(loads)
+assert type(load) == type(lambda: None), repr(load)   # type: ignore[comparison-overlap]
+assert type(loads) == type(lambda: None), repr(loads)   # type: ignore[comparison-overlap]
 
 __all__ = ["dumps", "loads", "dump", "load"]

--- a/src/allmydata/util/cbor.py
+++ b/src/allmydata/util/cbor.py
@@ -2,6 +2,20 @@
 Unified entry point for CBOR encoding and decoding.
 """
 
-from cbor2 import dumps, loads, dump, load
+import sys
+
+# We don't want to use the C extension for loading, at least for now, but using
+# it for dumping should be fine.
+from cbor2 import dumps, dump
+
+# Now, override the C extension so we can import the Python versions of loading
+# functions.
+del sys.modules["cbor2"]
+sys.modules["_cbor2"] = None
+from cbor2 import load, loads
+
+# Quick validation that we got the Python version, not the C version.
+assert type(load) == type(lambda: None), repr(load)
+assert type(loads) == type(lambda: None), repr(loads)
 
 __all__ = ["dumps", "loads", "dump", "load"]


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4088

**Update:** switched to Rust-based deserialization. I'm hoping to make it run faster, too, in an upcoming release (right now it needs to parse CBOR twice, but that's fixable).