### PR TITLE
3943 Re-enable Tor tests on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # 22.04 has some issue with Tor at the moment:
-          # https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3943
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-14
           - windows-2022
         python-version:
@@ -167,7 +165,7 @@ jobs:
         force-foolscap:
           - false
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             python-version: "3.12"
             force-foolscap: true
     steps:

--- a/docs/man/man1/grid-manager.1
+++ b/docs/man/man1/grid-manager.1
@@ -1,0 +1,76 @@
+.TH GRID-MANAGER 1 "March 2025" "Tahoe-LAFS" "User Commands"
+.
+.SH NAME
+grid-manager \- A Tahoe Grid Manager for issuing certificates to storage-servers.
+.
+.SH SYNOPSIS
+.B grid-manager
+[\fIOPTIONS\fR] \fICOMMAND\fR [\fIARGS\fR]...
+.
+.SH DESCRIPTION
+A Tahoe Grid Manager issues certificates to storage-servers.
+.
+A Tahoe client with one or more Grid Manager public keys configured will only upload to a Storage Server that presents a valid certificate signed by one of the configured Grid Manager keys.
+.
+Grid Manager configuration can be in a local directory or given via stdin. It contains long-term secret information (a private signing key) and should be kept safe.
+.
+.SH OPTIONS
+.TP
+.BR \f[B]-c,\ --config\ \fIPATH\fR
+Configuration directory (or - for stdin). \fIRequired.\fR
+.TP
+.B \f[B]--help
+Show help message and exit.
+.
+.SH COMMANDS
+.TP
+.B add
+Add a new storage-server by name to a Grid Manager.
+.TP
+.B create
+Make a new Grid Manager.
+.TP
+.B list
+List all storage-servers known to a Grid Manager.
+.TP
+.B public-identity
+Show the public identity key of a Grid Manager.
+.TP
+.B remove
+Remove an existing storage-server by name from a Grid Manager.
+.TP
+.B sign
+Sign a new certificate.
+.
+.SH AUTHORS
+Grid Manager has been written by meejah.
+.PP
+Tahoe-LAFS has been written by Brian Warner, Zooko Wilcox-O'Hearn, and numerous other contributors.
+.
+.SH REPORTING BUGS
+Please see
+.UR https://tahoe-lafs.org/trac/tahoe-lafs/wiki/HowToReportABug
+.UE
+.
+.PP
+Tahoe-LAFS home page:
+.UR https://tahoe-lafs.org/
+.UE
+.PP
+Tahoe-LAFS development mailing list:
+.UR https://lists.tahoe-lafs.org/mailman/listinfo/tahoe-dev
+.UE
+.
+.SH COPYRIGHT
+Copyright \(co 2006\(en2025 The Tahoe-LAFS Software Foundation.
+.
+.SH SEE ALSO
+.MR tahoe 1
+.PP
+The Tahoe-LAFS documentation on Grid Managers has more detail than this manual page:
+.UR https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html
+.UE
+.PP
+It includes a step-by-step tutorial on how to set up a managed grid:
+.UR https://tahoe-lafs.readthedocs.io/en/latest/managed-grid.html#example-setup-of-a-new-managed-grid
+.UE

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -306,8 +306,6 @@ def bob(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, reques
 
 
 @pytest.fixture(scope='session')
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    'Tor tests are unstable on Windows')
 def chutney(reactor, temp_dir: str) -> FilePath:
     """
     Install the Chutney software that is required to run a small local Tor grid.
@@ -337,8 +335,6 @@ class ChutneyTorNetwork:
 
 
 @pytest.fixture(scope='session')
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    reason='Tor tests are unstable on Windows')
 def tor_network(reactor, temp_dir, chutney, request):
     """
     Build a basic Tor network.

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -319,7 +319,7 @@ def chutney(reactor, temp_dir: str) -> FilePath:
         pytest.skip(f"Some command-line tools not found: {missing}")
 
     # The directory with all of the network definitions.
-    return FilePath(chutney.__file__).parent().child("data").path
+    return FilePath(chutney.__file__).parent().child("data")
 
 
 @frozen
@@ -362,7 +362,7 @@ def tor_network(reactor, temp_dir, chutney, request):
 
     :return: None
     """
-    chutney_root = chutney
+    chutney_root = chutney.path
     basic_network = join(chutney_root, 'networks', 'basic-min')
 
     env = environ.copy()

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -309,7 +309,7 @@ def bob(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, reques
 @pytest.fixture(scope='session')
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     'Tor tests are unstable on Windows')
-def chutney(reactor, temp_dir: str) -> tuple[str, dict[str, str]]:
+def chutney(reactor, temp_dir: str) -> FilePath:
     """
     Install the Chutney software that is required to run a small local Tor grid.
     """
@@ -319,12 +319,8 @@ def chutney(reactor, temp_dir: str) -> tuple[str, dict[str, str]]:
     if missing:
         pytest.skip(f"Some command-line tools not found: {missing}")
 
-    return (
-        # The directory with all of the network definitions.
-        FilePath(chutney.__file__).parent().child("data").path,
-        # There's nothing to add to the environment.
-        {},
-    )
+    # The directory with all of the network definitions.
+    return FilePath(chutney.__file__).parent().child("data").path
 
 
 @frozen
@@ -334,7 +330,6 @@ class ChutneyTorNetwork:
     "tor_network" fixture.
     """
     dir: FilePath
-    environ: Mapping[str, str]
     client_control_port: int
 
     @property
@@ -368,11 +363,10 @@ def tor_network(reactor, temp_dir, chutney, request):
 
     :return: None
     """
-    chutney_root, chutney_env = chutney
+    chutney_root = chutney
     basic_network = join(chutney_root, 'networks', 'basic-min')
 
     env = environ.copy()
-    env.update(chutney_env)
     env.update({
         # default is 60, probably too short for reliable automated use.
         "CHUTNEY_START_TIME": "180",
@@ -442,6 +436,5 @@ def tor_network(reactor, temp_dir, chutney, request):
     # and then examining "net/nodes/005c/torrc" for ControlPort value
     return ChutneyTorNetwork(
         chutney_root,
-        chutney_env,
         8005,
     )

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -370,7 +370,7 @@ def tor_network(reactor, temp_dir, chutney, request):
     :return: None
     """
     chutney_root, chutney_env = chutney
-    basic_network = join(chutney_root, 'networks', 'basic')
+    basic_network = join(chutney_root, 'networks', 'basic-min')
 
     env = environ.copy()
     env.update(chutney_env)

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -361,7 +361,7 @@ def tor_network(reactor, temp_dir, chutney, request):
     and 9009)
 
     The control ports start at 8000 (so the ControlPort for the client
-    nodes are 8008 and 8009).
+    node is 8005).
 
     :param chutney: The root directory of a Chutney checkout and a dict of
         additional environment variables to set so a Python process can use
@@ -439,10 +439,10 @@ def tor_network(reactor, temp_dir, chutney, request):
     except ProcessTerminated:
         print("Chutney.TorNet status failed (continuing)")
 
-    # the "8008" comes from configuring "networks/basic" in chutney
-    # and then examining "net/nodes/008c/torrc" for ControlPort value
+    # the "8005" comes from configuring "networks/basic" in chutney
+    # and then examining "net/nodes/005c/torrc" for ControlPort value
     return ChutneyTorNetwork(
         chutney_root,
         chutney_env,
-        8008,
+        8005,
     )

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -28,7 +28,6 @@ from twisted.internet.error import (
 
 import pytest
 import pytest_twisted
-from typing import Mapping
 
 from .util import (
     _MagicTextProtocol,

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -349,16 +349,15 @@ def tor_network(reactor, temp_dir, chutney, request):
     """
     Build a basic Tor network.
 
-    Instantiate the "networks/basic" Chutney configuration for a local
-    Tor network.
+    Instantiate the "networks/basic-min" Chutney configuration for
+    a local Tor network.
 
     This provides a small, local Tor network that can run v3 Onion
-    Services. It has 3 authorities, 5 relays and 2 clients.
+    Services.
 
-    The 'chutney' fixture pins a Chutney git qrevision, so things
-    shouldn't change. This network has two clients which are the only
-    nodes with valid SocksPort configuration ("008c" and "009c" 9008
-    and 9009)
+    The 'chutney' fixture pins a Chutney git revision, so things
+    shouldn't change. This network has one client which is the only
+    node with a valid SocksPort configuration ("005c" and 9005).
 
     The control ports start at 8000 (so the ControlPort for the client
     node is 8005).
@@ -376,7 +375,7 @@ def tor_network(reactor, temp_dir, chutney, request):
     env.update(chutney_env)
     env.update({
         # default is 60, probably too short for reliable automated use.
-        "CHUTNEY_START_TIME": "1200",
+        "CHUTNEY_START_TIME": "180",
     })
     chutney_argv = (sys.executable, '-m', 'chutney.TorNet')
     def chutney(argv):

--- a/integration/test_tor.py
+++ b/integration/test_tor.py
@@ -23,13 +23,6 @@ from allmydata.util.deferredutil import async_to_deferred
 
 # see "conftest.py" for the fixtures (e.g. "tor_network")
 
-# XXX: Integration tests that involve Tor do not run reliably on
-# Windows.  They are skipped for now, in order to reduce CI noise.
-#
-# https://tahoe-lafs.org/trac/tahoe-lafs/ticket/3347
-if sys.platform.startswith('win'):
-    pytest.skip('Skipping Tor tests on Windows', allow_module_level=True)
-
 @pytest_twisted.inlineCallbacks
 def test_onion_service_storage(reactor, request, temp_dir, flog_gatherer, tor_network, tor_introducer_furl):
     """

--- a/integration/test_tor.py
+++ b/integration/test_tor.py
@@ -30,7 +30,6 @@ from allmydata.util.deferredutil import async_to_deferred
 if sys.platform.startswith('win'):
     pytest.skip('Skipping Tor tests on Windows', allow_module_level=True)
 
-@pytest.mark.skipif(sys.version_info[:2] > (3, 11), reason='Chutney still does not support 3.12')
 @pytest_twisted.inlineCallbacks
 def test_onion_service_storage(reactor, request, temp_dir, flog_gatherer, tor_network, tor_introducer_furl):
     """
@@ -141,7 +140,6 @@ def _create_anonymous_node(reactor, name, web_port, request, temp_dir, flog_gath
     print("okay, launched")
     return result
 
-@pytest.mark.skipif(sys.version_info[:2] > (3, 11), reason='Chutney still does not support 3.12')
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='This test has issues on macOS')
 @pytest_twisted.inlineCallbacks
 def test_anonymous_client(reactor, request, temp_dir, flog_gatherer, tor_network, introducer_furl):

--- a/integration/test_tor.py
+++ b/integration/test_tor.py
@@ -133,7 +133,6 @@ def _create_anonymous_node(reactor, name, web_port, request, temp_dir, flog_gath
     print("okay, launched")
     return result
 
-@pytest.mark.skipif(sys.platform.startswith('darwin'), reason='This test has issues on macOS')
 @pytest_twisted.inlineCallbacks
 def test_anonymous_client(reactor, request, temp_dir, flog_gatherer, tor_network, introducer_furl):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,9 @@ test = [
     "prometheus-client == 0.11.0",
 
     "tahoe-lafs[tor]",  # our own "tor" extra
-    "tahoe-lafs[i2p]"  # our own "i2p" extra
+    "tahoe-lafs[i2p]",  # our own "i2p" extra
+    # Chutney with recent additions to make it a Python package:
+    "chutney @ git+https://gitlab.torproject.org/tpo/core/chutney@f25094db31fbbec7e88ae5801dd2dcf2d6d9ae5d"
 ]
 
 
@@ -297,3 +299,7 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/allmydata"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+

--- a/src/allmydata/test/cli/test_grid_manager.py
+++ b/src/allmydata/test/cli/test_grid_manager.py
@@ -90,7 +90,7 @@ class GridManagerCommandLine(TestCase):
             self.assertEqual(1, result.exit_code)
             self.assertIn(
                 "Can't create",
-                result.stdout,
+                result.output,
             )
 
     def test_create_stdout(self):

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,9 @@ platform = mylinux: linux
            mywindows: win32
 setenv =
          COVERAGE_PROCESS_START=.coveragerc
+deps =
+     # Get Chutney for Tor integration tests
+     git+https://gitlab.torproject.org/tpo/core/chutney@f25094db31fbbec7e88ae5801dd2dcf2d6d9ae5d
 commands =
          # NOTE: 'run with "py.test --keep-tempdir -s -v integration/" to debug failures'
          py.test --timeout=1800 --coverage -s -v {posargs:integration}


### PR DESCRIPTION
This sits on top of #1435 and #1434.

----

Experimental: Enable all Tor integration tests for all platforms again and see how they fare.