### PR TITLE
fix(parse_duration): resolve error when parsing durations in seconds

### DIFF
--- a/src/allmydata/test/test_time_format.py
+++ b/src/allmydata/test/test_time_format.py
@@ -81,24 +81,42 @@ class TimeFormat(unittest.TestCase, TimezoneMixin):
         DAY = 24*60*60
         MONTH = 31*DAY
         YEAR = 365*DAY
+
+        # seconds
         self.failUnlessEqual(p("1s"), 1)
+        self.failUnlessEqual(p("12 s"), 12)
+        self.failUnlessEqual(p("333second"), 333)
+        self.failUnlessEqual(p(" 333 second "), 333)
+        self.failUnlessEqual(p("5 seconds"), 5)
+        self.failUnlessEqual(p("60 SECONDS"), 60)
         self.failUnlessEqual(p("86400s"), DAY)
+
+        # days
         self.failUnlessEqual(p("1 day"), DAY)
         self.failUnlessEqual(p("2 days"), 2*DAY)
-        self.failUnlessEqual(p("3 months"), 3*MONTH)
-        self.failUnlessEqual(p("4 mo"), 4*MONTH)
-        self.failUnlessEqual(p("5 years"), 5*YEAR)
-        e = self.failUnlessRaises(ValueError, p, "123")
-        self.failUnlessIn("no unit (like day, month, or year) in '123'",
-                          str(e))
+        self.failUnlessEqual(p("5days"), 5*DAY)
         self.failUnlessEqual(p("7days"), 7*DAY)
         self.failUnlessEqual(p("31day"), 31*DAY)
         self.failUnlessEqual(p("60 days"), 60*DAY)
+        self.failUnlessEqual(p("70 DAYS"), 70*DAY)
+
+        # months
+        self.failUnlessEqual(p("4 mo"), 4*MONTH)
         self.failUnlessEqual(p("2mo"), 2*MONTH)
         self.failUnlessEqual(p("3 month"), 3*MONTH)
+        self.failUnlessEqual(p("3 months"), 3*MONTH)
+
+        # years
+        self.failUnlessEqual(p("5 years"), 5*YEAR)
+        self.failUnlessEqual(p("8 year"), 8*YEAR)
         self.failUnlessEqual(p("2years"), 2*YEAR)
+        self.failUnlessEqual(p("11YEARS"), 11*YEAR)
+
+        # errors
+        e = self.failUnlessRaises(ValueError, p, "123")
+        self.failUnlessIn("No valid unit in",str(e))
         e = self.failUnlessRaises(ValueError, p, "2kumquats")
-        self.failUnlessIn("no unit (like day, month, or year) in '2kumquats'", str(e))
+        self.failUnlessIn("No valid unit in", str(e))
 
     def test_parse_date(self):
         p = time_format.parse_date

--- a/src/allmydata/test/test_time_format.py
+++ b/src/allmydata/test/test_time_format.py
@@ -81,6 +81,8 @@ class TimeFormat(unittest.TestCase, TimezoneMixin):
         DAY = 24*60*60
         MONTH = 31*DAY
         YEAR = 365*DAY
+        self.failUnlessEqual(p("1s"), 1)
+        self.failUnlessEqual(p("86400s"), DAY)
         self.failUnlessEqual(p("1 day"), DAY)
         self.failUnlessEqual(p("2 days"), 2*DAY)
         self.failUnlessEqual(p("3 months"), 3*MONTH)

--- a/src/allmydata/util/time_format.py
+++ b/src/allmydata/util/time_format.py
@@ -53,12 +53,14 @@ def iso_utc_time_to_seconds(isotime, _conversion_re=re.compile(r"(?P<year>\d{4})
 def parse_duration(s):
     orig = s
     unit = None
+    SECOND = 1
     DAY = 24*60*60
     MONTH = 31*DAY
     YEAR = 365*DAY
     if s.endswith("s"):
+        unit = SECOND
         s = s[:-1]
-    if s.endswith("day"):
+    elif s.endswith("day"):
         unit = DAY
         s = s[:-len("day")]
     elif s.endswith("month"):

--- a/src/allmydata/util/time_format.py
+++ b/src/allmydata/util/time_format.py
@@ -73,7 +73,7 @@ def parse_duration(s):
         unit = YEAR
         s = s[:-len("YEAR")]
     else:
-        raise ValueError("no unit (like day, month, or year) in '%s'" % orig)
+        raise ValueError("no unit (like s, day, mo, month, or year) in '%s'" % orig)
     s = s.strip()
     return int(s) * unit
 

--- a/src/allmydata/util/time_format.py
+++ b/src/allmydata/util/time_format.py
@@ -10,7 +10,7 @@ from typing import Optional
 from enum import Enum
 
 
-class ParseDurationUnitFormat(Enum):
+class ParseDurationUnitFormat(str, Enum):
     SECONDS0 = "s"
     SECONDS1 = "second"
     SECONDS2 = "seconds"


### PR DESCRIPTION
Fixed an issue where configuring seconds in override_lease_duration previously resulted in errors due to missing elif statement in the parse_duration function


This configuration
```
[storage]
expire.enabled = True
expire.mode = age
expire.override_lease_duration = 100000s
```
Previously resulted in this error
```
Unknown error, here's the traceback:
2025-01-08T15:45:43.031716337Z Traceback (most recent call last):
2025-01-08T15:45:43.031717379Z   File "/usr/local/lib/python3.10/dist-packages/twisted/internet/defer.py", line 2017, in _inlineCallbacks
2025-01-08T15:45:43.031938379Z     result = context.run(gen.send, result)
2025-01-08T15:45:43.031945545Z   File "/usr/local/lib/python3.10/dist-packages/allmydata/client.py", line 306, in create_client_from_config
2025-01-08T15:45:43.032061629Z     client.init_storage(storage_plugins.announceable_storage_servers)
2025-01-08T15:45:43.032064420Z   File "/usr/local/lib/python3.10/dist-packages/allmydata/client.py", line 843, in init_storage
2025-01-08T15:45:43.032065504Z     ss = self.get_anonymous_storage_server()
2025-01-08T15:45:43.032066462Z   File "/usr/local/lib/python3.10/dist-packages/allmydata/client.py", line 806, in get_anonymous_storage_server
2025-01-08T15:45:43.032067462Z     o_l_d = parse_duration(o_l_d)
2025-01-08T15:45:43.032068212Z   File "/usr/local/lib/python3.10/dist-packages/allmydata/util/time_format.py", line 74, in parse_duration
2025-01-08T15:45:43.032069170Z     raise ValueError("no unit (like day, month, or year) in '%s'" % orig)
2025-01-08T15:45:43.032070045Z builtins.ValueError: no unit (like day, month, or year) in '100000s'
```