### PR TITLE
3943 Update integration test CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # 22.04 has some issue with Tor at the moment:
-          # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-14
           - windows-2022
         python-version:
@@ -167,7 +165,7 @@ jobs:
         force-foolscap:
           - false
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             python-version: "3.12"
             force-foolscap: true
     steps:


### PR DESCRIPTION
GitHub actions [deprecates the Ubuntu-20.04 image](https://github.com/actions/runner-images/issues/11101) we were still using because of https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943 .

Ubuntu-22.04 had an issue with Tor.
This PR bumps to 24.04, hoping that Tor issue has been resolved in the meantime.