### PR TITLE
3943 Install recent Chutney for Tor integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,21 +211,11 @@ jobs:
 
       - name: Run "Python 3 integration tests"
         if: "${{ !matrix.force-foolscap }}"
-        env:
-          # On macOS this is necessary to ensure unix socket paths for tor
-          # aren't too long. On Windows tox won't pass it through so it has no
-          # effect. On Linux it doesn't make a difference one way or another.
-          TMPDIR: "/tmp"
         run: |
           tox -e integration
 
       - name: Run "Python 3 integration tests (force Foolscap)"
         if: "${{ matrix.force-foolscap }}"
-        env:
-          # On macOS this is necessary to ensure unix socket paths for tor
-          # aren't too long. On Windows tox won't pass it through so it has no
-          # effect. On Linux it doesn't make a difference one way or another.
-          TMPDIR: "/tmp"
         run: |
           tox -e integration -- --force-foolscap integration/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,9 @@ jobs:
 
       - name: Install Tor [Ubuntu]
         if: ${{ contains(matrix.os, 'ubuntu') }}
-        run: sudo apt install tor
+        run: |
+          sudo add-apt-repository universe
+          sudo apt install tor
 
       # TODO: See https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3744.
       # We have to use an older version of Tor for running integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
           # aren't too long. On Windows tox won't pass it through so it has no
           # effect. On Linux it doesn't make a difference one way or another.
           TMPDIR: "/tmp"
+          # Tor doesn't want to start on Ubuntu-24.04 because of a too long
+          # file name for a socket.
+          CHUTNEY_ENABLE_CONTROLSOCKET: "false"
         run: |
           tox -e integration
 
@@ -226,6 +229,9 @@ jobs:
           # aren't too long. On Windows tox won't pass it through so it has no
           # effect. On Linux it doesn't make a difference one way or another.
           TMPDIR: "/tmp"
+          # Tor doesn't want to start on Ubuntu-24.04 because of a too long
+          # file name for a socket.
+          CHUTNEY_ENABLE_CONTROLSOCKET: "false"
         run: |
           tox -e integration -- --force-foolscap integration/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,6 @@ jobs:
           # aren't too long. On Windows tox won't pass it through so it has no
           # effect. On Linux it doesn't make a difference one way or another.
           TMPDIR: "/tmp"
-          # Tor doesn't want to start on Ubuntu-24.04 because of a too long
-          # file name for a socket.
-          CHUTNEY_ENABLE_CONTROLSOCKET: "false"
         run: |
           tox -e integration
 
@@ -229,9 +226,6 @@ jobs:
           # aren't too long. On Windows tox won't pass it through so it has no
           # effect. On Linux it doesn't make a difference one way or another.
           TMPDIR: "/tmp"
-          # Tor doesn't want to start on Ubuntu-24.04 because of a too long
-          # file name for a socket.
-          CHUTNEY_ENABLE_CONTROLSOCKET: "false"
         run: |
           tox -e integration -- --force-foolscap integration/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,8 @@ jobs:
       - name: Install Tor [Ubuntu]
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
-          sudo gpg --keyserver keyserver.ubuntu.com --recv-keys 74A941BA219EC810
-          sudo gpg --export 74A941BA219EC810 | sudo tee /usr/share/keyrings/tor-archive-keyring.gpg > /dev/null
+          gpg --keyserver keyserver.ubuntu.com --recv-keys 74A941BA219EC810
+          gpg --export 74A941BA219EC810 | sudo tee /usr/share/keyrings/tor-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org noble main" | sudo tee /etc/apt/sources.list.d/tor.list
           sudo apt update
           sudo apt install tor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,10 @@ jobs:
       - name: Install Tor [Ubuntu]
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
-          sudo add-apt-repository universe
+          sudo gpg --keyserver keyserver.ubuntu.com --recv-keys 74A941BA219EC810
+          sudo gpg --export 74A941BA219EC810 | sudo tee /usr/share/keyrings/tor-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org noble main" | sudo tee /etc/apt/sources.list.d/tor.list
+          sudo apt update
           sudo apt install tor
 
       # TODO: See https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3744.

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -316,7 +316,7 @@ def chutney(reactor, temp_dir: str) -> FilePath:
 
     missing = [exe for exe in ["tor", "tor-gencert"] if not which(exe)]
     if missing:
-        pytest.skip(f"Some command-line tools not found: {missing}")
+        pytest.fail(f"Some command-line tools not found: {missing}")
 
     # The directory with all of the network definitions.
     return FilePath(chutney.__file__).parent().child("data")

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -319,7 +319,7 @@ def chutney(reactor, temp_dir: str) -> FilePath:
         pytest.skip(f"Some command-line tools not found: {missing}")
 
     # The directory with all of the network definitions.
-    return FilePath(chutney.__file__).parent().child("data").path
+    return FilePath(chutney.__file__).parent().child("data")
 
 
 @frozen
@@ -362,7 +362,7 @@ def tor_network(reactor, temp_dir, chutney, request):
 
     :return: None
     """
-    chutney_root = chutney
+    chutney_root = chutney.path
     basic_network = join(chutney_root, 'networks', 'basic-min')
 
     env = environ.copy()

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -309,7 +309,7 @@ def bob(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, reques
 @pytest.fixture(scope='session')
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     'Tor tests are unstable on Windows')
-def chutney(reactor, temp_dir: str) -> tuple[str, dict[str, str]]:
+def chutney(reactor, temp_dir: str) -> FilePath:
     """
     Install the Chutney software that is required to run a small local Tor grid.
     """
@@ -319,12 +319,8 @@ def chutney(reactor, temp_dir: str) -> tuple[str, dict[str, str]]:
     if missing:
         pytest.skip(f"Some command-line tools not found: {missing}")
 
-    return (
-        # The directory with all of the network definitions.
-        FilePath(chutney.__file__).parent().child("data").path,
-        # There's nothing to add to the environment.
-        {},
-    )
+    # The directory with all of the network definitions.
+    return FilePath(chutney.__file__).parent().child("data").path
 
 
 @frozen
@@ -334,7 +330,6 @@ class ChutneyTorNetwork:
     "tor_network" fixture.
     """
     dir: FilePath
-    environ: Mapping[str, str]
     client_control_port: int
 
     @property
@@ -368,11 +363,10 @@ def tor_network(reactor, temp_dir, chutney, request):
 
     :return: None
     """
-    chutney_root, chutney_env = chutney
+    chutney_root = chutney
     basic_network = join(chutney_root, 'networks', 'basic-min')
 
     env = environ.copy()
-    env.update(chutney_env)
     env.update({
         # default is 60, probably too short for reliable automated use.
         "CHUTNEY_START_TIME": "180",
@@ -442,6 +436,5 @@ def tor_network(reactor, temp_dir, chutney, request):
     # and then examining "net/nodes/005c/torrc" for ControlPort value
     return ChutneyTorNetwork(
         chutney_root,
-        chutney_env,
         8005,
     )

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -370,7 +370,7 @@ def tor_network(reactor, temp_dir, chutney, request):
     :return: None
     """
     chutney_root, chutney_env = chutney
-    basic_network = join(chutney_root, 'networks', 'basic')
+    basic_network = join(chutney_root, 'networks', 'basic-min')
 
     env = environ.copy()
     env.update(chutney_env)

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -361,7 +361,7 @@ def tor_network(reactor, temp_dir, chutney, request):
     and 9009)
 
     The control ports start at 8000 (so the ControlPort for the client
-    nodes are 8008 and 8009).
+    node is 8005).
 
     :param chutney: The root directory of a Chutney checkout and a dict of
         additional environment variables to set so a Python process can use
@@ -439,10 +439,10 @@ def tor_network(reactor, temp_dir, chutney, request):
     except ProcessTerminated:
         print("Chutney.TorNet status failed (continuing)")
 
-    # the "8008" comes from configuring "networks/basic" in chutney
-    # and then examining "net/nodes/008c/torrc" for ControlPort value
+    # the "8005" comes from configuring "networks/basic" in chutney
+    # and then examining "net/nodes/005c/torrc" for ControlPort value
     return ChutneyTorNetwork(
         chutney_root,
         chutney_env,
-        8008,
+        8005,
     )

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -28,7 +28,6 @@ from twisted.internet.error import (
 
 import pytest
 import pytest_twisted
-from typing import Mapping
 
 from .util import (
     _MagicTextProtocol,

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -349,16 +349,15 @@ def tor_network(reactor, temp_dir, chutney, request):
     """
     Build a basic Tor network.
 
-    Instantiate the "networks/basic" Chutney configuration for a local
-    Tor network.
+    Instantiate the "networks/basic-min" Chutney configuration for
+    a local Tor network.
 
     This provides a small, local Tor network that can run v3 Onion
-    Services. It has 3 authorities, 5 relays and 2 clients.
+    Services.
 
-    The 'chutney' fixture pins a Chutney git qrevision, so things
-    shouldn't change. This network has two clients which are the only
-    nodes with valid SocksPort configuration ("008c" and "009c" 9008
-    and 9009)
+    The 'chutney' fixture pins a Chutney git revision, so things
+    shouldn't change. This network has one client which is the only
+    node with a valid SocksPort configuration ("005c" and 9005).
 
     The control ports start at 8000 (so the ControlPort for the client
     node is 8005).
@@ -376,7 +375,7 @@ def tor_network(reactor, temp_dir, chutney, request):
     env.update(chutney_env)
     env.update({
         # default is 60, probably too short for reliable automated use.
-        "CHUTNEY_START_TIME": "1200",
+        "CHUTNEY_START_TIME": "180",
     })
     chutney_argv = (sys.executable, '-m', 'chutney.TorNet')
     def chutney(argv):

--- a/integration/test_tor.py
+++ b/integration/test_tor.py
@@ -30,7 +30,6 @@ from allmydata.util.deferredutil import async_to_deferred
 if sys.platform.startswith('win'):
     pytest.skip('Skipping Tor tests on Windows', allow_module_level=True)
 
-@pytest.mark.skipif(sys.version_info[:2] > (3, 11), reason='Chutney still does not support 3.12')
 @pytest_twisted.inlineCallbacks
 def test_onion_service_storage(reactor, request, temp_dir, flog_gatherer, tor_network, tor_introducer_furl):
     """
@@ -141,7 +140,6 @@ def _create_anonymous_node(reactor, name, web_port, request, temp_dir, flog_gath
     print("okay, launched")
     return result
 
-@pytest.mark.skipif(sys.version_info[:2] > (3, 11), reason='Chutney still does not support 3.12')
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='This test has issues on macOS')
 @pytest_twisted.inlineCallbacks
 def test_anonymous_client(reactor, request, temp_dir, flog_gatherer, tor_network, introducer_furl):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,9 @@ test = [
     "prometheus-client == 0.11.0",
 
     "tahoe-lafs[tor]",  # our own "tor" extra
-    "tahoe-lafs[i2p]"  # our own "i2p" extra
+    "tahoe-lafs[i2p]",  # our own "i2p" extra
+    # Chutney with recent additions to make it a Python package:
+    "chutney @ git+https://gitlab.torproject.org/tpo/core/chutney@f25094db31fbbec7e88ae5801dd2dcf2d6d9ae5d"
 ]
 
 
@@ -297,3 +299,7 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/allmydata"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,7 @@ platform = mylinux: linux
            mywindows: win32
 setenv =
          COVERAGE_PROCESS_START=.coveragerc
+         CHUTNEY_ENABLE_CONTROLSOCKET=false
 deps =
      # Get Chutney for Tor integration tests
      git+https://gitlab.torproject.org/tpo/core/chutney@f25094db31fbbec7e88ae5801dd2dcf2d6d9ae5d

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,9 @@ platform = mylinux: linux
            mywindows: win32
 setenv =
          COVERAGE_PROCESS_START=.coveragerc
+deps =
+     # Get Chutney for Tor integration tests
+     git+https://gitlab.torproject.org/tpo/core/chutney@f25094db31fbbec7e88ae5801dd2dcf2d6d9ae5d
 commands =
          # NOTE: 'run with "py.test --keep-tempdir -s -v integration/" to debug failures'
          py.test --timeout=1800 --coverage -s -v {posargs:integration}


### PR DESCRIPTION
We had to work-around for Chutney not supporting Python 3.12 and not having the "normal Python stuff" for installation.

It does now and we can have much simpler logic.

Ticket: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943