### PR TITLE
4169 Add man page for grid manager.

### DIFF
--- a/docs/man/man1/grid-manager.1
+++ b/docs/man/man1/grid-manager.1
@@ -16,10 +16,10 @@ Grid Manager configuration can be in a local directory or given via stdin. It co
 .
 .SH OPTIONS
 .TP
-.BR \-c , " --config " \fIPATH\fR
-Configuration directory (or \- for stdin). \fIRequired.\fR
+.BR \f[B]-c,\ --config\ \fIPATH\fR
+Configuration directory (or - for stdin). \fIRequired.\fR
 .TP
-.B \--help
+.B \f[B]--help
 Show this message and exit.
 .
 .SH COMMANDS
@@ -43,13 +43,15 @@ Remove an existing storage-server by name from a Grid Manager.
 Sign a new certificate.
 .
 .SH AUTHORS
+Grid Manager has been written by meejah.
+.PP
 Tahoe-LAFS has been written by Brian Warner, Zooko Wilcox-O'Hearn, and numerous other contributors.
 .
 .SH REPORTING BUGS
 Please see <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug>.
-.
+.PP
 Tahoe-LAFS home page: <https://tahoe-lafs.org/>
-.
+.PP
 Tahoe-LAFS development mailing list: <https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev>
 .
 .SH COPYRIGHT

--- a/docs/man/man1/grid-manager.1
+++ b/docs/man/man1/grid-manager.1
@@ -59,3 +59,6 @@ Copyright \(co 2006\(en2025 The Tahoe-LAFS Software Foundation.
 .
 .SH SEE ALSO
 tahoe(1)
+.PP
+The Tahoe-LAFS documentation on Grid Managers has more detail than this manual page: <https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html>.
+It includes a tutorial-style step-by-step example on how to set up a managed grid: <https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html#example-setup-of-a-new-managed-grid>

--- a/docs/man/man1/grid-manager.1
+++ b/docs/man/man1/grid-manager.1
@@ -48,17 +48,29 @@ Grid Manager has been written by meejah.
 Tahoe-LAFS has been written by Brian Warner, Zooko Wilcox-O'Hearn, and numerous other contributors.
 .
 .SH REPORTING BUGS
-Please see https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug.
+Please see
+.UR https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug
+.UE
+.
 .PP
-Tahoe-LAFS home page: https://tahoe-lafs.org/
+Tahoe-LAFS home page:
+.UR https://tahoe-lafs.org/
+.UE
 .PP
-Tahoe-LAFS development mailing list: https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev
+Tahoe-LAFS development mailing list:
+.UR https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev
+.UE
 .
 .SH COPYRIGHT
 Copyright \(co 2006\(en2025 The Tahoe-LAFS Software Foundation.
 .
 .SH SEE ALSO
-tahoe(1)
+.MR tahoe 1
 .PP
-The Tahoe-LAFS documentation on Grid Managers has more detail than this manual page: https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html.
-It includes a tutorial-style step-by-step example on how to set up a managed grid: https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html#example-setup-of-a-new-managed-grid
+The Tahoe-LAFS documentation on Grid Managers has more detail than this manual page:
+.UR https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html
+.UE
+.PP
+It includes a step-by-step tutorial on how to set up a managed grid:
+.UR https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html#example-setup-of-a-new-managed-grid
+.UE

--- a/docs/man/man1/grid-manager.1
+++ b/docs/man/man1/grid-manager.1
@@ -1,0 +1,59 @@
+.TH GRID-MANAGER 1 "March 2025" "Tahoe-LAFS" "User Commands"
+.
+.SH NAME
+grid-manager \- A Tahoe Grid Manager for issuing certificates to storage-servers.
+.
+.SH SYNOPSIS
+.B grid-manager
+[\fIOPTIONS\fR] \fICOMMAND\fR [\fIARGS\fR]...
+.
+.SH DESCRIPTION
+A Tahoe Grid Manager issues certificates to storage-servers.
+.
+A Tahoe client with one or more Grid Manager public keys configured will only upload to a Storage Server that presents a valid certificate signed by one of the configured Grid Manager keys.
+.
+Grid Manager configuration can be in a local directory or given via stdin. It contains long-term secret information (a private signing key) and should be kept safe.
+.
+.SH OPTIONS
+.TP
+.BR \-c , " --config " \fIPATH\fR
+Configuration directory (or \- for stdin). \fIRequired.\fR
+.TP
+.B \--help
+Show this message and exit.
+.
+.SH COMMANDS
+.TP
+.B add
+Add a new storage-server by name to a Grid Manager.
+.TP
+.B create
+Make a new Grid Manager.
+.TP
+.B list
+List all storage-servers known to a Grid Manager.
+.TP
+.B public-identity
+Show the public identity key of a Grid Manager.
+.TP
+.B remove
+Remove an existing storage-server by name from a Grid Manager.
+.TP
+.B sign
+Sign a new certificate.
+.
+.SH AUTHORS
+Tahoe-LAFS has been written by Brian Warner, Zooko Wilcox-O'Hearn, and numerous other contributors.
+.
+.SH REPORTING BUGS
+Please see <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug>.
+.
+Tahoe-LAFS home page: <https://tahoe-lafs.org/>
+.
+Tahoe-LAFS development mailing list: <https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev>
+.
+.SH COPYRIGHT
+Copyright \(co 2006\(en2025 The Tahoe-LAFS Software Foundation.
+.
+.SH SEE ALSO
+tahoe(1)

--- a/docs/man/man1/grid-manager.1
+++ b/docs/man/man1/grid-manager.1
@@ -20,7 +20,7 @@ Grid Manager configuration can be in a local directory or given via stdin. It co
 Configuration directory (or - for stdin). \fIRequired.\fR
 .TP
 .B \f[B]--help
-Show this message and exit.
+Show help message and exit.
 .
 .SH COMMANDS
 .TP

--- a/docs/man/man1/grid-manager.1
+++ b/docs/man/man1/grid-manager.1
@@ -48,11 +48,11 @@ Grid Manager has been written by meejah.
 Tahoe-LAFS has been written by Brian Warner, Zooko Wilcox-O'Hearn, and numerous other contributors.
 .
 .SH REPORTING BUGS
-Please see <https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug>.
+Please see https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug.
 .PP
-Tahoe-LAFS home page: <https://tahoe-lafs.org/>
+Tahoe-LAFS home page: https://tahoe-lafs.org/
 .PP
-Tahoe-LAFS development mailing list: <https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev>
+Tahoe-LAFS development mailing list: https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev
 .
 .SH COPYRIGHT
 Copyright \(co 2006\(en2025 The Tahoe-LAFS Software Foundation.
@@ -60,5 +60,5 @@ Copyright \(co 2006\(en2025 The Tahoe-LAFS Software Foundation.
 .SH SEE ALSO
 tahoe(1)
 .PP
-The Tahoe-LAFS documentation on Grid Managers has more detail than this manual page: <https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html>.
-It includes a tutorial-style step-by-step example on how to set up a managed grid: <https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html#example-setup-of-a-new-managed-grid>
+The Tahoe-LAFS documentation on Grid Managers has more detail than this manual page: https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html.
+It includes a tutorial-style step-by-step example on how to set up a managed grid: https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html#example-setup-of-a-new-managed-grid


### PR DESCRIPTION
Add man page for grid manager.

Towards fixing a warning from [Debian Lintian](https://udd.debian.org/lintian/?packages=tahoe-lafs):

    no-manual-page	1	[usr/bin/grid-manager]

[ticket:4169](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4169#ticket)