### PR TITLE
4126 - SystemTest: 5min instead of 3min timeout

### DIFF
--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -115,7 +115,7 @@ class CountingDataUploadable(upload.Data):
 class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
     """Foolscap integration-y tests."""
     FORCE_FOOLSCAP_FOR_STORAGE = True
-    timeout = 180
+    timeout = 300
 
     @property
     def basedir(self):


### PR DESCRIPTION
Recently, mostly on CircleCI, the CI test suite runs into timeouts, often leading to subsequent "Dirty Reactor" errors.

Increasing the timeout makes this happen less often.

Ticket: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4126