### PR TITLE
Migrate to modern testing interface

### DIFF
--- a/newsfragments/4179.minor
+++ b/newsfragments/4179.minor
@@ -1,0 +1,1 @@
+Migrate to modern testing interface

--- a/src/allmydata/test/cli/test_cp.py
+++ b/src/allmydata/test/cli/test_cp.py
@@ -261,7 +261,7 @@ class Cp(GridTestMixin, CLITestMixin, unittest.TestCase):
 
         for i in range(1, 4):
             with open(os.path.join(self.basedir, "test%d" % (i,), "file"), "rb") as f:
-                self.assertEquals(f.read(), data)
+                self.assertEqual(f.read(), data)
 
     @defer.inlineCallbacks
     def test_cp_immutable_file(self):

--- a/src/allmydata/test/cli/test_grid_manager.py
+++ b/src/allmydata/test/cli/test_grid_manager.py
@@ -169,7 +169,7 @@ class GridManagerCommandLine(TestCase):
             self.invoke_and_check(grid_manager, ["--config", "foo", "create"])
             self.invoke_and_check(grid_manager, ["--config", "foo", "add", "storage0", pubkey0])
             result = self.runner.invoke(grid_manager, ["--config", "foo", "add", "storage0", pubkey1])
-            self.assertNotEquals(result.exit_code, 0)
+            self.assertNotEqual(result.exit_code, 0)
             self.assertIn(
                 "A storage-server called 'storage0' already exists",
                 result.output,
@@ -200,12 +200,12 @@ class GridManagerCommandLine(TestCase):
 
     def test_remove_missing(self):
         """
-        Error reported when removing non-existant server
+        Error reported when removing non-existent server
         """
         with self.runner.isolated_filesystem():
             self.invoke_and_check(grid_manager, ["--config", "foo", "create"])
             result = self.runner.invoke(grid_manager, ["--config", "foo", "remove", "storage0"])
-            self.assertNotEquals(result.exit_code, 0)
+            self.assertNotEqual(result.exit_code, 0)
             self.assertIn(
                 "No storage-server called 'storage0' exists",
                 result.output,
@@ -213,12 +213,12 @@ class GridManagerCommandLine(TestCase):
 
     def test_sign_missing(self):
         """
-        Error reported when signing non-existant server
+        Error reported when signing non-existent server
         """
         with self.runner.isolated_filesystem():
             self.invoke_and_check(grid_manager, ["--config", "foo", "create"])
             result = self.runner.invoke(grid_manager, ["--config", "foo", "sign", "storage0", "42"])
-            self.assertNotEquals(result.exit_code, 0)
+            self.assertNotEqual(result.exit_code, 0)
             self.assertIn(
                 "No storage-server called 'storage0' exists",
                 result.output,
@@ -237,7 +237,7 @@ class GridManagerCommandLine(TestCase):
             # make the directory un-writable (so we can't create a new cert)
             os.chmod("foo", 0o550)
             result = self.runner.invoke(grid_manager, ["--config", "foo", "sign", "storage0", "42"])
-            self.assertEquals(result.exit_code, 1)
+            self.assertEqual(result.exit_code, 1)
             self.assertIn(
                 "Permission denied",
                 result.output,

--- a/src/allmydata/test/common.py
+++ b/src/allmydata/test/common.py
@@ -970,7 +970,7 @@ class WebErrorMixin:
         response = yield treq.request(method, url, persistent=persistent,
                                       **args)
         body = yield response.content()
-        self.assertEquals(response.code, code)
+        self.assertEqual(response.code, code)
         if response_substring is not None:
             if isinstance(response_substring, str):
                 response_substring = response_substring.encode("utf-8")

--- a/src/allmydata/test/mutable/test_problems.py
+++ b/src/allmydata/test/mutable/test_problems.py
@@ -232,7 +232,7 @@ class Problems(GridTestMixin, AsyncTestCase, testutil.ShouldFailMixin):
         # that ought to work
         def _got_node(n):
             d = n.download_best_version()
-            d.addCallback(lambda res: self.assertEquals(res, b"contents 1"))
+            d.addCallback(lambda res: self.assertEqual(res, b"contents 1"))
             # now break the second peer
             def _break_peer1(res):
                 self.g.break_server(self.server1.get_serverid())
@@ -240,7 +240,7 @@ class Problems(GridTestMixin, AsyncTestCase, testutil.ShouldFailMixin):
             d.addCallback(lambda res: n.overwrite(MutableData(b"contents 2")))
             # that ought to work too
             d.addCallback(lambda res: n.download_best_version())
-            d.addCallback(lambda res: self.assertEquals(res, b"contents 2"))
+            d.addCallback(lambda res: self.assertEqual(res, b"contents 2"))
             def _explain_error(f):
                 print(f)
                 if f.check(NotEnoughServersError):
@@ -272,7 +272,7 @@ class Problems(GridTestMixin, AsyncTestCase, testutil.ShouldFailMixin):
         d = nm.create_mutable_file(MutableData(b"contents 1"))
         def _created(n):
             d = n.download_best_version()
-            d.addCallback(lambda res: self.assertEquals(res, b"contents 1"))
+            d.addCallback(lambda res: self.assertEqual(res, b"contents 1"))
             # now break one of the remaining servers
             def _break_second_server(res):
                 self.g.break_server(peerids[1])
@@ -280,7 +280,7 @@ class Problems(GridTestMixin, AsyncTestCase, testutil.ShouldFailMixin):
             d.addCallback(lambda res: n.overwrite(MutableData(b"contents 2")))
             # that ought to work too
             d.addCallback(lambda res: n.download_best_version())
-            d.addCallback(lambda res: self.assertEquals(res, b"contents 2"))
+            d.addCallback(lambda res: self.assertEqual(res, b"contents 2"))
             return d
         d.addCallback(_created)
         return d
@@ -411,7 +411,7 @@ class Problems(GridTestMixin, AsyncTestCase, testutil.ShouldFailMixin):
             return self._node.download_version(servermap, ver)
         d.addCallback(_then)
         d.addCallback(lambda data:
-            self.assertEquals(data, CONTENTS))
+            self.assertEqual(data, CONTENTS))
         return d
 
     def test_1654(self):

--- a/src/allmydata/test/mutable/test_repair.py
+++ b/src/allmydata/test/mutable/test_repair.py
@@ -221,7 +221,7 @@ class Repair(AsyncTestCase, PublishMixin, ShouldFailMixin):
             new_versionid = smap.best_recoverable_version()
             self.assertThat(new_versionid[0], Equals(5)) # seqnum 5
             d2 = self._fn.download_version(smap, new_versionid)
-            d2.addCallback(self.assertEquals, expected_contents)
+            d2.addCallback(self.assertEqual, expected_contents)
             return d2
         d.addCallback(_check_smap)
         return d

--- a/src/allmydata/test/test_multi_introducers.py
+++ b/src/allmydata/test/test_multi_introducers.py
@@ -110,7 +110,7 @@ class MultiIntroTests(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             yield create_client(self.basedir)
 
-        self.assertEquals(
+        self.assertEqual(
             str(ctx.exception),
             "'default' introducer furl cannot be specified in tahoe.cfg and introducers.yaml; "
             "please fix impossible configuration.",
@@ -154,14 +154,14 @@ class NoDefault(unittest.TestCase):
         self.yaml_path.setContent(ensure_binary(yamlutil.safe_dump(connections)))
         myclient = yield create_client(self.basedir)
         tahoe_cfg_furl = myclient.introducer_clients[0].introducer_furl
-        self.assertEquals(tahoe_cfg_furl, b'furl1')
+        self.assertEqual(tahoe_cfg_furl, b'furl1')
 
     @defer.inlineCallbacks
     def test_real_yaml(self):
         self.yaml_path.setContent(SIMPLE_YAML)
         myclient = yield create_client(self.basedir)
         tahoe_cfg_furl = myclient.introducer_clients[0].introducer_furl
-        self.assertEquals(tahoe_cfg_furl, b'furl1')
+        self.assertEqual(tahoe_cfg_furl, b'furl1')
 
     @defer.inlineCallbacks
     def test_invalid_equals_yaml(self):
@@ -178,4 +178,4 @@ class NoDefault(unittest.TestCase):
         connections = {'introducers': {} }
         self.yaml_path.setContent(ensure_binary(yamlutil.safe_dump(connections)))
         myclient = yield create_client(self.basedir)
-        self.assertEquals(len(myclient.introducer_clients), 0)
+        self.assertEqual(len(myclient.introducer_clients), 0)

--- a/src/allmydata/test/test_node.py
+++ b/src/allmydata/test/test_node.py
@@ -249,7 +249,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
             f.write("[node]\n")
         config = read_config(basedir, "")
 
-        self.assertEquals(config.get_config("node", "log_gatherer.furl", "def"), "def")
+        self.assertEqual(config.get_config("node", "log_gatherer.furl", "def"), "def")
         with self.assertRaises(MissingConfigEntry):
             config.get_config("node", "log_gatherer.furl")
 
@@ -262,7 +262,7 @@ class TestCase(testutil.SignalMixin, unittest.TestCase):
         with open(os.path.join(basedir, 'tahoe.cfg'), 'w'):
             pass
         config = read_config(basedir, "")
-        self.assertEquals(
+        self.assertEqual(
             config.enumerate_section("not-a-section"),
             {}
         )

--- a/src/allmydata/test/test_system.py
+++ b/src/allmydata/test/test_system.py
@@ -1154,7 +1154,7 @@ class SystemTest(SystemTestMixin, RunBinTahoeMixin, unittest.TestCase):
             d1 = self.GET("uri/%s?filename=%s"
                           % (str(self.mangle_uri(self.uri), "utf-8"), "mydata567"))
             e = yield self.assertFailure(d1, Error)
-            self.assertEquals(e.status, b"410")
+            self.assertEqual(e.status, b"410")
         d.addCallback(_get_from_bogus_uri)
         d.addCallback(self.log, "_got_from_bogus_uri", level=log.UNUSUAL)
 

--- a/src/allmydata/test/web/test_root.py
+++ b/src/allmydata/test/web/test_root.py
@@ -209,7 +209,7 @@ class RenderRoot(AsyncTestCase):
         raw_js = b"".join(lines).decode("utf8")
         js = json.loads(raw_js)
         servers = js["servers"]
-        self.assertEquals(len(servers), 2)
+        self.assertEqual(len(servers), 2)
         self.assertIn(
             {
                 "connection_status": "summary0",

--- a/src/allmydata/test/web/test_web.py
+++ b/src/allmydata/test/web/test_web.py
@@ -839,7 +839,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
             decoded = json.loads(res)
             self.assertEqual(decoded['introducers'], {u'statuses': []})
             actual_servers = decoded[u"servers"]
-            self.assertEquals(len(actual_servers), 2)
+            self.assertEqual(len(actual_servers), 2)
             self.assertIn(
                 {
                     u"nodeid": u'other_nodeid',
@@ -4349,7 +4349,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
         self.assertIn(response.code, codes)
         location = response.headers.getRawHeaders(b"location")[0]
         if target_location is not None:
-            self.assertEquals(str(location, "ascii"), target_location)
+            self.assertEqual(str(location, "ascii"), target_location)
         returnValue(location)
 
     @inlineCallbacks
@@ -4898,7 +4898,7 @@ class Web(WebMixin, WebErrorMixin, testutil.StallMixin, testutil.ReallyEqualMixi
         # If os.stat raises an exception for the missing directory and the
         # traceback reveals the parent directory name we don't want to see
         # that parent directory name in the response.  This addresses #1720.
-        d.addCallback(lambda e: self.assertEquals(str(e), "404 Not Found"))
+        d.addCallback(lambda e: self.assertEqual(str(e), "404 Not Found"))
         return d
 
 


### PR DESCRIPTION
## PR Summary
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```