### PR TITLE
4127.Add Python312 to NixOS matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ workflows:
                 - "python39"
                 - "python310"
                 - "python311"
+                - "python312"
 
       # Eventually, test against PyPy 3.8
       #- "pypy27-buster":


### PR DESCRIPTION
This adds Python312 to the NixOS `pythonVersion` matrix.