### PR TITLE
Remove NixOS 24.11 CI job for Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ workflows:
               nixpkgs:
                 - "nixpkgs-24_11"
               pythonVersion:
-                - "python310"
                 - "python311"
                 - "python312"
 


### PR DESCRIPTION
NixOS 24.11 has Python 3.12 as default; for testing 3.10 we need to compile quite a bit of software on each run, and we do not learn a lot, since other Linux distributions test 3.10 already.

Refs #4145