### PR TITLE
remove old Python2 __future__ statements

### DIFF
--- a/integration/test_aaa_aardvark.py
+++ b/integration/test_aaa_aardvark.py
@@ -5,10 +5,6 @@
 # You can safely skip any of these tests, it'll just appear to "take
 # longer" to start the first test as the fixtures get built
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/integration/test_sftp.py
+++ b/integration/test_sftp.py
@@ -10,10 +10,6 @@ These tests use Paramiko, rather than Twisted's Conch, because:
     2. Its API is much simpler to use.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/integration/test_streaming_logs.py
+++ b/integration/test_streaming_logs.py
@@ -1,12 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import (
-    print_function,
-    unicode_literals,
-    absolute_import,
-    division,
-)
 
 from future.utils import PY2
 if PY2:

--- a/misc/awesome_weird_stuff/boodlegrid.tac
+++ b/misc/awesome_weird_stuff/boodlegrid.tac
@@ -1,6 +1,5 @@
 # -*- python -*-
 
-from __future__ import print_function
 
 """Monitor a Tahoe grid, by playing sounds in response to remote events.
 

--- a/misc/build_helpers/check-build.py
+++ b/misc/build_helpers/check-build.py
@@ -2,7 +2,6 @@
 
 # This helper script is used with the 'test-desert-island' Makefile target.
 
-from __future__ import print_function
 
 import sys
 

--- a/misc/build_helpers/gen-package-table.py
+++ b/misc/build_helpers/gen-package-table.py
@@ -2,7 +2,6 @@
 # This script generates a table of dependencies in HTML format on stdout.
 # It expects to be run in the tahoe-lafs-dep-eggs directory.
 
-from __future__ import print_function
 
 import re, os, sys
 import pkg_resources

--- a/misc/build_helpers/run-deprecations.py
+++ b/misc/build_helpers/run-deprecations.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import sys, os, io, re
 from twisted.internet import reactor, protocol, task, defer

--- a/misc/build_helpers/test-osx-pkg.py
+++ b/misc/build_helpers/test-osx-pkg.py
@@ -29,7 +29,6 @@
 # characteristic: 14.1.0 (/Applications/tahoe.app/support/lib/python2.7/site-packages)
 # pyasn1-modules: 0.0.5 (/Applications/tahoe.app/support/lib/python2.7/site-packages/pyasn1_modules-0.0.5-py2.7.egg)
 
-from __future__ import print_function
 
 import os, re, shutil, subprocess, sys, tempfile
 

--- a/misc/checkers/check_grid.py
+++ b/misc/checkers/check_grid.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 """
 Test an existing Tahoe grid, both to see if the grid is still running and to

--- a/misc/coding_tools/check-debugging.py
+++ b/misc/coding_tools/check-debugging.py
@@ -8,7 +8,6 @@ Runs on Python 3.
 Usage: ./check-debugging.py src
 """
 
-from __future__ import print_function
 
 import sys, re, os
 

--- a/misc/coding_tools/check-interfaces.py
+++ b/misc/coding_tools/check-interfaces.py
@@ -4,7 +4,6 @@
 #
 #   bin/tahoe @misc/coding_tools/check-interfaces.py
 
-from __future__ import print_function
 
 import os, sys, re, platform
 

--- a/misc/coding_tools/check-umids.py
+++ b/misc/coding_tools/check-umids.py
@@ -8,7 +8,6 @@ This runs on Python 3.
 
 # ./check-umids.py src
 
-from __future__ import print_function
 
 import sys, re, os
 

--- a/misc/coding_tools/graph-deps.py
+++ b/misc/coding_tools/graph-deps.py
@@ -21,7 +21,6 @@
 # Install 'click' first. I run this with py2, but py3 might work too, if the
 # wheels can be built with py3.
 
-from __future__ import unicode_literals, print_function
 import os, sys, subprocess, json, tempfile, zipfile, re, itertools
 import email.parser
 from pprint import pprint

--- a/misc/coding_tools/make-canary-files.py
+++ b/misc/coding_tools/make-canary-files.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 """
 Given a list of nodeids and a 'convergence' file, create a bunch of files

--- a/misc/coding_tools/make_umid
+++ b/misc/coding_tools/make_umid
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 """Create a short probably-unique string for use as a umid= argument in a
 Foolscap log() call, to make it easier to locate the source code that

--- a/misc/operations_helpers/cpu-watcher-poll.py
+++ b/misc/operations_helpers/cpu-watcher-poll.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 from foolscap import Tub, eventual
 from twisted.internet import reactor

--- a/misc/operations_helpers/cpu-watcher-subscribe.py
+++ b/misc/operations_helpers/cpu-watcher-subscribe.py
@@ -1,6 +1,5 @@
 # -*- python -*-
 
-from __future__ import print_function
 
 from twisted.internet import reactor
 import sys

--- a/misc/operations_helpers/cpu-watcher.tac
+++ b/misc/operations_helpers/cpu-watcher.tac
@@ -1,6 +1,5 @@
 # -*- python -*-
 
-from __future__ import print_function
 
 """
 # run this tool on a linux box in its own directory, with a file named

--- a/misc/operations_helpers/find-share-anomalies.py
+++ b/misc/operations_helpers/find-share-anomalies.py
@@ -2,7 +2,6 @@
 
 # feed this the results of 'tahoe catalog-shares' for all servers
 
-from __future__ import print_function
 
 import sys
 

--- a/misc/operations_helpers/munin/tahoe_cpu_watcher
+++ b/misc/operations_helpers/munin/tahoe_cpu_watcher
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import os, sys, re
 import urllib

--- a/misc/operations_helpers/munin/tahoe_diskleft
+++ b/misc/operations_helpers/munin/tahoe_diskleft
@@ -5,7 +5,6 @@
 # is left on all disks across the grid. The plugin should be configured with
 # env_url= pointing at the diskwatcher.tac webport.
 
-from __future__ import print_function
 
 import os, sys, urllib, json
 

--- a/misc/operations_helpers/munin/tahoe_disktotal
+++ b/misc/operations_helpers/munin/tahoe_disktotal
@@ -6,7 +6,6 @@
 # used. The plugin should be configured with env_url= pointing at the
 # diskwatcher.tac webport.
 
-from __future__ import print_function
 
 import os, sys, urllib, json
 

--- a/misc/operations_helpers/munin/tahoe_diskusage
+++ b/misc/operations_helpers/munin/tahoe_diskusage
@@ -5,7 +5,6 @@
 # is being used per unit time. The plugin should be configured with env_url=
 # pointing at the diskwatcher.tac webport.
 
-from __future__ import print_function
 
 import os, sys, urllib, json
 

--- a/misc/operations_helpers/munin/tahoe_diskused
+++ b/misc/operations_helpers/munin/tahoe_diskused
@@ -5,7 +5,6 @@
 # used on all disks across the grid. The plugin should be configured with
 # env_url= pointing at the diskwatcher.tac webport.
 
-from __future__ import print_function
 
 import os, sys, urllib, json
 

--- a/misc/operations_helpers/munin/tahoe_doomsday
+++ b/misc/operations_helpers/munin/tahoe_doomsday
@@ -5,7 +5,6 @@
 # left before the grid fills up. The plugin should be configured with
 # env_url= pointing at the diskwatcher.tac webport.
 
-from __future__ import print_function
 
 import os, sys, urllib, json
 

--- a/misc/operations_helpers/munin/tahoe_estimate_files
+++ b/misc/operations_helpers/munin/tahoe_estimate_files
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import sys, os.path
 

--- a/misc/operations_helpers/munin/tahoe_files
+++ b/misc/operations_helpers/munin/tahoe_files
@@ -18,7 +18,6 @@
 #  env.basedir_NODE3 /path/to/node3
 #
 
-from __future__ import print_function
 
 import os, sys
 

--- a/misc/operations_helpers/munin/tahoe_helperstats_active
+++ b/misc/operations_helpers/munin/tahoe_helperstats_active
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import os, sys
 import urllib

--- a/misc/operations_helpers/munin/tahoe_helperstats_fetched
+++ b/misc/operations_helpers/munin/tahoe_helperstats_fetched
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import os, sys
 import urllib

--- a/misc/operations_helpers/munin/tahoe_introstats
+++ b/misc/operations_helpers/munin/tahoe_introstats
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import os, sys
 import urllib

--- a/misc/operations_helpers/munin/tahoe_nodememory
+++ b/misc/operations_helpers/munin/tahoe_nodememory
@@ -4,7 +4,6 @@
 # by 'allmydata start', then extracts the amount of memory they consume (both
 # VmSize and VmRSS) from /proc
 
-from __future__ import print_function
 
 import os, sys, re
 

--- a/misc/operations_helpers/munin/tahoe_overhead
+++ b/misc/operations_helpers/munin/tahoe_overhead
@@ -27,7 +27,6 @@
 # This plugin should be configured with env_diskwatcher_url= pointing at the
 # diskwatcher.tac webport, and env_deepsize_url= pointing at the PHP script.
 
-from __future__ import print_function
 
 import os, sys, urllib, json
 

--- a/misc/operations_helpers/munin/tahoe_rootdir_space
+++ b/misc/operations_helpers/munin/tahoe_rootdir_space
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import os, sys
 import urllib

--- a/misc/operations_helpers/munin/tahoe_server_latency_
+++ b/misc/operations_helpers/munin/tahoe_server_latency_
@@ -42,7 +42,6 @@
 # of course, these URLs must match the webports you have configured into the
 # storage nodes.
 
-from __future__ import print_function
 
 import os, sys
 import urllib

--- a/misc/operations_helpers/munin/tahoe_server_operations_
+++ b/misc/operations_helpers/munin/tahoe_server_operations_
@@ -32,7 +32,6 @@
 # of course, these URLs must match the webports you have configured into the
 # storage nodes.
 
-from __future__ import print_function
 
 import os, sys
 import urllib

--- a/misc/operations_helpers/munin/tahoe_spacetime
+++ b/misc/operations_helpers/munin/tahoe_spacetime
@@ -5,7 +5,6 @@
 # then extrapolate to guess how many weeks/months/years of storage space we
 # have left, and output it to another munin graph
 
-from __future__ import print_function
 
 import sys, os, time
 import rrdtool

--- a/misc/operations_helpers/munin/tahoe_stats
+++ b/misc/operations_helpers/munin/tahoe_stats
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import os
 import json

--- a/misc/operations_helpers/munin/tahoe_storagespace
+++ b/misc/operations_helpers/munin/tahoe_storagespace
@@ -18,7 +18,6 @@
 # Allmydata-tahoe must be installed on the system where this plugin is used,
 # since it imports a utility module from allmydata.utils .
 
-from __future__ import print_function
 
 import os, sys
 import commands

--- a/misc/operations_helpers/provisioning/reliability.py
+++ b/misc/operations_helpers/provisioning/reliability.py
@@ -1,6 +1,5 @@
 #! /usr/bin/python
 
-from __future__ import print_function
 
 import math
 from allmydata.util import statistics

--- a/misc/operations_helpers/provisioning/test_provisioning.py
+++ b/misc/operations_helpers/provisioning/test_provisioning.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import unittest
 from allmydata import provisioning

--- a/misc/operations_helpers/spacetime/diskwatcher.tac
+++ b/misc/operations_helpers/spacetime/diskwatcher.tac
@@ -1,6 +1,5 @@
 # -*- python -*-
 
-from __future__ import print_function
 
 """
 Run this tool with twistd in its own directory, with a file named 'urls.txt'

--- a/misc/simulators/bench_spans.py
+++ b/misc/simulators/bench_spans.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 """
 To use this, get a trace file such as this one:

--- a/misc/simulators/count_dirs.py
+++ b/misc/simulators/count_dirs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 """
 This tool estimates how much space would be consumed by a filetree into which

--- a/misc/simulators/hashbasedsig.py
+++ b/misc/simulators/hashbasedsig.py
@@ -1,6 +1,5 @@
 #!python
 
-from __future__ import print_function
 
 # range of hash output lengths
 range_L_hash = [128]

--- a/misc/simulators/ringsim.py
+++ b/misc/simulators/ringsim.py
@@ -4,7 +4,6 @@
 
 # import time
 
-from __future__ import print_function
 
 import math
 from hashlib import md5  # sha1, sha256

--- a/misc/simulators/simulate_load.py
+++ b/misc/simulators/simulate_load.py
@@ -2,7 +2,6 @@
 
 # WARNING. There is a bug in this script so that it does not simulate the actual Tahoe Two server selection algorithm that it was intended to simulate. See http://allmydata.org/trac/tahoe-lafs/ticket/302 (stop permuting peerlist, use SI as offset into ring instead?)
 
-from __future__ import print_function
 
 from past.builtins import cmp
 

--- a/misc/simulators/simulator.py
+++ b/misc/simulators/simulator.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
 
 import hashlib
 import os, random

--- a/misc/simulators/sizes.py
+++ b/misc/simulators/sizes.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/misc/simulators/storage-overhead.py
+++ b/misc/simulators/storage-overhead.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import sys, math
 from allmydata import uri, storage

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -1,6 +1,5 @@
 # -*- mode: python -*-
 
-from __future__ import print_function
 
 from distutils.sysconfig import get_python_lib
 import hashlib

--- a/src/allmydata/__main__.py
+++ b/src/allmydata/__main__.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/_monkeypatch.py
+++ b/src/allmydata/_monkeypatch.py
@@ -4,10 +4,6 @@ Monkey-patching of third party libraries.
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/blacklist.py
+++ b/src/allmydata/blacklist.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/check_results.py
+++ b/src/allmydata/check_results.py
@@ -1,9 +1,5 @@
 """Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/codec.py
+++ b/src/allmydata/codec.py
@@ -3,10 +3,6 @@ CRS encoding and decoding.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/crypto/__init__.py
+++ b/src/allmydata/crypto/__init__.py
@@ -9,10 +9,6 @@ objects that `cryptography` documents.
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/crypto/aes.py
+++ b/src/allmydata/crypto/aes.py
@@ -9,10 +9,6 @@ objects that `cryptography` documents.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/crypto/error.py
+++ b/src/allmydata/crypto/error.py
@@ -3,10 +3,6 @@ Exceptions raise by allmydata.crypto.* modules
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/crypto/util.py
+++ b/src/allmydata/crypto/util.py
@@ -3,10 +3,6 @@ Utilities used by allmydata.crypto modules
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/deep_stats.py
+++ b/src/allmydata/deep_stats.py
@@ -2,10 +2,6 @@
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/dirnode.py
+++ b/src/allmydata/dirnode.py
@@ -2,10 +2,6 @@
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/frontends/auth.py
+++ b/src/allmydata/frontends/auth.py
@@ -1,10 +1,6 @@
 """
 Authentication for frontends.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/frontends/sftpd.py
+++ b/src/allmydata/frontends/sftpd.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/hashtree.py
+++ b/src/allmydata/hashtree.py
@@ -49,10 +49,6 @@ or eat  your children, but it might.  Use at your own risk.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/history.py
+++ b/src/allmydata/history.py
@@ -1,9 +1,5 @@
 """Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/checker.py
+++ b/src/allmydata/immutable/checker.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/__init__.py
+++ b/src/allmydata/immutable/downloader/__init__.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/common.py
+++ b/src/allmydata/immutable/downloader/common.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/fetcher.py
+++ b/src/allmydata/immutable/downloader/fetcher.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/finder.py
+++ b/src/allmydata/immutable/downloader/finder.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/node.py
+++ b/src/allmydata/immutable/downloader/node.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/segmentation.py
+++ b/src/allmydata/immutable/downloader/segmentation.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/share.py
+++ b/src/allmydata/immutable/downloader/share.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/downloader/status.py
+++ b/src/allmydata/immutable/downloader/status.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/encode.py
+++ b/src/allmydata/immutable/encode.py
@@ -4,10 +4,6 @@
 Ported to Python 3.
 """
 
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/filenode.py
+++ b/src/allmydata/immutable/filenode.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/happiness_upload.py
+++ b/src/allmydata/immutable/happiness_upload.py
@@ -4,10 +4,6 @@ on.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/literal.py
+++ b/src/allmydata/immutable/literal.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/offloaded.py
+++ b/src/allmydata/immutable/offloaded.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/immutable/repairer.py
+++ b/src/allmydata/immutable/repairer.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -5,10 +5,6 @@ Ported to Python 3.
 
 Note that for RemoteInterfaces, the __remote_name__ needs to be a native string because of https://github.com/warner/foolscap/blob/43f4485a42c9c28e2c79d655b3a9e24d4e6360ca/src/foolscap/remoteinterface.py#L67
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2, native_str
 if PY2:

--- a/src/allmydata/introducer/__init__.py
+++ b/src/allmydata/introducer/__init__.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/introducer/client.py
+++ b/src/allmydata/introducer/client.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/introducer/common.py
+++ b/src/allmydata/introducer/common.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/introducer/interfaces.py
+++ b/src/allmydata/introducer/interfaces.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2, native_str
 if PY2:

--- a/src/allmydata/monitor.py
+++ b/src/allmydata/monitor.py
@@ -3,10 +3,6 @@ Manage status of long-running operations.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/mutable/checker.py
+++ b/src/allmydata/mutable/checker.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/mutable/layout.py
+++ b/src/allmydata/mutable/layout.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/mutable/publish.py
+++ b/src/allmydata/mutable/publish.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/mutable/repairer.py
+++ b/src/allmydata/mutable/repairer.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/admin.py
+++ b/src/allmydata/scripts/admin.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/backupdb.py
+++ b/src/allmydata/scripts/backupdb.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/default_nodedir.py
+++ b/src/allmydata/scripts/default_nodedir.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/slow_operation.py
+++ b/src/allmydata/scripts/slow_operation.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/scripts/tahoe_add_alias.py
+++ b/src/allmydata/scripts/tahoe_add_alias.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_backup.py
+++ b/src/allmydata/scripts/tahoe_backup.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_check.py
+++ b/src/allmydata/scripts/tahoe_check.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_cp.py
+++ b/src/allmydata/scripts/tahoe_cp.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_get.py
+++ b/src/allmydata/scripts/tahoe_get.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/scripts/tahoe_ls.py
+++ b/src/allmydata/scripts/tahoe_ls.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_manifest.py
+++ b/src/allmydata/scripts/tahoe_manifest.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/scripts/tahoe_mkdir.py
+++ b/src/allmydata/scripts/tahoe_mkdir.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_mv.py
+++ b/src/allmydata/scripts/tahoe_mv.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_run.py
+++ b/src/allmydata/scripts/tahoe_run.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_status.py
+++ b/src/allmydata/scripts/tahoe_status.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_unlink.py
+++ b/src/allmydata/scripts/tahoe_unlink.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/scripts/tahoe_webopen.py
+++ b/src/allmydata/scripts/tahoe_webopen.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/storage/common.py
+++ b/src/allmydata/storage/common.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/storage/crawler.py
+++ b/src/allmydata/storage/crawler.py
@@ -4,10 +4,6 @@ Crawl the storage server shares.
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/storage/expirer.py
+++ b/src/allmydata/storage/expirer.py
@@ -1,7 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/storage/immutable.py
+++ b/src/allmydata/storage/immutable.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2, bytes_to_native_str
 if PY2:

--- a/src/allmydata/storage/immutable_schema.py
+++ b/src/allmydata/storage/immutable_schema.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/storage/lease.py
+++ b/src/allmydata/storage/lease.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/storage/mutable.py
+++ b/src/allmydata/storage/mutable.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/storage/mutable_schema.py
+++ b/src/allmydata/storage/mutable_schema.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/storage/shares.py
+++ b/src/allmydata/storage/shares.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/__init__.py
+++ b/src/allmydata/test/__init__.py
@@ -15,10 +15,6 @@ some side-effects which make things better when the test suite runs.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/common.py
+++ b/src/allmydata/test/cli/common.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_admin.py
+++ b/src/allmydata/test/cli/test_admin.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_alias.py
+++ b/src/allmydata/test/cli/test_alias.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_backup.py
+++ b/src/allmydata/test/cli/test_backup.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_backupdb.py
+++ b/src/allmydata/test/cli/test_backupdb.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_check.py
+++ b/src/allmydata/test/cli/test_check.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_cli.py
+++ b/src/allmydata/test/cli/test_cli.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_cp.py
+++ b/src/allmydata/test/cli/test_cp.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_create_alias.py
+++ b/src/allmydata/test/cli/test_create_alias.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_list.py
+++ b/src/allmydata/test/cli/test_list.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/test/cli/test_mv.py
+++ b/src/allmydata/test/cli/test_mv.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli/test_status.py
+++ b/src/allmydata/test/cli/test_status.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/cli_node_api.py
+++ b/src/allmydata/test/cli_node_api.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/common_util.py
+++ b/src/allmydata/test/common_util.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2, PY3, bchr, binary_type
 from future.builtins import str as future_str

--- a/src/allmydata/test/common_web.py
+++ b/src/allmydata/test/common_web.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/matchers.py
+++ b/src/allmydata/test/matchers.py
@@ -3,10 +3,6 @@ Testtools-style matchers useful to the Tahoe-LAFS test suite.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_checker.py
+++ b/src/allmydata/test/mutable/test_checker.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_datahandle.py
+++ b/src/allmydata/test/mutable/test_datahandle.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_different_encoding.py
+++ b/src/allmydata/test/mutable/test_different_encoding.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_exceptions.py
+++ b/src/allmydata/test/mutable/test_exceptions.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_filehandle.py
+++ b/src/allmydata/test/mutable/test_filehandle.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_filenode.py
+++ b/src/allmydata/test/mutable/test_filenode.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_interoperability.py
+++ b/src/allmydata/test/mutable/test_interoperability.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_multiple_encodings.py
+++ b/src/allmydata/test/mutable/test_multiple_encodings.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_multiple_versions.py
+++ b/src/allmydata/test/mutable/test_multiple_versions.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_problems.py
+++ b/src/allmydata/test/mutable/test_problems.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_repair.py
+++ b/src/allmydata/test/mutable/test_repair.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_roundtrip.py
+++ b/src/allmydata/test/mutable/test_roundtrip.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_servermap.py
+++ b/src/allmydata/test/mutable/test_servermap.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/test_update.py
+++ b/src/allmydata/test/mutable/test_update.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/mutable/util.py
+++ b/src/allmydata/test/mutable/util.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2, bchr
 if PY2:

--- a/src/allmydata/test/storage_plugin.py
+++ b/src/allmydata/test/storage_plugin.py
@@ -4,10 +4,6 @@ functionality.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/strategies.py
+++ b/src/allmydata/test/strategies.py
@@ -3,10 +3,6 @@ Hypothesis strategies use for testing Tahoe-LAFS.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_abbreviate.py
+++ b/src/allmydata/test/test_abbreviate.py
@@ -3,10 +3,6 @@ Tests for allmydata.util.abbreviate.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_base32.py
+++ b/src/allmydata/test/test_base32.py
@@ -3,10 +3,6 @@ Tests for allmydata.util.base32.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_base62.py
+++ b/src/allmydata/test/test_base62.py
@@ -4,10 +4,6 @@ Tests for allmydata.util.base62.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_checker.py
+++ b/src/allmydata/test/test_checker.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_codec.py
+++ b/src/allmydata/test/test_codec.py
@@ -3,10 +3,6 @@ Tests for allmydata.codec.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_common_util.py
+++ b/src/allmydata/test/test_common_util.py
@@ -1,10 +1,6 @@
 """
 This module has been ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_configutil.py
+++ b/src/allmydata/test/test_configutil.py
@@ -3,10 +3,6 @@ Tests for allmydata.util.configutil.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_connections.py
+++ b/src/allmydata/test/test_connections.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_consumer.py
+++ b/src/allmydata/test/test_consumer.py
@@ -4,10 +4,6 @@ Tests for allmydata.util.consumer.
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_crawler.py
+++ b/src/allmydata/test/test_crawler.py
@@ -4,10 +4,6 @@ Tests for allmydata.storage.crawler.
 Ported to Python 3.
 """
 
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/test/test_crypto.py
+++ b/src/allmydata/test/test_crypto.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_deepcheck.py
+++ b/src/allmydata/test/test_deepcheck.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 # Python 2 compatibility
 # Can't use `builtins.str` because something deep in Twisted callbacks ends up repr'ing

--- a/src/allmydata/test/test_dirnode.py
+++ b/src/allmydata/test/test_dirnode.py
@@ -2,10 +2,6 @@
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from past.builtins import long
 

--- a/src/allmydata/test/test_encode.py
+++ b/src/allmydata/test/test_encode.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_encodingutil.py
+++ b/src/allmydata/test/test_encodingutil.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2, PY3
 if PY2:

--- a/src/allmydata/test/test_filenode.py
+++ b/src/allmydata/test/test_filenode.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_happiness.py
+++ b/src/allmydata/test/test_happiness.py
@@ -6,10 +6,6 @@ allmydata.util.happinessutil.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_hashutil.py
+++ b/src/allmydata/test/test_hashutil.py
@@ -3,10 +3,6 @@ Tests for allmydata.util.hashutil.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -4,10 +4,6 @@ Tests for allmydata.util.humanreadable.
 This module has been ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_humanreadable.py
+++ b/src/allmydata/test/test_humanreadable.py
@@ -27,7 +27,7 @@ class NoArgumentException(Exception):
 class HumanReadable(unittest.TestCase):
     def test_repr(self):
         hr = humanreadable.hr
-        self.failUnlessEqual(hr(foo), "<foo() at test_humanreadable.py:24>")
+        self.failUnlessEqual(hr(foo), "<foo() at test_humanreadable.py:20>")
         self.failUnlessEqual(hr(self.test_repr),
                              "<bound method HumanReadable.test_repr of <allmydata.test.test_humanreadable.HumanReadable testMethod=test_repr>>")
         self.failUnlessEqual(hr(long(1)), "1")

--- a/src/allmydata/test/test_hung_server.py
+++ b/src/allmydata/test/test_hung_server.py
@@ -3,10 +3,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_i2p_provider.py
+++ b/src/allmydata/test/test_i2p_provider.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_immutable.py
+++ b/src/allmydata/test/test_immutable.py
@@ -1,10 +1,6 @@
 """
 This module has been ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_json_metadata.py
+++ b/src/allmydata/test/test_json_metadata.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_log.py
+++ b/src/allmydata/test/test_log.py
@@ -4,10 +4,6 @@ Tests for allmydata.util.log.
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2, native_str
 if PY2:

--- a/src/allmydata/test/test_monitor.py
+++ b/src/allmydata/test/test_monitor.py
@@ -2,10 +2,6 @@
 Tests for allmydata.monitor.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_multi_introducers.py
+++ b/src/allmydata/test/test_multi_introducers.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_netstring.py
+++ b/src/allmydata/test/test_netstring.py
@@ -3,10 +3,6 @@ Tests for allmydata.util.netstring.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_no_network.py
+++ b/src/allmydata/test/test_no_network.py
@@ -3,10 +3,6 @@ Test the NoNetworkGrid test harness.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_observer.py
+++ b/src/allmydata/test/test_observer.py
@@ -4,10 +4,6 @@ Tests for allmydata.util.observer.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_openmetrics.py
+++ b/src/allmydata/test/test_openmetrics.py
@@ -4,10 +4,6 @@ Tests for ``/statistics?t=openmetrics``.
 Ported to Python 3.
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 

--- a/src/allmydata/test/test_python2_regressions.py
+++ b/src/allmydata/test/test_python2_regressions.py
@@ -2,10 +2,6 @@
 Tests to check for Python2 regressions
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_repairer.py
+++ b/src/allmydata/test/test_repairer.py
@@ -2,10 +2,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -2,13 +2,6 @@
 Ported to Python 3
 """
 
-from __future__ import (
-    absolute_import,
-)
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from future.utils import PY2
 if PY2:
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401

--- a/src/allmydata/test/test_sftp.py
+++ b/src/allmydata/test/test_sftp.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_spans.py
+++ b/src/allmydata/test/test_spans.py
@@ -2,10 +2,6 @@
 Tests for allmydata.util.spans.
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_statistics.py
+++ b/src/allmydata/test/test_statistics.py
@@ -3,10 +3,6 @@ Tests for allmydata.util.statistics.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_stats.py
+++ b/src/allmydata/test/test_stats.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_storage_web.py
+++ b/src/allmydata/test/test_storage_web.py
@@ -4,10 +4,6 @@ Tests for twisted.storage that uses Web APIs.
 Partially ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_time_format.py
+++ b/src/allmydata/test/test_time_format.py
@@ -1,10 +1,6 @@
 """
 Tests for allmydata.util.time_format.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_upload.py
+++ b/src/allmydata/test/test_upload.py
@@ -3,10 +3,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_uri.py
+++ b/src/allmydata/test/test_uri.py
@@ -4,10 +4,6 @@ Tests for allmydata.uri.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -2,10 +2,6 @@
 Ported to Python3.
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/common.py
+++ b/src/allmydata/test/web/common.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/matchers.py
+++ b/src/allmydata/test/web/matchers.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/test_common.py
+++ b/src/allmydata/test/web/test_common.py
@@ -3,10 +3,6 @@ Tests for ``allmydata.web.common``.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/test_grid.py
+++ b/src/allmydata/test/web/test_grid.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/test_introducer.py
+++ b/src/allmydata/test/web/test_introducer.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/test_logs.py
+++ b/src/allmydata/test/web/test_logs.py
@@ -4,13 +4,6 @@ Tests for ``allmydata.web.logs``.
 Ported to Python 3.
 """
 
-from __future__ import (
-    print_function,
-    unicode_literals,
-    absolute_import,
-    division,
-)
-
 from future.utils import PY2
 if PY2:
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401

--- a/src/allmydata/test/web/test_private.py
+++ b/src/allmydata/test/web/test_private.py
@@ -4,13 +4,6 @@ Tests for ``allmydata.web.private``.
 Ported to Python 3.
 """
 
-from __future__ import (
-    print_function,
-    unicode_literals,
-    absolute_import,
-    division,
-)
-
 from future.utils import PY2
 if PY2:
     from future.builtins import filter, map, zip, ascii, chr, hex, input, next, oct, open, pow, round, super, bytes, dict, list, object, range, str, max, min  # noqa: F401

--- a/src/allmydata/test/web/test_root.py
+++ b/src/allmydata/test/web/test_root.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/test_status.py
+++ b/src/allmydata/test/web/test_status.py
@@ -3,10 +3,6 @@ Tests for ```allmydata.web.status```.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/test/web/test_util.py
+++ b/src/allmydata/test/web/test_util.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/unknown.py
+++ b/src/allmydata/unknown.py
@@ -1,9 +1,5 @@
 """Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/abbreviate.py
+++ b/src/allmydata/util/abbreviate.py
@@ -3,10 +3,6 @@ Convert timestamps to abbreviated English text.
 
 Ported to Python 3.
 """
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/assertutil.py
+++ b/src/allmydata/util/assertutil.py
@@ -7,10 +7,6 @@ have tests.
 Ported to Python 3.
 """
 
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/base62.py
+++ b/src/allmydata/util/base62.py
@@ -3,10 +3,6 @@ Base62 encoding.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/configutil.py
+++ b/src/allmydata/util/configutil.py
@@ -5,10 +5,6 @@ Configuration is returned as Unicode strings.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/consumer.py
+++ b/src/allmydata/util/consumer.py
@@ -4,10 +4,6 @@ a filenode's read() method. See download_to_data() for an example of its use.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/dbutil.py
+++ b/src/allmydata/util/dbutil.py
@@ -6,10 +6,6 @@ Test coverage currently provided by test_backupdb.py.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/encodingutil.py
+++ b/src/allmydata/util/encodingutil.py
@@ -7,10 +7,6 @@ Ported to Python 3.
 Once Python 2 support is dropped, most of this module will obsolete, since
 Unicode is the default everywhere in Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2, PY3, native_str
 from future.builtins import str as future_str

--- a/src/allmydata/util/fileutil.py
+++ b/src/allmydata/util/fileutil.py
@@ -4,10 +4,6 @@ Ported to Python3.
 Futz with files like a pro.
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/gcutil.py
+++ b/src/allmydata/util/gcutil.py
@@ -10,10 +10,6 @@ Helpers for managing garbage collection.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/happinessutil.py
+++ b/src/allmydata/util/happinessutil.py
@@ -4,10 +4,6 @@ reporting it in messages.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/hashutil.py
+++ b/src/allmydata/util/hashutil.py
@@ -3,10 +3,6 @@ Hashing utilities.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/humanreadable.py
+++ b/src/allmydata/util/humanreadable.py
@@ -4,10 +4,6 @@ Utilities for turning objects into human-readable strings.
 This module has been ported to Python 3.
 """
 
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/idlib.py
+++ b/src/allmydata/util/idlib.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/jsonbytes.py
+++ b/src/allmydata/util/jsonbytes.py
@@ -4,10 +4,6 @@ A JSON encoder than can serialize bytes.
 Ported to Python 3.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/log.py
+++ b/src/allmydata/util/log.py
@@ -3,10 +3,6 @@ Logging utilities.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/mathutil.py
+++ b/src/allmydata/util/mathutil.py
@@ -6,10 +6,6 @@ Backwards compatibility for direct imports.
 Ported to Python 3.
 """
 
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/netstring.py
+++ b/src/allmydata/util/netstring.py
@@ -3,10 +3,6 @@ Netstring encoding and decoding.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/observer.py
+++ b/src/allmydata/util/observer.py
@@ -4,10 +4,6 @@ Observer for Twisted code.
 Ported to Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/rrefutil.py
+++ b/src/allmydata/util/rrefutil.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/spans.py
+++ b/src/allmydata/util/spans.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/statistics.py
+++ b/src/allmydata/util/statistics.py
@@ -11,10 +11,6 @@ Ported to Python 3.
 # Transitive Grace Period Public License, version 1 or later.
 
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/time_format.py
+++ b/src/allmydata/util/time_format.py
@@ -4,10 +4,6 @@ Time formatting utilities.
 ISO-8601:
 http://www.cl.cam.ac.uk/~mgk25/iso-time.html
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/util/yamlutil.py
+++ b/src/allmydata/util/yamlutil.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/check_results.py
+++ b/src/allmydata/web/check_results.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/directory.py
+++ b/src/allmydata/web/directory.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/info.py
+++ b/src/allmydata/web/info.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/logs.py
+++ b/src/allmydata/web/logs.py
@@ -1,12 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import (
-    print_function,
-    unicode_literals,
-    absolute_import,
-    division,
-)
 
 from autobahn.twisted.resource import WebSocketResource
 from autobahn.twisted.websocket import (

--- a/src/allmydata/web/operations.py
+++ b/src/allmydata/web/operations.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/private.py
+++ b/src/allmydata/web/private.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -2,10 +2,6 @@
 Ported to Python 3.
 """
 
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/storage.py
+++ b/src/allmydata/web/storage.py
@@ -1,10 +1,6 @@
 """
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/web/storage_plugins.py
+++ b/src/allmydata/web/storage_plugins.py
@@ -4,10 +4,6 @@ of all enabled storage client plugins.
 
 Ported to Python 3.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from future.utils import PY2
 if PY2:

--- a/src/allmydata/windows/fixups.py
+++ b/src/allmydata/windows/fixups.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 from future.utils import PY3
 from past.builtins import unicode

--- a/ws_client.py
+++ b/ws_client.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import sys
 import json


### PR DESCRIPTION
This is the easiest part to review from my huge previous PR.

`from __future__ import annotations` stays of course.
