### PR TITLE
Fix #4166: Make test_create_already look in the process's output instead of only stdout

### DIFF
--- a/src/allmydata/test/cli/test_grid_manager.py
+++ b/src/allmydata/test/cli/test_grid_manager.py
@@ -90,7 +90,7 @@ class GridManagerCommandLine(TestCase):
             self.assertEqual(1, result.exit_code)
             self.assertIn(
                 "Can't create",
-                result.stdout,
+                result.output,
             )
 
     def test_create_stdout(self):


### PR DESCRIPTION
... (supposedly) some recent dependency change made it so the (human-readable) error output lands in stderr instead of stdout (as it should be).

Fixes [ticket:4166](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4166)