### PR TITLE
4129.CircleCI/Windows: Use all available cores.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,8 @@ jobs:
             # Run the test suite under coverage measurement using the
             # parameterized version of Python, writing subunitv2-format
             # results to the file given in the environment.
-            python -b -m coverage run -m twisted.trial --reporter=subunitv2-file --rterrors allmydata
+            # The "windows.large" resource_class has eight cores.
+            python -b -m coverage run -m twisted.trial --jobs=8 --reporter=subunitv2-file --rterrors allmydata
 
       - "run":
           name: "Upload Coverage"


### PR DESCRIPTION
[ticket: 4129](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4129).

This makes the Windows test suites in CircleCI use all (eight) available cores.

Before this PR the utilization looks like this: https://app.circleci.com/pipelines/github/tahoe-lafs/tahoe-lafs/5118/workflows/13b3a428-9d8d-4b2e-9e20-9dcb766dad2a/jobs/88161/resources