### PR TITLE
4136.Update MacOS environment from 12 to 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-12
+          - os: macos-13
             python-version: "3.12"
           # We only support PyPy on Linux at the moment.
           - os: ubuntu-latest
@@ -160,7 +160,7 @@ jobs:
           # 22.04 has some issue with Tor at the moment:
           # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943
           - ubuntu-20.04
-          - macos-12
+          - macos-13
           - windows-latest
         python-version:
           - "3.11"
@@ -242,7 +242,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-13
           - windows-latest
           - ubuntu-latest
         python-version:


### PR DESCRIPTION
This PR fixes the CI MacOS runners by updating to a still supported version of the platform to fix

> The macOS-12 environment is deprecated, consider switching to macOS-13

e.g. happening here: https://github.com/tahoe-lafs/tahoe-lafs/actions/runs/12145353362/job/33866787645?pr=1398

[ticket: 4136](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4136#ticket)