### PR TITLE
4130.GitHub Actions: Don't run the Pypy 3.8 job anymore.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
             python-version: "3.12"
           # We only support PyPy on Linux at the moment.
           - os: ubuntu-latest
-            python-version: "pypy-3.8"
-          - os: ubuntu-latest
             python-version: "pypy-3.9"
           - os: ubuntu-latest
             python-version: "3.12"


### PR DESCRIPTION
Fixes [ticket: 4130](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4130).