### PR TITLE
4131: Remove Python 3.8 and OracleLinux 8 with it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,6 @@ dockerhub-auth-template: &DOCKERHUB_AUTH
         <<: *DOCKERHUB_CONTEXT
     - "build-image-fedora-35":
         <<: *DOCKERHUB_CONTEXT
-    - "build-image-oraclelinux-8":
-        <<: *DOCKERHUB_CONTEXT
     # Restore later as PyPy38
     #- "build-image-pypy27-buster":
     #    <<: *DOCKERHUB_CONTEXT
@@ -88,8 +86,7 @@ workflows:
       - "ubuntu-22-04":
           {}
 
-      # Equivalent to RHEL 8; CentOS 8 is dead.
-      - "oraclelinux-8":
+      - "fedora-35":
           {}
 
       - "nixos":
@@ -543,15 +540,15 @@ jobs:
       <<: *UTF_8_ENVIRONMENT
       TAHOE_LAFS_TOX_ENVIRONMENT: "py310"
 
-  oraclelinux-8: &RHEL_DERIV
+  fedora-35: &RHEL_DERIV
     docker:
       - <<: *DOCKERHUB_AUTH
-        image: "tahoelafsci/oraclelinux:8-py3.8"
+        image: "tahoelafsci/fedora:35-py3"
         user: "nobody"
 
     environment:
       <<: *UTF_8_ENVIRONMENT
-      TAHOE_LAFS_TOX_ENVIRONMENT: "py38"
+      TAHOE_LAFS_TOX_ENVIRONMENT: "py310"
 
     # pip cannot install packages if the working directory is not readable.
     # We want to run a lot of steps as nobody instead of as root.
@@ -566,13 +563,6 @@ jobs:
       - store_artifacts: *STORE_ELIOT_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS
       - run: *SUBMIT_COVERAGE
-
-  fedora-35:
-    <<: *RHEL_DERIV
-    docker:
-      - <<: *DOCKERHUB_AUTH
-        image: "tahoelafsci/fedora:35-py3"
-        user: "nobody"
 
   nixos:
     parameters:
@@ -700,14 +690,6 @@ jobs:
       TAG: "22.04"
       PYTHON_VERSION: "3.10"
 
-
-  build-image-oraclelinux-8:
-    <<: *BUILD_IMAGE
-
-    environment:
-      DISTRO: "oraclelinux"
-      TAG: "8"
-      PYTHON_VERSION: "3.8"
 
   build-image-fedora-35:
     <<: *BUILD_IMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,10 +99,6 @@ workflows:
                 - "python310"
                 - "python311"
 
-      # Eventually, test against PyPy 3.8
-      #- "pypy27-buster":
-      #    {}
-
       # Other assorted tasks and configurations
       - "codechecks":
           {}
@@ -457,21 +453,6 @@ jobs:
       - <<: *DOCKERHUB_AUTH
         image: "tahoelafsci/debian:11-py3.9"
         user: "nobody"
-
-
-  # Restore later using PyPy3.8
-  # pypy27-buster:
-  #   <<: *DEBIAN
-  #   docker:
-  #     - <<: *DOCKERHUB_AUTH
-  #       image: "tahoelafsci/pypy:buster-py2"
-  #       user: "nobody"
-  #   environment:
-  #     <<: *UTF_8_ENVIRONMENT
-  #     # We don't do coverage since it makes PyPy far too slow:
-  #     TAHOE_LAFS_TOX_ENVIRONMENT: "pypy27"
-  #     # Since we didn't collect it, don't upload it.
-  #     UPLOAD_COVERAGE: ""
 
   c-locale:
     <<: *DEBIAN

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Once ``tahoe --version`` works, see `How to Run Tahoe-LAFS <docs/running.rst>`__
 🐍 Python 2
 -----------
 
-Python 3.8 or later is required.
+Python 3.9 or later is required.
 If you are still using Python 2.7, use Tahoe-LAFS version 1.17.1.
 
 

--- a/newsfragments/4131.minor
+++ b/newsfragments/4131.minor
@@ -1,0 +1,1 @@
+Removing python 3.8 (EOL) and anything related, including CI checks

--- a/setup.py
+++ b/setup.py
@@ -380,8 +380,8 @@ setup(name="tahoe-lafs", # also set in __init__.py
       package_dir = {'':'src'},
       packages=find_packages('src') + ['allmydata.test.plugins'],
       classifiers=trove_classifiers,
-      # We support Python 3.8 or later, 3.13 is untested for now
-      python_requires=">=3.8, <3.13",
+      # We support Python 3.9 or later, 3.13 is untested for now
+      python_requires=">=3.9, <3.13",
       install_requires=install_requires,
       extras_require={
           # Duplicate the Twisted pywin32 dependency here.  See

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 
 from six import ensure_str
 import sys
-if sys.version_info[:2] >= (3, 9):
-    from importlib.resources import files as resource_files, as_file
-else:
-    from importlib_resources import files as resource_files, as_file
+from importlib.resources import files as resource_files, as_file
 from contextlib import ExitStack
 import weakref
 from typing import Optional, Union, TypeVar, overload

--- a/src/allmydata/web/common.py
+++ b/src/allmydata/web/common.py
@@ -4,8 +4,8 @@ Ported to Python 3.
 from __future__ import annotations
 
 from six import ensure_str
-import sys
-from importlib.resources import files as resource_files, as_file
+from importlib.resources import files as resource_files
+from importlib.resources import as_file
 from contextlib import ExitStack
 import weakref
 from typing import Optional, Union, TypeVar, overload

--- a/tox.ini
+++ b/tox.ini
@@ -7,19 +7,17 @@
 # the tox-gh-actions package.
 [gh-actions]
 python =
-    3.8: py38-coverage
     3.9: py39-coverage
     3.10: py310-coverage
     3.11: py311-coverage
     3.12: py312-coverage
-    pypy-3.8: pypy38
     pypy-3.9: pypy39
 
 [pytest]
 twisted = 1
 
 [tox]
-envlist = typechecks,codechecks,py{38,39,310,311,312}-{coverage},pypy27,pypy38,pypy39,integration
+envlist = typechecks,codechecks,py{39,310,311,312}-{coverage},pypy39,integration
 minversion = 4
 
 [testenv]
@@ -138,7 +136,7 @@ commands =
     # Different versions of Python have a different standard library, and we
     # want to be compatible with all the variations. For speed's sake we only do
     # the earliest and latest versions.
-    mypy --python-version=3.8 src
+    mypy --python-version=3.9 src
     mypy --python-version=3.12 src
 
 


### PR DESCRIPTION
Since Python 3.8 is EOL: let's remove it properly.

In addition, because we were testing Python 3.i on OracleLinux 8, let's remove it too.
But then, we could bring back Fedora to test Python 3.10 on a RH like distro.

ticket: [4131](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4131)