### PR TITLE
Fix `Read the Docs` config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,5 +6,8 @@ build:
     python: "3.10"
 
 python:
-   install:
-   - requirements: docs/requirements.txt
+  install:
+  - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Building ReadTheDocs without explicitly pointing to the configuration to use has been deprecated in order to make builds more explicit and predictable: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

Fixes [ticket: 4164](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4164)