### PR TITLE
4190 failUnlessRaises has been deprecated

### DIFF
--- a/src/allmydata/test/cli/test_backup.py
+++ b/src/allmydata/test/cli/test_backup.py
@@ -350,7 +350,7 @@ class Backup(GridTestMixin, CLITestMixin, StallMixin, unittest.TestCase):
         self._check_filtering(filtered, subdir_listdir, (u'another_doc.lyx', u'CVS'),
                               (u'.svn', u'_darcs', u'run_snake_run.py'))
         # test BackupConfigurationError
-        self.failUnlessRaises(cli.BackupConfigurationError,
+        self.assertRaises(cli.BackupConfigurationError,
                               parse,
                               ['--exclude-from-utf-8', excl_filepath + '.no', 'from', 'to'])
 

--- a/src/allmydata/test/cli/test_cli.py
+++ b/src/allmydata/test/cli/test_cli.py
@@ -398,9 +398,9 @@ class CLI(CLITestMixin, unittest.TestCase):
         self.failUnlessReallyEqual(ga1(u"URI:stuff:./file"), (b"URI:stuff", b"file"))
         self.failUnlessReallyEqual(ga1(u"URI:stuff/dir/file"), (b"URI:stuff", b"dir/file"))
         self.failUnlessReallyEqual(ga1(u"URI:stuff:./dir/file"), (b"URI:stuff", b"dir/file"))
-        self.failUnlessRaises(common.UnknownAliasError, ga1, u"missing:")
-        self.failUnlessRaises(common.UnknownAliasError, ga1, u"missing:dir")
-        self.failUnlessRaises(common.UnknownAliasError, ga1, u"missing:dir/file")
+        self.assertRaises(common.UnknownAliasError, ga1, u"missing:")
+        self.assertRaises(common.UnknownAliasError, ga1, u"missing:dir")
+        self.assertRaises(common.UnknownAliasError, ga1, u"missing:dir/file")
 
         def ga2(path):
             return get_alias(aliases, path, None)
@@ -433,9 +433,9 @@ class CLI(CLITestMixin, unittest.TestCase):
         self.failUnlessReallyEqual(ga2(u"URI:stuff:./file"), (b"URI:stuff", b"file"))
         self.failUnlessReallyEqual(ga2(u"URI:stuff/dir/file"), (b"URI:stuff", b"dir/file"))
         self.failUnlessReallyEqual(ga2(u"URI:stuff:./dir/file"), (b"URI:stuff", b"dir/file"))
-        self.failUnlessRaises(common.UnknownAliasError, ga2, u"missing:")
-        self.failUnlessRaises(common.UnknownAliasError, ga2, u"missing:dir")
-        self.failUnlessRaises(common.UnknownAliasError, ga2, u"missing:dir/file")
+        self.assertRaises(common.UnknownAliasError, ga2, u"missing:")
+        self.assertRaises(common.UnknownAliasError, ga2, u"missing:dir")
+        self.assertRaises(common.UnknownAliasError, ga2, u"missing:dir/file")
 
         def ga3(path):
             old = common.pretend_platform_uses_lettercolon
@@ -465,16 +465,16 @@ class CLI(CLITestMixin, unittest.TestCase):
         self.failUnlessReallyEqual(ga3(u"URI:stuff"), (b"URI:stuff", b""))
         self.failUnlessReallyEqual(ga3(u"URI:stuff:./file"), (b"URI:stuff", b"file"))
         self.failUnlessReallyEqual(ga3(u"URI:stuff:./dir/file"), (b"URI:stuff", b"dir/file"))
-        self.failUnlessRaises(common.UnknownAliasError, ga3, u"missing:")
-        self.failUnlessRaises(common.UnknownAliasError, ga3, u"missing:dir")
-        self.failUnlessRaises(common.UnknownAliasError, ga3, u"missing:dir/file")
+        self.assertRaises(common.UnknownAliasError, ga3, u"missing:")
+        self.assertRaises(common.UnknownAliasError, ga3, u"missing:dir")
+        self.assertRaises(common.UnknownAliasError, ga3, u"missing:dir/file")
         # calling get_alias with a path that doesn't include an alias and
         # default set to something that isn't in the aliases argument should
         # raise an UnknownAliasError.
         def ga4(path):
             return get_alias(aliases, path, u"badddefault:")
-        self.failUnlessRaises(common.UnknownAliasError, ga4, u"afile")
-        self.failUnlessRaises(common.UnknownAliasError, ga4, u"a/dir/path/")
+        self.assertRaises(common.UnknownAliasError, ga4, u"afile")
+        self.assertRaises(common.UnknownAliasError, ga4, u"a/dir/path/")
 
         def ga5(path):
             old = common.pretend_platform_uses_lettercolon
@@ -484,7 +484,7 @@ class CLI(CLITestMixin, unittest.TestCase):
             finally:
                 common.pretend_platform_uses_lettercolon = old
             return retval
-        self.failUnlessRaises(common.UnknownAliasError, ga5, u"C:\\Windows")
+        self.assertRaises(common.UnknownAliasError, ga5, u"C:\\Windows")
 
     def test_alias_tolerance(self):
         def s128(c): return base32.b2a(c*(128//8))
@@ -497,7 +497,7 @@ class CLI(CLITestMixin, unittest.TestCase):
         self.failUnlessReallyEqual(ga1(u"present:file"), (TA, b"file"))
         # this throws, via assert IDirnodeURI.providedBy(), since get_alias()
         # wants a dirnode, and the future cap gives us UnknownURI instead.
-        self.failUnlessRaises(AssertionError, ga1, u"future:stuff")
+        self.assertRaises(AssertionError, ga1, u"future:stuff")
 
     def test_listdir_unicode_good(self):
         filenames = [u'L\u00F4zane', u'Bern', u'Gen\u00E8ve']  # must be NFC
@@ -958,7 +958,7 @@ class Mkdir(GridTestMixin, CLITestMixin, unittest.TestCase):
 
     def test_mkdir_bad_mutable_type(self):
         o = cli.MakeDirectoryOptions()
-        self.failUnlessRaises(usage.UsageError,
+        self.assertRaises(usage.UsageError,
                               o.parseOptions,
                               ["--format=LDMF"])
 
@@ -1241,7 +1241,7 @@ class Options(ReallyEqualMixin, unittest.TestCase):
         self.failUnlessEqual(o.aliases[DEFAULT_ALIAS].encode("ascii"), other_uri)
         self.failUnlessEqual(o.where, u"subdir")
 
-        self.failUnlessRaises(usage.UsageError, parse2,
+        self.assertRaises(usage.UsageError, parse2,
                               ["--node-url", "NOT-A-URL"])
 
         o = parse2(["--node-url", "http://localhost:8080"])
@@ -1253,19 +1253,19 @@ class Options(ReallyEqualMixin, unittest.TestCase):
     def test_version(self):
         # "tahoe --version" dumps text to stdout and exits
         stdout = StringIO()
-        self.failUnlessRaises(SystemExit, self.parse, ["--version"], stdout)
+        self.assertRaises(SystemExit, self.parse, ["--version"], stdout)
         self.failUnlessIn(allmydata.__full_version__, stdout.getvalue())
         # but "tahoe SUBCOMMAND --version" should be rejected
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["run", "--version"])
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["run", "--version-and-path"])
 
     def test_quiet(self):
         # accepted as an overall option, but not on subcommands
         o = self.parse(["--quiet", "run"])
         self.failUnless(o.parent["quiet"])
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["run", "--quiet"])
 
     def test_basedir(self):
@@ -1293,24 +1293,24 @@ class Options(ReallyEqualMixin, unittest.TestCase):
         o = self.parse(["run", "here", some_twistd_option])
         self.failUnlessReallyEqual(o["basedir"], fileutil.abspath_expanduser_unicode(u"here"))
 
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["--basedir", "there", "run"])
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["run", "--node-directory", "there"])
 
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["--node-directory=there",
                                "run", "--basedir=here"])
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["run", "--basedir=here", "anywhere"])
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["--node-directory=there",
                                "run", "anywhere"])
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["--node-directory=there",
                                "run", "--basedir=here", "anywhere"])
 
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["--node-directory=there", "run", some_twistd_option])
-        self.failUnlessRaises(usage.UsageError, self.parse,
+        self.assertRaises(usage.UsageError, self.parse,
                               ["run", "--basedir=here", some_twistd_option])

--- a/src/allmydata/test/cli/test_cp.py
+++ b/src/allmydata/test/cli/test_cp.py
@@ -19,7 +19,7 @@ class Cp(GridTestMixin, CLITestMixin, unittest.TestCase):
 
     def test_not_enough_args(self):
         o = cli.CpOptions()
-        self.failUnlessRaises(usage.UsageError,
+        self.assertRaises(usage.UsageError,
                               o.parseOptions, ["onearg"])
 
     def test_unicode_filename(self):

--- a/src/allmydata/test/cli/test_put.py
+++ b/src/allmydata/test/cli/test_put.py
@@ -495,7 +495,7 @@ class Put(GridTestMixin, CLITestMixin, unittest.TestCase):
 
     def test_mutable_type_invalid_format(self):
         o = cli.PutOptions()
-        self.failUnlessRaises(usage.UsageError,
+        self.assertRaises(usage.UsageError,
                               o.parseOptions,
                               ["--format=LDMF"])
 

--- a/src/allmydata/test/test_abbreviate.py
+++ b/src/allmydata/test/test_abbreviate.py
@@ -133,9 +133,9 @@ class Abbreviate(unittest.TestCase):
         self.failUnlessEqual(p("9EB"), 9*1000*1000*1000*1000*1000*1000)
         self.failUnlessEqual(p("9EiB"), 9*1024*1024*1024*1024*1024*1024)
 
-        e = self.failUnlessRaises(ValueError, p, "12 cubits")
+        e = self.assertRaises(ValueError, p, "12 cubits")
         self.failUnlessIn("12 cubits", str(e))
-        e = self.failUnlessRaises(ValueError, p, "1 BB")
+        e = self.assertRaises(ValueError, p, "1 BB")
         self.failUnlessIn("1 BB", str(e))
-        e = self.failUnlessRaises(ValueError, p, "fhtagn")
+        e = self.assertRaises(ValueError, p, "fhtagn")
         self.failUnlessIn("fhtagn", str(e))

--- a/src/allmydata/test/test_base32.py
+++ b/src/allmydata/test/test_base32.py
@@ -37,5 +37,5 @@ class Base32(unittest.TestCase):
 
     def test_a2b(self):
         self.failUnlessEqual(base32.a2b(b"ci2a"), b"\x12\x34")
-        self.failUnlessRaises(AssertionError, base32.a2b, b"b0gus")
+        self.assertRaises(AssertionError, base32.a2b, b"b0gus")
         self.assertFalse(base32.could_be_base32_encoded(b"b0gus"))

--- a/src/allmydata/test/test_client.py
+++ b/src/allmydata/test/test_client.py
@@ -188,7 +188,7 @@ class Basic(testutil.ReallyEqualMixin, unittest.TestCase):
         logged_messages = []
         self.patch(twisted.python.log, 'msg', logged_messages.append)
 
-        e = self.failUnlessRaises(
+        e = self.assertRaises(
             OldConfigError,
             client.read_config,
             basedir,

--- a/src/allmydata/test/test_dictutil.py
+++ b/src/allmydata/test/test_dictutil.py
@@ -43,7 +43,7 @@ class DictUtil(unittest.TestCase):
         self.failUnlessEqual(d.get_aux("key"), "serialized")
         def _get_missing(key):
             return d[key]
-        self.failUnlessRaises(KeyError, _get_missing, "nonkey")
+        self.assertRaises(KeyError, _get_missing, "nonkey")
         self.failUnlessEqual(d.get("nonkey"), None)
         self.failUnlessEqual(d.get("nonkey", "nonvalue"), "nonvalue")
         self.failUnlessEqual(d.get_aux("nonkey"), None)
@@ -58,7 +58,7 @@ class DictUtil(unittest.TestCase):
         del d["key2"]
         self.failUnlessEqual(list(d.keys()), ["key"])
         self.failIf("key2" in d)
-        self.failUnlessRaises(KeyError, _get_missing, "key2")
+        self.assertRaises(KeyError, _get_missing, "key2")
         self.failUnlessEqual(d.get("key2"), None)
         self.failUnlessEqual(d.get_aux("key2"), None)
         d["key2"] = "newvalue2"

--- a/src/allmydata/test/test_dirnode.py
+++ b/src/allmydata/test/test_dirnode.py
@@ -1540,23 +1540,23 @@ class Packing(testutil.ReallyEqualMixin, unittest.TestCase):
         self.failUnlessIn(b"lit", packed)
 
         kids = self._make_kids(nm, ["imm", "lit", "write"])
-        self.failUnlessRaises(dirnode.MustBeDeepImmutableError,
+        self.assertRaises(dirnode.MustBeDeepImmutableError,
                               dirnode.pack_children,
                               kids, fn.get_writekey(), deep_immutable=True)
 
         # read-only is not enough: all children must be immutable
         kids = self._make_kids(nm, ["imm", "lit", "read"])
-        self.failUnlessRaises(dirnode.MustBeDeepImmutableError,
+        self.assertRaises(dirnode.MustBeDeepImmutableError,
                               dirnode.pack_children,
                               kids, fn.get_writekey(), deep_immutable=True)
 
         kids = self._make_kids(nm, ["imm", "lit", "dirwrite"])
-        self.failUnlessRaises(dirnode.MustBeDeepImmutableError,
+        self.assertRaises(dirnode.MustBeDeepImmutableError,
                               dirnode.pack_children,
                               kids, fn.get_writekey(), deep_immutable=True)
 
         kids = self._make_kids(nm, ["imm", "lit", "dirread"])
-        self.failUnlessRaises(dirnode.MustBeDeepImmutableError,
+        self.assertRaises(dirnode.MustBeDeepImmutableError,
                               dirnode.pack_children,
                               kids, fn.get_writekey(), deep_immutable=True)
 
@@ -1801,16 +1801,16 @@ class Dirnode2(testutil.ReallyEqualMixin, testutil.ShouldFailMixin, unittest.Tes
             n.raise_error()
 
         for (i, n) in unknown_rw:
-            self.failUnlessRaises(MustNotBeUnknownRWError, lambda n=n: n.raise_error())
+            self.assertRaises(MustNotBeUnknownRWError, lambda n=n: n.raise_error())
 
         for (i, n) in must_be_ro:
-            self.failUnlessRaises(MustBeReadonlyError, lambda n=n: n.raise_error())
+            self.assertRaises(MustBeReadonlyError, lambda n=n: n.raise_error())
 
         for (i, n) in must_be_imm:
-            self.failUnlessRaises(MustBeDeepImmutableError, lambda n=n: n.raise_error())
+            self.assertRaises(MustBeDeepImmutableError, lambda n=n: n.raise_error())
 
         for (i, n) in bad_uri:
-            self.failUnlessRaises(uri.BadURIError, lambda n=n: n.raise_error())
+            self.assertRaises(uri.BadURIError, lambda n=n: n.raise_error())
 
         for (i, n) in ok:
             self.failIf(n.get_readonly_uri() is None, i)

--- a/src/allmydata/test/test_encodingutil.py
+++ b/src/allmydata/test/test_encodingutil.py
@@ -168,7 +168,7 @@ class StdlibUnicode(unittest.TestCase):
             fn.encode(enc)
             raise unittest.SkipTest("This test cannot be run unless we know a filename that is not representable.")
         except UnicodeEncodeError:
-            self.failUnlessRaises(UnicodeEncodeError, open, fn, 'wb')
+            self.assertRaises(UnicodeEncodeError, open, fn, 'wb')
 
 
 class QuoteOutput(ReallyEqualMixin, unittest.TestCase):
@@ -415,7 +415,7 @@ class TestToFromStr(ReallyEqualMixin, unittest.TestCase):
         self.failUnlessReallyEqual(to_bytes(None), None)
 
     def test_from_utf8_or_none(self):
-        self.failUnlessRaises(AssertionError, from_utf8_or_none, u"foo")
+        self.assertRaises(AssertionError, from_utf8_or_none, u"foo")
         self.failUnlessReallyEqual(from_utf8_or_none(b"lumi\xc3\xa8re"), u"lumi\u00E8re")
         self.failUnlessReallyEqual(from_utf8_or_none(None), None)
-        self.failUnlessRaises(UnicodeDecodeError, from_utf8_or_none, b"\xFF")
+        self.assertRaises(UnicodeDecodeError, from_utf8_or_none, b"\xFF")

--- a/src/allmydata/test/test_hashtree.py
+++ b/src/allmydata/test/test_hashtree.py
@@ -25,10 +25,10 @@ class Complete(SyncTestCase):
         root = ht[0]
         self.failUnlessEqual(len(root), 32)
         self.failUnlessEqual(ht.get_leaf(0), tagged_hash(b"tag", b"0"))
-        self.failUnlessRaises(IndexError, ht.get_leaf, 8)
+        self.assertRaises(IndexError, ht.get_leaf, 8)
         self.failUnlessEqual(ht.get_leaf_index(0), 7)
-        self.failUnlessRaises(IndexError, ht.parent, 0)
-        self.failUnlessRaises(IndexError, ht.needed_for, -1)
+        self.assertRaises(IndexError, ht.parent, 0)
+        self.assertRaises(IndexError, ht.needed_for, -1)
 
     def test_well_known_tree(self):
         self.assertEqual(
@@ -75,7 +75,7 @@ class Incomplete(SyncTestCase):
         ht = hashtree.IncompleteHashTree(8)
         self.failUnlessEqual(ht[0], None)
         self.failUnlessEqual(ht.get_leaf(0), None)
-        self.failUnlessRaises(IndexError, ht.get_leaf, 8)
+        self.assertRaises(IndexError, ht.get_leaf, 8)
         self.failUnlessEqual(ht.get_leaf_index(0), 7)
 
     def test_needed_hashes(self):
@@ -206,7 +206,7 @@ class Incomplete(SyncTestCase):
             self.fail("bad hash: %s" % e)
 
         self.failUnlessEqual(ht.get_leaf(0), tagged_hash(b"tag", b"0"))
-        self.failUnlessRaises(IndexError, ht.get_leaf, 8)
+        self.assertRaises(IndexError, ht.get_leaf, 8)
 
         # this should succeed too
         try:

--- a/src/allmydata/test/test_introducer.py
+++ b/src/allmydata/test/test_introducer.py
@@ -1011,20 +1011,20 @@ class Signatures(SyncTestCase):
         self.failUnlessEqual(b"pub-" + key2, public_key_str)
 
         # not signed
-        self.failUnlessRaises(UnknownKeyError,
+        self.assertRaises(UnknownKeyError,
                               unsign_from_foolscap, (msg, None, key))
-        self.failUnlessRaises(UnknownKeyError,
+        self.assertRaises(UnknownKeyError,
                               unsign_from_foolscap, (msg, sig, None))
         # bad signature
         bad_ann = {"key1": "value2"}
         bad_msg = json.dumps(bad_ann).encode("utf-8")
-        self.failUnlessRaises(BadSignature,
+        self.assertRaises(BadSignature,
                               unsign_from_foolscap, (bad_msg, sig, key))
 
         # unrecognized signatures
-        self.failUnlessRaises(UnknownKeyError,
+        self.assertRaises(UnknownKeyError,
                               unsign_from_foolscap, (bad_msg, b"v999-sig", key))
-        self.failUnlessRaises(UnknownKeyError,
+        self.assertRaises(UnknownKeyError,
                               unsign_from_foolscap, (bad_msg, sig, b"v999-key"))
 
     def test_unsigned_announcement(self):

--- a/src/allmydata/test/test_netstring.py
+++ b/src/allmydata/test/test_netstring.py
@@ -22,12 +22,12 @@ class Netstring(unittest.TestCase):
             self.assertIsInstance(s, bytes)
         self.failUnlessEqual(split_netstring(a, 2), ([b"hello", b"world"], len(a)))
         self.failUnlessEqual(split_netstring(a, 2, required_trailer=b""), ([b"hello", b"world"], len(a)))
-        self.failUnlessRaises(ValueError, split_netstring, a, 3)
-        self.failUnlessRaises(ValueError, split_netstring, a+b" extra", 2, required_trailer=b"")
+        self.assertRaises(ValueError, split_netstring, a, 3)
+        self.assertRaises(ValueError, split_netstring, a+b" extra", 2, required_trailer=b"")
         self.failUnlessEqual(split_netstring(a+b" extra", 2), ([b"hello", b"world"], len(a)))
         self.failUnlessEqual(split_netstring(a+b"++", 2, required_trailer=b"++"),
                              ([b"hello", b"world"], len(a)+2))
-        self.failUnlessRaises(ValueError,
+        self.assertRaises(ValueError,
                               split_netstring, a+b"+", 2, required_trailer=b"not")
 
     def test_extra(self):
@@ -46,6 +46,6 @@ class Netstring(unittest.TestCase):
         self.failUnlessEqual(top[1], b"is")
         self.failUnlessEqual(top[2], a)
         self.failUnlessEqual(top[3], b".")
-        self.failUnlessRaises(ValueError, split_netstring, a, 2, required_trailer=b"")
+        self.assertRaises(ValueError, split_netstring, a, 2, required_trailer=b"")
         bottom = split_netstring(a, 2)
         self.failUnlessEqual(bottom, ([b"hello", b"world"], len(netstring(b"hello")+netstring(b"world"))))

--- a/src/allmydata/test/test_runner.py
+++ b/src/allmydata/test/test_runner.py
@@ -290,13 +290,13 @@ class CreateNode(unittest.TestCase):
             self.failUnless(os.path.exists(os.path.join(n4, tac)))
 
         # make sure it rejects too many arguments
-        self.failUnlessRaises(usage.UsageError, parse_cli,
+        self.assertRaises(usage.UsageError, parse_cli,
                               command, "basedir", "extraarg")
 
         # when creating a non-client, there is no default for the basedir
         if not is_client:
             argv = [command]
-            self.failUnlessRaises(usage.UsageError, parse_cli,
+            self.assertRaises(usage.UsageError, parse_cli,
                                   command)
 
     def test_node(self):
@@ -311,7 +311,7 @@ class CreateNode(unittest.TestCase):
 
     def test_subcommands(self):
         # no arguments should trigger a command listing, via UsageError
-        self.failUnlessRaises(usage.UsageError, parse_cli,
+        self.assertRaises(usage.UsageError, parse_cli,
                               )
 
 

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -1536,9 +1536,9 @@ class MutableServer(SyncTestCase):
         #self.failUnlessEqual(s0.get_length(), 100)
 
         bad_secrets = (b"bad write enabler", secrets[1], secrets[2])
-        f = self.assertRaises(BadWriteEnablerError,
-                                  write, b"si1", bad_secrets,
-                                  {}, [])
+        with self.assertRaises(BadWriteEnablerError) as cm:
+            write(b"si1", bad_secrets, {}, [])
+        f = cm.exception
         self.assertThat(str(f), Contains("The write enabler was recorded by nodeid 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'."))
 
         # this testv should fail

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -829,7 +829,7 @@ class Server(AsyncTestCase):
 
         ss.get_buckets(b"allocate")
 
-        e = self.failUnlessRaises(UnknownImmutableContainerVersionError,
+        e = self.assertRaises(UnknownImmutableContainerVersionError,
                                   ss.get_buckets, b"si1")
         self.assertThat(e.filename, Equals(fn))
         self.assertThat(e.version, Equals(0))
@@ -1085,8 +1085,8 @@ class Server(AsyncTestCase):
 
         # renew the first lease. Only the proper renew_secret should work
         ss.renew_lease(b"si0", rs0)
-        self.failUnlessRaises(IndexError, ss.renew_lease, b"si0", cs0)
-        self.failUnlessRaises(IndexError, ss.renew_lease, b"si0", rs1)
+        self.assertRaises(IndexError, ss.renew_lease, b"si0", cs0)
+        self.assertRaises(IndexError, ss.renew_lease, b"si0", rs1)
 
         # check that si0 is still readable
         readers = ss.get_buckets(b"si0")
@@ -1398,7 +1398,7 @@ class MutableServer(SyncTestCase):
         f.write(b"BAD MAGIC")
         f.close()
         read = ss.slot_readv
-        e = self.failUnlessRaises(UnknownMutableContainerVersionError,
+        e = self.assertRaises(UnknownMutableContainerVersionError,
                                   read, b"si1", [0], [(0,10)])
         self.assertThat(e.filename, Equals(fn))
         self.assertTrue(e.version.startswith(b"BAD MAGIC"))
@@ -1423,7 +1423,7 @@ class MutableServer(SyncTestCase):
         # Trying to make the container too large (by sending a write vector
         # whose offset is too high) will raise an exception.
         TOOBIG = MutableShareFile.MAX_SIZE + 10
-        self.failUnlessRaises(DataTooLargeError,
+        self.assertRaises(DataTooLargeError,
                               rstaraw, b"si1", secrets,
                               {0: ([], [(TOOBIG,data)], None)},
                               [])
@@ -1534,7 +1534,7 @@ class MutableServer(SyncTestCase):
         #self.failUnlessEqual(s0.get_length(), 100)
 
         bad_secrets = (b"bad write enabler", secrets[1], secrets[2])
-        f = self.failUnlessRaises(BadWriteEnablerError,
+        f = self.assertRaises(BadWriteEnablerError,
                                   write, b"si1", bad_secrets,
                                   {}, [])
         self.assertThat(str(f), Contains("The write enabler was recorded by nodeid 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'."))
@@ -1718,7 +1718,7 @@ class MutableServer(SyncTestCase):
 
         # examine the exception thus raised, make sure the old nodeid is
         # present, to provide for share migration
-        e = self.failUnlessRaises(IndexError,
+        e = self.assertRaises(IndexError,
                                   ss.renew_lease, b"si1",
                                   secrets(20)[1])
         e_s = str(e)
@@ -2735,7 +2735,7 @@ class MDMFProxies(AsyncTestCase, ShouldFailMixin):
                             None, mw0.put_signature, self.signature))
 
         d.addCallback(lambda ignored:
-            self.failUnlessRaises(LayoutInvalid, mw0.get_signable))
+            self.assertRaises(LayoutInvalid, mw0.get_signable))
 
         # ..and, since that fails, we also shouldn't be able to put the
         # verification key.

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -1399,7 +1399,7 @@ class MutableServer(SyncTestCase):
         f.close()
         read = ss.slot_readv
         with self.assertRaises(UnknownMutableContainerVersionError) as cm:
-          read(b"si1", [0], [(0,10)])
+            read(b"si1", [0], [(0,10)])
         e = cm.exception
         self.assertThat(e.filename, Equals(fn))
         self.assertTrue(e.version.startswith(b"BAD MAGIC"))
@@ -1719,10 +1719,9 @@ class MutableServer(SyncTestCase):
 
         # examine the exception thus raised, make sure the old nodeid is
         # present, to provide for share migration
-        e = self.assertRaises(IndexError,
-                                  ss.renew_lease, b"si1",
-                                  secrets(20)[1])
-        e_s = str(e)
+        with self.assertRaises(IndexError) as cm:
+            ss.renew_lease(b"si1", secrets(20)[1])
+        e_s = str(cm.exception)
         self.assertThat(e_s, Contains("Unable to renew non-existent lease"))
         self.assertThat(e_s, Contains("I have leases accepted by nodeids:"))
         self.assertThat(e_s, Contains("nodeids: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ."))

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -1398,8 +1398,9 @@ class MutableServer(SyncTestCase):
         f.write(b"BAD MAGIC")
         f.close()
         read = ss.slot_readv
-        e = self.assertRaises(UnknownMutableContainerVersionError,
-                                  read, b"si1", [0], [(0,10)])
+        with self.assertRaises(UnknownMutableContainerVersionError) as cm:
+          read(b"si1", [0], [(0,10)])
+        e = cm.exception
         self.assertThat(e.filename, Equals(fn))
         self.assertTrue(e.version.startswith(b"BAD MAGIC"))
         self.assertThat(str(e), Contains("had unexpected version"))

--- a/src/allmydata/test/test_storage.py
+++ b/src/allmydata/test/test_storage.py
@@ -829,8 +829,9 @@ class Server(AsyncTestCase):
 
         ss.get_buckets(b"allocate")
 
-        e = self.assertRaises(UnknownImmutableContainerVersionError,
-                                  ss.get_buckets, b"si1")
+        with self.assertRaises(UnknownImmutableContainerVersionError) as cm:
+            ss.get_buckets(b"si1")
+        e = cm.exception
         self.assertThat(e.filename, Equals(fn))
         self.assertThat(e.version, Equals(0))
         self.assertThat(str(e), Contains("had unexpected version 0"))

--- a/src/allmydata/test/test_storage_web.py
+++ b/src/allmydata/test/test_storage_web.py
@@ -894,7 +894,7 @@ class LeaseCrawler(unittest.TestCase, pollmixin.PollMixin):
     def test_bad_mode(self):
         basedir = "storage/LeaseCrawler/bad_mode"
         fileutil.make_dirs(basedir)
-        e = self.failUnlessRaises(ValueError,
+        e = self.assertRaises(ValueError,
                                   StorageServer, basedir, b"\x00" * 20,
                                   expiration_mode="bogus")
         self.failUnlessIn("GC mode 'bogus' must be 'age' or 'cutoff-date'", str(e))

--- a/src/allmydata/test/test_time_format.py
+++ b/src/allmydata/test/test_time_format.py
@@ -53,7 +53,7 @@ class TimeFormat(unittest.TestCase, TimezoneMixin):
             return 1.0
         self.failUnlessEqual(time_format.iso_utc(t=my_time),
                              "1970-01-01_00:00:01")
-        e = self.failUnlessRaises(ValueError,
+        e = self.assertRaises(ValueError,
                                   time_format.iso_utc_time_to_seconds,
                                   "invalid timestring")
         self.failUnless("not a complete ISO8601 timestamp" in str(e))
@@ -113,9 +113,9 @@ class TimeFormat(unittest.TestCase, TimezoneMixin):
         self.failUnlessEqual(p("11YEARS"), 11*YEAR)
 
         # errors
-        e = self.failUnlessRaises(ValueError, p, "123")
+        e = self.assertRaises(ValueError, p, "123")
         self.failUnlessIn("No valid unit in",str(e))
-        e = self.failUnlessRaises(ValueError, p, "2kumquats")
+        e = self.assertRaises(ValueError, p, "2kumquats")
         self.failUnlessIn("No valid unit in", str(e))
 
     def test_parse_date(self):

--- a/src/allmydata/test/test_uri.py
+++ b/src/allmydata/test/test_uri.py
@@ -169,7 +169,7 @@ class CHKFile(testutil.ReallyEqualMixin, unittest.TestCase):
         needed_shares = 25
         total_shares = 100
         size = 1234
-        self.failUnlessRaises(TypeError,
+        self.assertRaises(TypeError,
                               uri.CHKFileURI,
                               key=key,
                               uri_extension_hash=uri_extension_hash,
@@ -179,10 +179,10 @@ class CHKFile(testutil.ReallyEqualMixin, unittest.TestCase):
 
                               bogus_extra_argument="reject me",
                               )
-        self.failUnlessRaises(TypeError,
+        self.assertRaises(TypeError,
                               uri.CHKFileVerifierURI,
                               bogus="bogus")
-        self.failUnlessRaises(TypeError,
+        self.assertRaises(TypeError,
                               uri.CHKFileVerifierURI,
                               storage_index=storage_index,
                               uri_extension_hash=uri_extension_hash,
@@ -247,7 +247,7 @@ class Unknown(testutil.ReallyEqualMixin, unittest.TestCase):
 class Constraint(testutil.ReallyEqualMixin, unittest.TestCase):
     def test_constraint(self):
         bad = b"http://127.0.0.1:3456/uri/URI%3ADIR2%3Agh3l5rbvnv2333mrfvalmjfr4i%3Alz6l7u3z3b7g37s4zkdmfpx5ly4ib4m6thrpbusi6ys62qtc6mma/"
-        self.failUnlessRaises(uri.BadURIError, uri.DirectoryURI.init_from_string, bad)
+        self.assertRaises(uri.BadURIError, uri.DirectoryURI.init_from_string, bad)
         fileURI = b'URI:CHK:gh3l5rbvnv2333mrfvalmjfr4i:lz6l7u3z3b7g37s4zkdmfpx5ly4ib4m6thrpbusi6ys62qtc6mma:3:10:345834'
         uri.CHKFileURI.init_from_string(fileURI)
 
@@ -375,21 +375,21 @@ class Mutable(testutil.ReallyEqualMixin, unittest.TestCase):
         # readcap.
         u1 = uri.ReadonlyMDMFFileURI(self.readkey, self.fingerprint)
         cap = u1.to_string()
-        self.failUnlessRaises(uri.BadURIError,
+        self.assertRaises(uri.BadURIError,
                               uri.WriteableMDMFFileURI.init_from_string,
                               cap)
 
     def test_create_writeable_mdmf_cap_from_verifycap(self):
         u1 = uri.MDMFVerifierURI(self.storage_index, self.fingerprint)
         cap = u1.to_string()
-        self.failUnlessRaises(uri.BadURIError,
+        self.assertRaises(uri.BadURIError,
                               uri.WriteableMDMFFileURI.init_from_string,
                               cap)
 
     def test_create_readonly_mdmf_cap_from_verifycap(self):
         u1 = uri.MDMFVerifierURI(self.storage_index, self.fingerprint)
         cap = u1.to_string()
-        self.failUnlessRaises(uri.BadURIError,
+        self.assertRaises(uri.BadURIError,
                               uri.ReadonlyMDMFFileURI.init_from_string,
                               cap)
 

--- a/src/allmydata/test/test_util.py
+++ b/src/allmydata/test/test_util.py
@@ -117,16 +117,16 @@ class FileUtil(ReallyEqualMixin, unittest.TestCase):
         dest_path   = os.path.join(workdir, "dest")
 
         # when neither file exists
-        self.failUnlessRaises(OSError, fileutil.rename_no_overwrite, source_path, dest_path)
+        self.assertRaises(OSError, fileutil.rename_no_overwrite, source_path, dest_path)
 
         # when only dest exists
         fileutil.write(dest_path,   b"dest")
-        self.failUnlessRaises(OSError, fileutil.rename_no_overwrite, source_path, dest_path)
+        self.assertRaises(OSError, fileutil.rename_no_overwrite, source_path, dest_path)
         self.failUnlessEqual(fileutil.read(dest_path),   b"dest")
 
         # when both exist
         fileutil.write(source_path, b"source")
-        self.failUnlessRaises(OSError, fileutil.rename_no_overwrite, source_path, dest_path)
+        self.assertRaises(OSError, fileutil.rename_no_overwrite, source_path, dest_path)
         self.failUnlessEqual(fileutil.read(source_path), b"source")
         self.failUnlessEqual(fileutil.read(dest_path),   b"dest")
 
@@ -144,11 +144,11 @@ class FileUtil(ReallyEqualMixin, unittest.TestCase):
         replacement_path = os.path.join(workdir, "replacement")
 
         # when none of the files exist
-        self.failUnlessRaises(fileutil.ConflictError, fileutil.replace_file, replaced_path, replacement_path)
+        self.assertRaises(fileutil.ConflictError, fileutil.replace_file, replaced_path, replacement_path)
 
         # when only replaced exists
         fileutil.write(replaced_path,   b"foo")
-        self.failUnlessRaises(fileutil.ConflictError, fileutil.replace_file, replaced_path, replacement_path)
+        self.assertRaises(fileutil.ConflictError, fileutil.replace_file, replaced_path, replacement_path)
         self.failUnlessEqual(fileutil.read(replaced_path), b"foo")
 
         # when both replaced and replacement exist
@@ -179,7 +179,7 @@ class FileUtil(ReallyEqualMixin, unittest.TestCase):
         self.failUnlessEqual(10+11+12+13, used)
 
     def test_abspath_expanduser_unicode(self):
-        self.failUnlessRaises(AssertionError, fileutil.abspath_expanduser_unicode, b"bytestring")
+        self.assertRaises(AssertionError, fileutil.abspath_expanduser_unicode, b"bytestring")
 
         saved_cwd = os.path.normpath(os.getcwd())
         abspath_cwd = fileutil.abspath_expanduser_unicode(u".")

--- a/src/allmydata/test/web/test_util.py
+++ b/src/allmydata/test/web/test_util.py
@@ -15,7 +15,7 @@ class Util(ShouldFailMixin, testutil.ReallyEqualMixin, unittest.TestCase):
         self.failUnlessReallyEqual(common.parse_replace_arg(b"false"), False)
         self.failUnlessReallyEqual(common.parse_replace_arg(b"only-files"),
                                    ONLY_FILES)
-        self.failUnlessRaises(common.WebError, common.parse_replace_arg, b"only_fles")
+        self.assertRaises(common.WebError, common.parse_replace_arg, b"only_fles")
 
     def test_abbreviate_time(self):
         self.failUnlessReallyEqual(common.abbreviate_time(None), "")


### PR DESCRIPTION
Fix (some) tests: Replace deprecated 'failUnlessRaises` with 'assertRaises' everywhere

With this patch applied, the Windows Server 2022 CPython 3.12 tests (with previously 11 failures because of this) should be green again.

More details in the [ticket: 4190](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4190).