### PR TITLE
4110 "--storage-dir" is an option

### DIFF
--- a/newsfragments/4110.incompat
+++ b/newsfragments/4110.incompat
@@ -1,0 +1,3 @@
+Properly interpret "tahoe create --storage-dir" as an option.
+
+Versions of from 1.19.0 and older interpreted "--storage-dir" as a "flag" and thus wouldn't work properly.

--- a/newsfragments/4110.incompat
+++ b/newsfragments/4110.incompat
@@ -1,3 +1,3 @@
 Properly interpret "tahoe create --storage-dir" as an option.
 
-Versions of from 1.19.0 and older interpreted "--storage-dir" as a "flag" and thus wouldn't work properly.
+Versions 1.19.0 and older interpreted "--storage-dir" as a "flag" and thus wouldn't work properly.

--- a/src/allmydata/scripts/create_node.py
+++ b/src/allmydata/scripts/create_node.py
@@ -234,13 +234,15 @@ class CreateClientOptions(_CreateBaseOptions):
 class CreateNodeOptions(CreateClientOptions):
     optFlags = [
         ("no-storage", None, "Do not offer storage service to other nodes."),
-        ("storage-dir", None, "Path where the storage will be placed."),
         ("helper", None, "Enable helper"),
     ] + TOR_FLAGS + I2P_FLAGS
 
     synopsis = "[options] [NODEDIR]"
     description = "Create a full Tahoe-LAFS node (client+server)."
-    optParameters = CreateClientOptions.optParameters + WHERE_OPTS + TOR_OPTS + I2P_OPTS
+
+    optParameters = [
+        ("storage-dir", None, None, "Path where the storage will be placed."),
+    ] + CreateClientOptions.optParameters + WHERE_OPTS + TOR_OPTS + I2P_OPTS
 
     def parseArgs(self, basedir=None):
         CreateClientOptions.parseArgs(self, basedir)

--- a/src/allmydata/test/cli/test_create.py
+++ b/src/allmydata/test/cli/test_create.py
@@ -241,6 +241,13 @@ class Config(unittest.TestCase):
         self.assertFalse(cfg.has_section("connections"))
 
     @defer.inlineCallbacks
+    def test_storage_dir(self):
+        basedir = self.mktemp()
+        rc, out, err = yield run_cli("create-node", "--storage-dir", "/tmp/storage", "--hostname=foo", basedir)
+        cfg = read_config(basedir)
+        self.assertEqual(cfg.get("storage", "storage_dir"), "/tmp/storage")
+
+    @defer.inlineCallbacks
     def test_node_hide_ip(self):
         basedir = self.mktemp()
         rc, out, err = yield run_cli("create-node", "--hide-ip",


### PR DESCRIPTION
"--storage-dir" should be interpreted as an option. Instead, it is listed as a "flag" so it doesn't work as described (and would produce incorrect tahoe.cfg files if it was used as a flag).