### PR TITLE
4158 Fix a bunch of "SyntaxWarning: invalid escape sequence"

### DIFF
--- a/newsfragments/4158.minor
+++ b/newsfragments/4158.minor
@@ -1,0 +1,1 @@
+Fixed a couple of SyntaxWarnings from invalid escape sequences (shown under Python 3.12 and 3.13).

--- a/src/allmydata/hashtree.py
+++ b/src/allmydata/hashtree.py
@@ -70,7 +70,7 @@ def roundup_pow2(x):
 
 
 class CompleteBinaryTreeMixin:
-    """
+    r"""
     Adds convenience methods to a complete binary tree.
 
     Assumes the total number of elements in the binary tree may be
@@ -179,7 +179,7 @@ def pair_hash(a, b):
     return tagged_pair_hash(b'Merkle tree internal node', a, b)
 
 class HashTree(CompleteBinaryTreeMixin, list):
-    """
+    r"""
     Compute Merkle hashes at any node in a complete binary tree.
 
     Tree is indexed like so::

--- a/src/allmydata/interfaces.py
+++ b/src/allmydata/interfaces.py
@@ -406,7 +406,7 @@ class IStorageBucketWriter(Interface):
         """
 
     def put_uri_extension(data):
-        """This block of data contains integrity-checking information (hashes
+        r"""This block of data contains integrity-checking information (hashes
         of plaintext, crypttext, and shares), as well as encoding parameters
         that are necessary to recover the data. This is a serialized dict
         mapping strings to other strings. The hash of this data is kept in

--- a/src/allmydata/node.py
+++ b/src/allmydata/node.py
@@ -90,7 +90,7 @@ def _common_valid_config():
     })
 
 # group 1 will be addr (dotted quad string), group 3 if any will be portnum (string)
-ADDR_RE = re.compile("^([1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*)(:([1-9][0-9]*))?$")
+ADDR_RE = re.compile(r"^([1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*)(:([1-9][0-9]*))?$")
 
 # this is put into README in new node-directories (for client and introducers)
 PRIV_README = """

--- a/src/allmydata/test/cli/test_backup.py
+++ b/src/allmydata/test/cli/test_backup.py
@@ -36,9 +36,9 @@ class Backup(GridTestMixin, CLITestMixin, StallMixin, unittest.TestCase):
 
     def count_output(self, out):
         mo = re.search(r"(\d)+ files uploaded \((\d+) reused\), "
-                        "(\d)+ files skipped, "
-                        "(\d+) directories created \((\d+) reused\), "
-                        "(\d+) directories skipped", out)
+                        r"(\d)+ files skipped, "
+                        r"(\d+) directories created \((\d+) reused\), "
+                        r"(\d+) directories skipped", out)
         return [int(s) for s in mo.groups()]
 
     def count_output2(self, out):

--- a/src/allmydata/test/cli/test_cli.py
+++ b/src/allmydata/test/cli/test_cli.py
@@ -764,7 +764,7 @@ class Errors(GridTestMixin, CLITestMixin, unittest.TestCase):
         # enough shares. The one remaining share might be in either the
         # COMPLETE or the PENDING state.
         in_complete_msg = "ran out of shares: complete=sh0 pending= overdue= unused= need 3"
-        in_pending_msg_regex = "ran out of shares: complete= pending=Share\(.+\) overdue= unused= need 3"
+        in_pending_msg_regex = r"ran out of shares: complete= pending=Share\(.+\) overdue= unused= need 3"
 
         d.addCallback(lambda ign: self.do_cli("get", self.uri_1share))
         def _check1(args):

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -254,7 +254,7 @@ class CreateNode(unittest.TestCase):
         # Fail if there is a non-empty line that doesn't end with a
         # punctuation mark.
         for line in err.splitlines():
-            self.failIf(re.search("[\S][^\.!?]$", line), (line,))
+            self.failIf(re.search(r"[\S][^\.!?]$", line), (line,))
 
         # test that the non --basedir form works too
         n2 = os.path.join(basedir, command + "-n2")

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1968,7 +1968,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
     def test_CSS_FILE(self):
         d = self.GET("/tahoe.css", followRedirect=True)
         def _check(res):
-            CSS_STYLE=re.compile(r'toolbar\s{.+text-align:\scenter.+toolbar-item.+display:\sinline',re.DOTALL)
+            CSS_STYLE=re.compile(b'toolbar\\s{.+text-align:\\scenter.+toolbar-item.+display:\\sinline',re.DOTALL)
             self.failUnless(CSS_STYLE.search(res), res)
         d.addCallback(_check)
         return d

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -1968,7 +1968,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
     def test_CSS_FILE(self):
         d = self.GET("/tahoe.css", followRedirect=True)
         def _check(res):
-            CSS_STYLE=re.compile(b'toolbar\s{.+text-align:\scenter.+toolbar-item.+display:\sinline',re.DOTALL)
+            CSS_STYLE=re.compile(r'toolbar\s{.+text-align:\scenter.+toolbar-item.+display:\sinline',re.DOTALL)
             self.failUnless(CSS_STYLE.search(res), res)
         d.addCallback(_check)
         return d

--- a/src/allmydata/util/i2p_provider.py
+++ b/src/allmydata/util/i2p_provider.py
@@ -189,7 +189,7 @@ class _Provider(service.MultiService):
         privkeyfile = self._get_i2p_config("dest.private_key_file")
         external_port = self._get_i2p_config("dest.port")
         sam_port = self._get_i2p_config("sam.port")
-        escaped_sam_port = sam_port.replace(':', '\:')
+        escaped_sam_port = sam_port.replace(':', r'\:')
         # for now, this returns a string, which then gets passed to
         # endpoints.serverFromString . But it can also return an Endpoint
         # directly, which means we don't need to encode all these options

--- a/src/allmydata/web/status.py
+++ b/src/allmydata/web/status.py
@@ -1556,8 +1556,8 @@ class Statistics(MultiFormatResource):
 
         def mangle_name(name):
             return re.sub(
-                u"_(\d\d)_(\d)_percentile",
-                u'{quantile="0.\g<1>\g<2>"}',
+                r"_(\d\d)_(\d)_percentile",
+                r'{quantile="0.\g<1>\g<2>"}',
                 name.replace(u".", u"_")
             )
 


### PR DESCRIPTION
Since Python 3.12 the warnings for invalid escape sequences are getting louder - to the point they show up when installing our package in Debian ([ticket: 4158](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4158), [CircleCI run installing the newly-built package](https://app.circleci.com/pipelines/github/LeastAuthority/tahoe-lafs/1303/workflows/0ee30e67-de10-4d03-8c93-6a51000393ad/jobs/15982/parallel-runs/0/steps/0-105)).

From https://stackoverflow.com/a/77531416/1181063:

> Back in Python 3.6, using invalid escape sequences in string literals [was deprecated](https://docs.python.org/dev/whatsnew/3.6.html#deprecated-python-behavior) ([bpo-27364](https://github.com/python/cpython/issues/71551)). Since then, attempting to use an invalid escape sequence has emitted a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). This can often go unnoticed if you don't run Python with [warnings enabled](https://docs.python.org/3/using/cmdline.html#cmdoption-W). DeprecationWarnings are silenced by default.
>
> Python 3.12 [upgraded the DeprecationWarning to a SyntaxWarning](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes). SyntaxWarnings are emitted by the compiler when the code is parsed, not when it's being run, so they cannot be ignored using a runtime warning filter. Unlike DeprecationWarnings, SyntaxWarnings are displayed by default, which is why you're seeing it now. This increase in visibility was intentional. In a future version of Python, using invalid escape sequences in string literals is planned to eventually become a hard SyntaxError.

Refs [ticket: 4158](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4158)